### PR TITLE
Add filter functionality to Csv step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+* The `Csv` step now has a `filter()` method. You can set multiple
+  filters for all mapped column names by `Comparison` (equal, greater
+  than, less than,...) or `StringCheck` (contains, starts/ends with).
 
 ## [0.3.0] - 2022-04-27
 ### Added
-* By calling monitorMemoryUsage() you can tell the Crawler to add
+* By calling `monitorMemoryUsage()` you can tell the Crawler to add
   log messages with the current memory usage after every step
   invocation.
   You can also set a limit in bytes when to start monitoring and
@@ -34,6 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   traverse the Generator, if you don't need the results where you're
   calling the crawler.
 * Implement the behaviour for when a `Group` step should add
-  something to the Result using `setResultKey` or `addKeysToResult`,
-  which was still missing. For groups this will only work when using
-  `combineToSingleOutput`.
+  something to the Result using `setResultKey()` or
+  `addKeysToResult()`, which was still missing. For groups this will
+  only work when using `combineToSingleOutput`.

--- a/src/Steps/Csv/Filter.php
+++ b/src/Steps/Csv/Filter.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Csv;
+
+use Crwlr\Crawler\Steps\FilterRules\Comparison;
+use Crwlr\Crawler\Steps\FilterRules\StringCheck;
+
+final class Filter
+{
+    public function __construct(
+        private readonly string $columnName,
+        private readonly Comparison|StringCheck $operator,
+        private readonly mixed $filterValue,
+    ) {
+    }
+
+    /**
+     * @param mixed[] $csvRow
+     * @return bool
+     */
+    public function matches(array $csvRow): bool
+    {
+        return isset($csvRow[$this->columnName]) &&
+            $this->operator->evaluate($csvRow[$this->columnName], $this->filterValue);
+    }
+}

--- a/src/Steps/FilterRules/Comparison.php
+++ b/src/Steps/FilterRules/Comparison.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\FilterRules;
+
+enum Comparison
+{
+    case Equal;
+
+    case NotEqual;
+
+    case GreaterThan;
+
+    case GreaterThanOrEqual;
+
+    case LessThan;
+
+    case LessThanOrEqual;
+
+    public function evaluate(mixed $value, mixed $compareTo): bool
+    {
+        return match ($this) {
+            self::Equal => ($value === $compareTo),
+            self::NotEqual => ($value !== $compareTo),
+            self::GreaterThan => ($value > $compareTo),
+            self::GreaterThanOrEqual => ($value >= $compareTo),
+            self::LessThan => ($value < $compareTo),
+            self::LessThanOrEqual => ($value <= $compareTo),
+        };
+    }
+}

--- a/src/Steps/FilterRules/StringCheck.php
+++ b/src/Steps/FilterRules/StringCheck.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\FilterRules;
+
+enum StringCheck
+{
+    case Contains;
+
+    case StartsWith;
+
+    case EndsWith;
+
+    public function evaluate(string $haystack, string $needle): bool
+    {
+        return match ($this) {
+            self::Contains => str_contains($haystack, $needle),
+            self::StartsWith => str_starts_with($haystack, $needle),
+            self::EndsWith => str_ends_with($haystack, $needle),
+        };
+    }
+}

