### PR TITLE
Fix Generators usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+* Previously the __use of Generators__ actually didn't make a lot of
+  sense, because the outputs of one step were only iterated and
+  passed on to the next step, after the current step was invoked
+  with all its inputs. That makes steps with a lot of inputs
+  bottlenecks and causes bigger memory consumption. So, changed the
+  crawler to immediately pass on outputs of one step to the next
+  step if there is one.
 
 ## [0.2.0] - 2022-04-25
 ### Added

--- a/src/Steps/BaseStep.php
+++ b/src/Steps/BaseStep.php
@@ -13,7 +13,7 @@ use Psr\Log\LoggerInterface;
  * Base class for classes Step and Group which share some things in terms of adding output data to Result objects.
  */
 
-abstract class BaseStep
+abstract class BaseStep implements StepInterface
 {
     protected ?string $resultKey = null;
 
@@ -29,6 +29,11 @@ abstract class BaseStep
     protected ?string $useInputKey = null;
 
     protected bool|string $uniqueOutput = false;
+
+    /**
+     * @var bool[]
+     */
+    protected array $uniqueOutputKeys = [];
 
     protected bool $cascades = true;
 
@@ -110,9 +115,9 @@ abstract class BaseStep
         return $this;
     }
 
-    final public function outputsShallBeUnique(): bool
+    public function resetAfterRun(): void
     {
-        return $this->uniqueOutput !== false;
+        $this->uniqueOutputKeys = [];
     }
 
     /**

--- a/src/Steps/Group.php
+++ b/src/Steps/Group.php
@@ -11,7 +11,7 @@ use Generator;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 
-final class Group extends BaseStep implements StepInterface
+final class Group extends BaseStep
 {
     /**
      * @var StepInterface[]

--- a/src/Steps/Step.php
+++ b/src/Steps/Step.php
@@ -10,7 +10,7 @@ use Exception;
 use Generator;
 use InvalidArgumentException;
 
-abstract class Step extends BaseStep implements StepInterface
+abstract class Step extends BaseStep
 {
     protected ?Closure $updateInputUsingOutput = null;
 
@@ -87,18 +87,16 @@ abstract class Step extends BaseStep implements StepInterface
 
     private function invokeAndYieldUnique(mixed $validInputValue, ?Result $result): Generator
     {
-        $uniqueKeys = [];
-
         foreach ($this->invoke($validInputValue) as $output) {
             $output = $this->output($output, $result);
 
             $key = is_string($this->uniqueOutput) ? $output->setKey($this->uniqueOutput) : $output->setKey();
 
-            if (isset($uniqueKeys[$key])) {
+            if (isset($this->uniqueOutputKeys[$key])) {
                 continue;
             }
 
-            $uniqueKeys[$key] = true; // Don't keep the output value, just the key, to keep memory usage low.
+            $this->uniqueOutputKeys[$key] = true; // Don't keep output value, just the key, to keep memory usage low.
 
             yield $output;
         }

--- a/src/Steps/StepInterface.php
+++ b/src/Steps/StepInterface.php
@@ -32,9 +32,9 @@ interface StepInterface
 
     public function uniqueOutputs(?string $key = null): static;
 
-    public function outputsShallBeUnique(): bool;
-
     public function dontCascade(): static;
 
     public function cascades(): bool;
+
+    public function resetAfterRun(): void;
 }

--- a/tests/Steps/GroupTest.php
+++ b/tests/Steps/GroupTest.php
@@ -344,21 +344,6 @@ it(
     }
 );
 
-it('knows if it will produce unique output or not', function () {
-    $step = new class () extends Step {
-        protected function invoke(mixed $input): Generator
-        {
-            yield 'boo';
-        }
-    };
-
-    expect($step->outputsShallBeUnique())->toBeFalse();
-
-    $step->uniqueOutputs();
-
-    expect($step->outputsShallBeUnique())->toBeTrue();
-});
-
 test(
     'It combines the outputs of all it\'s steps into one output containing an array when combineToSingleOutput is used',
     function () {

--- a/tests/Steps/LoopTest.php
+++ b/tests/Steps/LoopTest.php
@@ -743,13 +743,3 @@ it(
         expect($outputs)->toHaveCount(5);
     }
 );
-
-it('knows if it will produce only unique outputs', function () {
-    $loop = new Loop(helper_getStepYieldingObjectWithIncrementingNumber());
-
-    expect($loop->outputsShallBeUnique())->toBeFalse();
-
-    $loop->uniqueOutputs();
-
-    expect($loop->outputsShallBeUnique())->toBeTrue();
-});

--- a/tests/Steps/StepTest.php
+++ b/tests/Steps/StepTest.php
@@ -253,21 +253,6 @@ it('makes object outputs unique when providing no key name to uniqueOutput', fun
     expect($output)->toHaveCount(8);
 });
 
-it('knows if it will produce unique output or not', function () {
-    $step = new class () extends Step {
-        protected function invoke(mixed $input): Generator
-        {
-            yield 'boo';
-        }
-    };
-
-    expect($step->outputsShallBeUnique())->toBeFalse();
-
-    $step->uniqueOutputs();
-
-    expect($step->outputsShallBeUnique())->toBeTrue();
-});
-
 it('calls the validateAndSanitizeInput method', function () {
     $step = new class () extends Step {
         protected function validateAndSanitizeInput(mixed $input): string


### PR DESCRIPTION
Previously the use of Generators actually didn't make a lot of sense,
because the outputs of one step were only iterated and passed on to the
next step, after the current step was invoked with all its inputs. That
makes steps with a lot of inputs bottlenecks and causes bigger memory
consumption. So, change the crawler to immediately pass on outputs of
one step to the next step if there is one.

Also simplify how unique step output works. The crawler class doesn't
need to know if a step should produce unique output and handle it,
instead the step saves the unique keys in a class property until it is
reset by the Crawler (after a full run).
This also makes unique output from loops a lot simpler, which now also
works without cascadeWhenFinished.