### PR TITLE
Implement Group setResultKey and addKeysToResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0] - 2022-04-25
 ### Added
 * `uniqueOutputs()` method to Steps to get only unique output values.
   If outputs are array or object, you can provide a key that will be
-  used as identifier to check for uniqueness. Otherwise the arrays or
-  objects will be serialized for comparison which will probably be 
+  used as identifier to check for uniqueness. Otherwise, the arrays
+  or objects will be serialized for comparison which will probably be 
   slower.
 * `runAndTraverse()` method to Crawler, so you don't need to manually
   traverse the Generator, if you don't need the results where you're
   calling the crawler.
+* Implement the behaviour for when a `Group` step should add
+  something to the Result using `setResultKey` or `addKeysToResult`,
+  which was still missing. For groups this will only work when using
+  `combineToSingleOutput`.

--- a/src/Steps/AddsDataToResult.php
+++ b/src/Steps/AddsDataToResult.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Crwlr\Crawler\Steps;
+
+use Crwlr\Crawler\Result;
+
+/**
+ * Base class for classes Step and Group which share some things in terms of adding output data to Result objects.
+ */
+
+abstract class AddsDataToResult
+{
+    protected ?string $resultKey = null;
+
+    /**
+     * True means add all elements of the output array. Array of strings means, add just those keys.
+     *
+     * @var bool|string[]
+     */
+    protected bool|array $addToResult = false;
+
+    /**
+     * When the output of a step is a simple value (not array), add it with this key to the Result.
+     */
+    public function setResultKey(string $key): static
+    {
+        $this->resultKey = $key;
+
+        return $this;
+    }
+
+    /**
+     * The key, the output value will be added to the result with (if set via setResultKey()).
+     */
+    public function getResultKey(): ?string
+    {
+        return $this->resultKey;
+    }
+
+    /**
+     * When the output of a step is an array, call this method with null to add all it's elements/properties
+     * to the Result, or provide an array with the keys that should be added.
+     *
+     * @param string[]|null $keys
+     */
+    public function addKeysToResult(?array $keys = null): static
+    {
+        $this->addToResult = $keys ?? true;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function addsToOrCreatesResult(): bool
+    {
+        return $this->resultKey !== null || $this->addToResult !== false;
+    }
+
+    final protected function addOutputDataToResult(mixed $output, ?Result $result = null): ?Result
+    {
+        if ($this->addsToOrCreatesResult()) {
+            if (!$result) {
+                $result = new Result();
+            }
+
+            if ($this->resultKey !== null) {
+                $result->set($this->resultKey, $output);
+            }
+
+            if ($this->addToResult !== false && is_array($output)) {
+                $this->addDataFromOutputArrayToResult($output, $result);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param mixed[] $output
+     */
+    protected function addDataFromOutputArrayToResult(array $output, Result $result): void
+    {
+        foreach ($output as $key => $value) {
+            if ($this->addToResult === true) {
+                $result->set(is_string($key) ? $key : '', $value);
+            } elseif (is_array($this->addToResult) && in_array($key, $this->addToResult, true)) {
+                $result->set($this->choseResultKey($key), $value);
+            }
+        }
+    }
+
+    protected function choseResultKey(int|string $keyInOutput): string
+    {
+        if (is_array($this->addToResult)) {
+            $mapToKey = array_search($keyInOutput, $this->addToResult, true);
+
+            if (is_string($mapToKey)) {
+                return $mapToKey;
+            }
+        }
+
+        return is_string($keyInOutput) ? $keyInOutput : '';
+    }
+}

--- a/src/Steps/Group.php
+++ b/src/Steps/Group.php
@@ -209,7 +209,7 @@ final class Group extends BaseStep implements StepInterface
      */
     private function prepareCombinedOutputs(array $combinedOutputs, ?Result $result = null): Output
     {
-        $outputData = $this->normalizeCombinedOutputs($combinedOutputs, $result);
+        $outputData = $this->normalizeCombinedOutputs($combinedOutputs);
 
         $this->addOutputDataToResult($outputData, $result);
 
@@ -225,19 +225,11 @@ final class Group extends BaseStep implements StepInterface
      * @param mixed[] $combinedOutputs
      * @return mixed[]
      */
-    private function normalizeCombinedOutputs(array $combinedOutputs, ?Result $result = null): array
+    private function normalizeCombinedOutputs(array $combinedOutputs): array
     {
-        $normalized = [];
-
-        foreach ($combinedOutputs as $key => $combinedOutput) {
-            if (count($combinedOutput) === 1) {
-                $normalized[$key] = reset($combinedOutput);
-            } else {
-                $normalized[$key] = $combinedOutput;
-            }
-        }
-
-        return $normalized;
+        return array_map(function ($output) {
+            return count($output) === 1 ? reset($output) : $output;
+        }, $combinedOutputs);
     }
 
     /**

--- a/src/Steps/Group.php
+++ b/src/Steps/Group.php
@@ -50,7 +50,7 @@ final class Group extends AddsDataToResult implements StepInterface
                 if ($this->combine && $step->cascades()) {
                     $stepKey = $step->getResultKey() ?? $key;
 
-                    $combinedOutput = $this->addOutputToCombinedOutputs($output, $combinedOutput, $stepKey);
+                    $combinedOutput = $this->addOutputToCombinedOutputs($output->get(), $combinedOutput, $stepKey);
                 } elseif ($this->cascades() && $step->cascades()) {
                     if ($this->uniqueOutput !== false && $this->existsInUniqueKeys($output, $uniqueKeys)) {
                         continue;
@@ -193,22 +193,6 @@ final class Group extends AddsDataToResult implements StepInterface
     }
 
     /**
-     * @param mixed[] $output
-     */
-    protected function addDataFromOutputArrayToResult(array $output, Result $result): void
-    {
-        foreach ($output as $outputArray) {
-            foreach ($outputArray as $key => $value) {
-                if ($this->addToResult === true) {
-                    $result->set(is_string($key) ? $key : '', $value);
-                } elseif (is_array($this->addToResult) && in_array($key, $this->addToResult, true)) {
-                    $result->set($this->choseResultKey($key), $value);
-                }
-            }
-        }
-    }
-
-    /**
      * @throws Exception
      */
     private function prepareInput(Input $input): Input
@@ -260,10 +244,14 @@ final class Group extends AddsDataToResult implements StepInterface
     {
         if (is_array($output)) {
             foreach ($output as $key => $value) {
-                $combined[$stepKey][$key][] = $value;
+                if (is_int($stepKey) && is_string($key)) {
+                    $combined[$key][] = $value;
+                } else {
+                    $combined[$stepKey][$key][] = $value;
+                }
             }
         } else {
-            $combined[$stepKey][] = $output->get();
+            $combined[$stepKey][] = $output;
         }
 
         return $combined;

--- a/src/Steps/StepInterface.php
+++ b/src/Steps/StepInterface.php
@@ -9,6 +9,8 @@ use Psr\Log\LoggerInterface;
 
 interface StepInterface
 {
+    public function addLogger(LoggerInterface $logger): static;
+
     /**
      * @param Input $input
      * @return Generator<Output>
@@ -26,15 +28,13 @@ interface StepInterface
      */
     public function addKeysToResult(?array $keys = null): static;
 
+    public function addsToOrCreatesResult(): bool;
+
     public function uniqueOutputs(?string $key = null): static;
 
     public function outputsShallBeUnique(): bool;
 
-    public function addsToOrCreatesResult(): bool;
-
     public function dontCascade(): static;
 
     public function cascades(): bool;
-
-    public function addLogger(LoggerInterface $logger): static;
 }

--- a/tests/Steps/GroupTest.php
+++ b/tests/Steps/GroupTest.php
@@ -421,6 +421,31 @@ test(
     }
 );
 
+it(
+    'merges array outputs with string keys to one array when using combineToSingleOutput',
+    function () {
+        $step1 = helper_getValueReturningStep(['foo' => 'fooValue', 'bar' => 'barValue']);
+
+        $step2 = helper_getValueReturningStep(['baz' => 'bazValue', 'yo' => 'lo']);
+
+        $group = (new Group())
+            ->addStep($step1)
+            ->addStep($step2)
+            ->combineToSingleOutput();
+
+        $output = helper_invokeStepWithInput($group);
+
+        expect($output)->toHaveCount(1);
+
+        expect($output[0]->get())->toBe([
+            'foo' => 'fooValue',
+            'bar' => 'barValue',
+            'baz' => 'bazValue',
+            'yo' => 'lo',
+        ]);
+    }
+);
+
 test('It doesn\'t output anything when the dontCascade method was called', function () {
     $step1 = helper_getValueReturningStep('something');
 

--- a/tests/Steps/GroupTest.php
+++ b/tests/Steps/GroupTest.php
@@ -511,6 +511,16 @@ test(
     }
 );
 
+it('knows if it will cascade its output', function () {
+    $group = new Group();
+
+    expect($group->cascades())->toBeTrue();
+
+    $group->dontCascade();
+
+    expect($group->cascades())->toBeFalse();
+});
+
 test('You can update the input for further steps with the output of a step that is before those steps', function () {
     $step1 = helper_getValueReturningStep(' rocks')
         ->updateInputUsingOutput(function (mixed $input, mixed $output) {
@@ -626,6 +636,22 @@ it('knows when at least one of the steps adds something to the final result when
     expect($outputs[2]->result)->toBeInstanceOf(Result::class);
 
     expect($outputs[2]->result->get('duck'))->toBe('Track'); // @phpstan-ignore-line
+});
+
+it('uses a key from array input when defined', function () {
+    $step = helper_getInputReturningStep();
+
+    $group = (new Group())
+        ->addStep($step)
+        ->useInputKey('bar');
+
+    $outputs = helper_invokeStepWithInput($group, new Input(
+        ['foo' => 'fooValue', 'bar' => 'barValue', 'baz' => 'bazValue']
+    ));
+
+    expect($outputs)->toHaveCount(1);
+
+    expect($outputs[0]->get())->toBe('barValue');
 });
 
 test('when calling setResultKey without calling combineToSingleOutput before, it throws an Exception', function () {

--- a/tests/Steps/StepTest.php
+++ b/tests/Steps/StepTest.php
@@ -9,6 +9,7 @@ use Crwlr\Crawler\Result;
 use Crwlr\Crawler\Steps\Step;
 use Generator;
 use PHPUnit\Framework\TestCase;
+use function tests\helper_getInputReturningStep;
 use function tests\helper_getStepYieldingMultipleArraysWithNumber;
 use function tests\helper_getStepYieldingMultipleNumbers;
 use function tests\helper_getStepYieldingMultipleObjectsWithNumber;
@@ -120,6 +121,18 @@ test('The addsToOrCreatesResult method returns false when no result key is set a
     $step = helper_getValueReturningStep('lol');
 
     expect($step->addsToOrCreatesResult())->toBeFalse();
+});
+
+it('uses a key from array input when defined', function () {
+    $step = helper_getInputReturningStep()->useInputKey('bar');
+
+    $output = helper_invokeStepWithInput($step, new Input(
+        ['foo' => 'fooValue', 'bar' => 'barValue', 'baz' => 'bazValue']
+    ));
+
+    expect($output)->toHaveCount(1);
+
+    expect($output[0]->get())->toBe('barValue');
 });
 
 it('doesn\'t add the result object to the Input object only to the Output', function () {
@@ -308,6 +321,16 @@ it('still returns output from invokeStep when dontCascade was called', function 
     $output = helper_invokeStepWithInput($step);
 
     expect($output)->toHaveCount(1);
+});
+
+it('tells you if its output shall be cascaded to the next step', function () {
+    $step = helper_getInputReturningStep();
+
+    expect($step->cascades())->toBeTrue();
+
+    $step->dontCascade();
+
+    expect($step->cascades())->toBeFalse();
 });
 
 test('You can add and call an updateInputUsingOutput callback', function () {


### PR DESCRIPTION
Both methods work for Groups only when combineToSingleOutput is used (and was called before), otherwise they'll throw an Exception.
setResultKey, will add the whole combined output as value with the defined key. addKeysToResult adds keys from the combined output to the result.
Also change how the first param of addStep() works in groups: when its a string, don't set the result key, but use it as key in the combined output.