--- a/tests/Steps/Csv/FilterTest.php
+++ b/tests/Steps/Csv/FilterTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace tests\Steps\Csv;
+
+use Crwlr\Crawler\Steps\Csv\Filter;
+use Crwlr\Crawler\Steps\FilterRules\Comparison;
+use Crwlr\Crawler\Steps\FilterRules\StringCheck;
+
+it('returns false when the colunn doesn\'t exist', function () {
+    $row = ['foo' => 'fooValue', 'bar' => 'barValue'];
+
+    expect((new Filter('fooo', Comparison::Equal, 'fooValue'))->matches($row))->toBeFalse();
+});
+
+it('correctly filters rows with equal filter', function (bool $expectedResult, array $row) {
+    expect((new Filter('baz', Comparison::Equal, 'bazValue'))->matches($row))->toBe($expectedResult);
+})->with([
+    [true, ['foo' => 'fooValue', 'bar' => 'barValue', 'baz' => 'bazValue']],
+    [true, ['foo' => 'fooValue 2', 'bar' => 'barValue 2', 'baz' => 'bazValue']],
+    [false, ['foo' => 'fooValue', 'bar' => 'barValue', 'baz' => 'bazValue 2']],
+]);
+
+it('correctly filters rows with not equal filter', function (bool $expectedResult, array $row) {
+    expect((new Filter('baz', Comparison::NotEqual, 'bazValue'))->matches($row))->toBe($expectedResult);
+})->with([
+    [false, ['foo' => 'fooValue', 'bar' => 'barValue', 'baz' => 'bazValue']],
+    [false, ['foo' => 'fooValue 2', 'bar' => 'barValue 2', 'baz' => 'bazValue']],
+    [true, ['foo' => 'fooValue', 'bar' => 'barValue', 'baz' => 'bazValue 2']],
+]);
+
+it('correctly filters rows with greater than filter', function (bool $expectedResult, array $row) {
+    expect((new Filter('baz', Comparison::GreaterThan, 3))->matches($row))->toBe($expectedResult);
+})->with([
+    [true, ['foo' => 'fooValue', 'bar' => 'barValue', 'baz' => 4]],
+    [true, ['foo' => 'fooValue 2', 'bar' => 'barValue 2', 'baz' => 3.001]],
+    [false, ['foo' => 'fooValue', 'bar' => 'barValue', 'baz' => 3]],
+    [false, ['foo' => 'fooValue', 'bar' => 'barValue', 'baz' => 2]],
+]);
+
+it('correctly filters rows with greater than or equal filter', function (bool $expectedResult, array $row) {
+    expect((new Filter('baz', Comparison::GreaterThanOrEqual, 3))->matches($row))->toBe($expectedResult);
+})->with([
+    [true, ['foo' => 'fooValue', 'bar' => 'barValue', 'baz' => 4]],
+    [true, ['foo' => 'fooValue 2', 'bar' => 'barValue 2', 'baz' => 3.001]],
+    [true, ['foo' => 'fooValue', 'bar' => 'barValue', 'baz' => 3]],
+    [false, ['foo' => 'fooValue', 'bar' => 'barValue', 'baz' => 2]],
+]);
+
+it('correctly filters rows with less than filter', function (bool $expectedResult, array $row) {
+    expect((new Filter('baz', Comparison::LessThan, 3))->matches($row))->toBe($expectedResult);
+})->with([
+    [true, ['foo' => 'fooValue', 'bar' => 'barValue', 'baz' => 2]],
+    [true, ['foo' => 'fooValue 2', 'bar' => 'barValue 2', 'baz' => 2.999]],
+    [false, ['foo' => 'fooValue', 'bar' => 'barValue', 'baz' => 3]],
+    [false, ['foo' => 'fooValue', 'bar' => 'barValue', 'baz' => 4]],
+]);
+
+it('correctly filters rows with less than or equal filter', function (bool $expectedResult, array $row) {
+    expect((new Filter('baz', Comparison::LessThanOrEqual, 3))->matches($row))->toBe($expectedResult);
+})->with([
+    [true, ['foo' => 'fooValue', 'bar' => 'barValue', 'baz' => 2]],
+    [true, ['foo' => 'fooValue 2', 'bar' => 'barValue 2', 'baz' => 2.999]],
+    [true, ['foo' => 'fooValue', 'bar' => 'barValue', 'baz' => 3]],
+    [false, ['foo' => 'fooValue', 'bar' => 'barValue', 'baz' => 4]],
+]);
+
+it('correctly filters rows with string contains filter', function (bool $expectedResult, array $row) {
+    expect((new Filter('bar', StringCheck::Contains, 'pew'))->matches($row))->toBe($expectedResult);
+})->with([
+    [true, ['foo' => 'fooValue', 'bar' => 'pew', 'baz' => 'bazValue']],
+    [true, ['foo' => 'fooValue', 'bar' => 'bar pewbar', 'baz' => 'bazValue']],
+    [true, ['foo' => 'fooValue', 'bar' => 'bar pew', 'baz' => 'bazValue']],
+    [false, ['foo' => 'fooValue', 'bar' => 'barValue', 'baz' => 'bazValue']],
+]);
+
+it('correctly filters rows with string starts with filter', function (bool $expectedResult, array $row) {
+    expect((new Filter('bar', StringCheck::StartsWith, 'pew'))->matches($row))->toBe($expectedResult);
+})->with([
+    [true, ['foo' => 'fooValue', 'bar' => 'pew', 'baz' => 'bazValue']],
+    [true, ['foo' => 'fooValue', 'bar' => 'pew bar', 'baz' => 'bazValue']],
+    [true, ['foo' => 'fooValue', 'bar' => 'pewbar', 'baz' => 'bazValue']],
+    [false, ['foo' => 'fooValue', 'bar' => 'bar pew', 'baz' => 'bazValue']],
+]);
+
+it('correctly filters rows with string ends with filter', function (bool $expectedResult, array $row) {
+    expect((new Filter('bar', StringCheck::EndsWith, 'pew'))->matches($row))->toBe($expectedResult);
+})->with([
+    [true, ['foo' => 'fooValue', 'bar' => 'pew', 'baz' => 'bazValue']],
+    [true, ['foo' => 'fooValue', 'bar' => 'bar pew', 'baz' => 'bazValue']],
+    [true, ['foo' => 'fooValue', 'bar' => 'barpew', 'baz' => 'bazValue']],
+    [false, ['foo' => 'fooValue', 'bar' => 'pew bar', 'baz' => 'bazValue']],
+]);

