### PR TITLE
Unique step outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+* `uniqueOutputs()` method to Steps to get only unique output values.
+  If outputs are array or object, you can provide a key that will be
+  used as identifier to check for uniqueness. Otherwise the arrays or
+  objects will be serialized for comparison which will probably be 
+  slower.

--- a/src/Io.php
+++ b/src/Io.php
@@ -4,7 +4,7 @@ namespace Crwlr\Crawler;
 
 class Io
 {
-    private mixed $value;
+    protected mixed $value;
 
     public function __construct(mixed $value, public ?Result $result = null)
     {

--- a/src/Output.php
+++ b/src/Output.php
@@ -4,4 +4,49 @@ namespace Crwlr\Crawler;
 
 class Output extends Io
 {
+    private string|int|float|bool|null $key = null;
+
+    /**
+     * Sets and returns a key to use as identifier
+     *
+     * To only get unique results from a step use the key this method creates for comparison.
+     * In case the output values are arrays or objects and contain a unique identifier that can be used, provide that
+     * key name, so it doesn't need to create a key from the whole array/object.
+     */
+    public function setKey(?string $useFromValue = null): string|int|float|bool|null
+    {
+        if ($useFromValue && is_array($this->value) && array_key_exists($useFromValue, $this->value)) {
+            $this->key = $this->valueToString($this->value[$useFromValue]);
+        } elseif ($useFromValue && is_object($this->value) && property_exists($this->value, $useFromValue)) {
+            $this->key = $this->valueToString($this->value->{$useFromValue});
+        } else {
+            $this->key = $this->valueToString($this->value);
+        }
+
+        return $this->key;
+    }
+
+    public function getKey(): string|int|float|bool|null
+    {
+        if ($this->key === null) {
+            $this->setKey();
+        }
+
+        return $this->key;
+    }
+
+    private function valueToString(mixed $value): string
+    {
+        if (is_array($value) || is_object($value)) {
+            return md5(serialize($this->value));
+        } elseif (is_int($value) || is_float($value)) {
+            return (string) $value;
+        } elseif (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        } elseif (is_null($value)) {
+            return 'null';
+        }
+
+        return $value;
+    }
 }

--- a/src/Steps/StepInterface.php
+++ b/src/Steps/StepInterface.php
@@ -26,6 +26,10 @@ interface StepInterface
      */
     public function addKeysToResult(?array $keys = null): static;
 
+    public function uniqueOutputs(?string $key = null): static;
+
+    public function outputsShallBeUnique(): bool;
+
     public function addsToOrCreatesResult(): bool;
 
     public function dontCascade(): static;

--- a/tests/IoTest.php
+++ b/tests/IoTest.php
@@ -13,24 +13,32 @@ function helper_getIoInstance(mixed $value, ?Result $result = null): Io
 
 test('It can be created with only a value.', function () {
     $io = helper_getIoInstance('test');
+
     expect($io)->toBeInstanceOf(Io::class);
 });
 
 test('You can add a Result object.', function () {
     $result = new Result();
+
     $io = helper_getIoInstance('test', $result);
+
     expect($io->result)->toBe($result);
 });
 
 test('You can create it from another Io instance and it keeps the value of the original instance.', function () {
     $io1 = helper_getIoInstance('test');
+
     $io2 = helper_getIoInstance($io1);
+
     expect($io2->get())->toBe('test');
 });
 
 test('When created from another Io instance it passes on the Result object.', function () {
     $result = new Result();
+
     $io1 = helper_getIoInstance('test', $result);
+
     $io2 = helper_getIoInstance($io1);
+
     expect($io2->result)->toBe($result);
 });

--- a/tests/OutputTest.php
+++ b/tests/OutputTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace tests;
+
+use Crwlr\Crawler\Output;
+use stdClass;
+
+/**
+ * @param mixed[] $data
+ */
+function helper_getStdClassWithData(array $data): stdClass
+{
+    $object = new stdClass();
+
+    foreach ($data as $key => $value) {
+        $object->{$key} = $value;
+    }
+
+    return $object;
+}
+
+it('sets a simple value key', function ($value, $key) {
+    $output = new Output($value);
+
+    expect($output->setKey())->toBe($key);
+
+    expect($output->getKey())->toBe($key);
+})->with([
+    ['foo', 'foo'],
+    [123, '123'],
+    [123.1234, '123.1234'],
+    [true, 'true'],
+    [false, 'false'],
+    [null, 'null'],
+]);
+
+it('sets a key from array output', function () {
+    $output = new Output(['foo' => 'bar', 'yo' => 123.45]);
+
+    expect($output->setKey('yo'))->toBe('123.45');
+
+    expect($output->getKey())->toBe('123.45');
+});
+
+it('sets a key from object output', function () {
+    $value = helper_getStdClassWithData(['foo' => 'bar', 'yo' => 123.45]);
+
+    $output = new Output($value);
+
+    expect($output->setKey('yo'))->toBe('123.45');
+
+    expect($output->getKey())->toBe('123.45');
+});
+
+it('creates a string key for array output when not providing a key name', function () {
+    $output = new Output(['one', 'two', 'three']);
+
+    expect($output->setKey())->toBe('6975f1fd65cae4b21e32f4f47bf153a8');
+
+    expect($output->getKey())->toBe('6975f1fd65cae4b21e32f4f47bf153a8');
+});
+
+it('creates a string key for object output when not providing a key name', function () {
+    $object = helper_getStdClassWithData(['one', 'two', 'three']);
+
+    $output = new Output($object);
+
+    expect($output->setKey())->toBe('bb8dd69ea029ca1379df3994721f5fa9');
+
+    expect($output->getKey())->toBe('bb8dd69ea029ca1379df3994721f5fa9');
+});
+
+it('creates a string key for array output when provided key name doesn\'t exist in output array', function () {
+    $output = new Output(['one', 'two', 'three']);
+
+    expect($output->setKey('four'))->toBe('6975f1fd65cae4b21e32f4f47bf153a8');
+
+    expect($output->getKey())->toBe('6975f1fd65cae4b21e32f4f47bf153a8');
+});
+
+it('creates a string key for array output when provided key name doesn\'t exist in output object', function () {
+    $object = helper_getstdClassWithData(['one', 'two', 'three']);
+
+    $output = new Output($object);
+
+    expect($output->setKey('four'))->toBe('bb8dd69ea029ca1379df3994721f5fa9');
+
+    expect($output->getKey())->toBe('bb8dd69ea029ca1379df3994721f5fa9');
+});
+
+test('getKey returns a key when setKey was not called yet', function () {
+    $output = new Output('test');
+
+    expect($output->getKey())->toBe('test');
+});

--- a/tests/OutputTest.php
+++ b/tests/OutputTest.php
@@ -3,21 +3,6 @@
 namespace tests;
 
 use Crwlr\Crawler\Output;
-use stdClass;
-
-/**
- * @param mixed[] $data
- */
-function helper_getStdClassWithData(array $data): stdClass
-{
-    $object = new stdClass();
-
-    foreach ($data as $key => $value) {
-        $object->{$key} = $value;
-    }
-
-    return $object;
-}
 
 it('sets a simple value key', function ($value, $key) {
     $output = new Output($value);


### PR DESCRIPTION
Add `uniqueOutputs()` method to Steps to get only unique output values.
When outputs are array or object, you can provide a key that will be used as identifier to check for uniqueness. Otherwise the arrays or objects will be serialized for comparison which will probably be slower.