--- a/tests/Steps/FilterRules/ComparisonTest.php
+++ b/tests/Steps/FilterRules/ComparisonTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace tests\Steps\FilterRules;
+
+use Crwlr\Crawler\Steps\FilterRules\Comparison;
+
+it('correctly applies equal operator', function (bool $expectedResult, mixed $value1, mixed $value2) {
+    $comparison = Comparison::Equal;
+
+    expect($comparison->evaluate($value1, $value2))->toBe($expectedResult);
+})->with([
+    [true, 1, 1],
+    [true, 'one', 'one'],
+    [true, 1.12, 1.12],
+    [false, 1, 2],
+    [false, 1, '1'],
+    [false, 'one', 'two'],
+    [false, 1.12, 1.122],
+]);
+
+it('correctly applies not equal operator', function (bool $expectedResult, mixed $value1, mixed $value2) {
+    $comparison = Comparison::NotEqual;
+
+    expect($comparison->evaluate($value1, $value2))->toBe($expectedResult);
+})->with([
+    [false, 1, 1],
+    [false, 'one', 'one'],
+    [false, 1.12, 1.12],
+    [true, 1, 2],
+    [true, 1, '1'],
+    [true, 'one', 'two'],
+    [true, 1.12, 1.122],
+]);
+
+it('correctly applies greater than operator', function (bool $expectedResult, mixed $value1, mixed $value2) {
+    $comparison = Comparison::GreaterThan;
+
+    expect($comparison->evaluate($value1, $value2))->toBe($expectedResult);
+})->with([
+    [true, 1, 0],
+    [true, 12, 3],
+    [true, 1.12, 1.11],
+    [false, 11, 11],
+    [false, 0, 1],
+    [false, 3.59, 3.591],
+]);
+
+it('correctly applies greater than or equal operator', function (bool $expectedResult, mixed $value1, mixed $value2) {
+    $comparison = Comparison::GreaterThanOrEqual;
+
+    expect($comparison->evaluate($value1, $value2))->toBe($expectedResult);
+})->with([
+    [true, 1, 0],
+    [true, 12, 3],
+    [true, 1.12, 1.11],
+    [true, 11, 11],
+    [false, 0, 1],
+    [false, 3.59, 3.591],
+]);
+
+it('correctly applies less than operator', function (bool $expectedResult, mixed $value1, mixed $value2) {
+    $comparison = Comparison::LessThan;
+
+    expect($comparison->evaluate($value1, $value2))->toBe($expectedResult);
+})->with([
+    [true, 0, 1],
+    [true, 4, 5],
+    [true, 5.79, 5.7901],
+    [false, 11, 11],
+    [false, 1, 0],
+    [false, 9.2901, 9.29],
+]);
+
+it('correctly applies less than or equal operator', function (bool $expectedResult, mixed $value1, mixed $value2) {
+    $comparison = Comparison::LessThanOrEqual;
+
+    expect($comparison->evaluate($value1, $value2))->toBe($expectedResult);
+})->with([
+    [true, 0, 1],
+    [true, 4, 5],
+    [true, 5.79, 5.7901],
+    [true, 11, 11],
+    [false, 1, 0],
+    [false, 9.2901, 9.29],
+]);

--- a/tests/Steps/FilterRules/StringCheckTest.php
+++ b/tests/Steps/FilterRules/StringCheckTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace tests\Steps\FilterRules;
+
+use Crwlr\Crawler\Steps\FilterRules\StringCheck;
+
+it('checks if a string contains another string', function (
+    bool $expectedResult,
+    mixed $haystack,
+    mixed $needle,
+) {
+    $comparison = StringCheck::Contains;
+
+    expect($comparison->evaluate($haystack, $needle))->toBe($expectedResult);
+})->with([
+    [true, 'foobarbaz', 'foo'],
+    [true, 'foo bar baz', 'foo'],
+    [true, 'foo bar baz', 'bar'],
+    [true, 'foo bar baz', 'baz'],
+    [false, 'foo bar baz', 'Foo'],
+]);
+
+it('checks if a string starts with another string', function (
+    bool $expectedResult,
+    mixed $haystack,
+    mixed $needle,
+) {
+    $comparison = StringCheck::StartsWith;
+
+    expect($comparison->evaluate($haystack, $needle))->toBe($expectedResult);
+})->with([
+    [true, 'foobarbaz', 'foo'],
+    [true, 'foo bar baz', 'foo'],
+    [true, 'foo bar baz', 'foo bar'],
+    [false, 'foo bar baz', 'bar'],
+    [false, 'foo bar baz', 'baz'],
+    [false, 'foo bar baz', 'Foo'],
+]);
+
+it('checks if a string ends with another string', function (
+    bool $expectedResult,
+    mixed $haystack,
+    mixed $needle,
+) {
+    $comparison = StringCheck::EndsWith;
+
+    expect($comparison->evaluate($haystack, $needle))->toBe($expectedResult);
+})->with([
+    [true, 'foobarbaz', 'baz'],
+    [true, 'foo bar baz', 'baz'],
+    [true, 'foo bar baz', 'bar baz'],
+    [false, 'foo bar baz', 'bar'],
+    [false, 'foo bar baz', 'foo'],
+    [false, 'foo bar baz', 'Baz'],
+]);


### PR DESCRIPTION
There is a new `filter()` method, and you can set multiple filters for different columns of CSV data. Currently available are basic comparison (equals, greater than, less than,...) and string (contains, starts/ends with) filters.