### PR TITLE
Rename filter() to where() and add orWhere()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-* The `BaseStep` class now has a `filter()` method. You can set 
-  multiple filters that will be applied to all outputs. Outputs not
-  matching one of the filters, are not yielded. Currently available
-  filters are comparison filters (equal, greater/less than,...) and
-  a few string filters (contains, starts/ends with).
+* The `BaseStep` class now has `where()` and `orWhere()` methods to
+  filter step outputs. You can set multiple filters that will be
+  applied to all outputs. When setting a filter using `orWhere`
+  it's linked to the previously added Filter with "OR". Outputs not
+  matching one of the filters, are not yielded. The available
+  filters can be accessed through static methods on the new `Filter`
+  class. Currently available filters are comparison filters (equal,
+  greater/less than,...) and a few string filters (contains,
+  starts/ends with).
 
 ## [0.3.0] - 2022-04-27
 ### Added

--- a/src/Steps/Filters/Filter.php
+++ b/src/Steps/Filters/Filter.php
@@ -11,6 +11,8 @@ abstract class Filter implements FilterInterface
 {
     protected ?string $useKey = null;
 
+    protected bool|FilterInterface $or = false;
+
     public static function equal(mixed $equalToValue): Comparison
     {
         return new Comparison(Comparisons::Equal, $equalToValue);
@@ -61,6 +63,33 @@ abstract class Filter implements FilterInterface
         $this->useKey = $key;
 
         return $this;
+    }
+
+    /**
+     * Step::orWhere() uses this method to link further Filters with OR to this filter.
+     * The Step then takes care of checking if one of the ORs evaluates to true.
+     */
+    public function addOr(FilterInterface $filter): void
+    {
+        if ($this->or instanceof FilterInterface) {
+            $or = $this->or;
+
+            while ($or->getOr()) {
+                $or = $or->getOr();
+            }
+
+            $or->addOr($filter);
+        } else {
+            $this->or = $filter;
+        }
+    }
+
+    /**
+     * Get the Filter linked to this Filter as OR.
+     */
+    public function getOr(): ?FilterInterface
+    {
+        return $this->or instanceof FilterInterface ? $this->or : null;
     }
 
     protected function getKey(mixed $value): mixed

--- a/src/Steps/Filters/FilterInterface.php
+++ b/src/Steps/Filters/FilterInterface.php
@@ -4,10 +4,17 @@ namespace Crwlr\Crawler\Steps\Filters;
 
 interface FilterInterface
 {
+    /**
+     * When the value that will be evaluated is array or object, provide a key to use from that array/object.
+     */
     public function useKey(string $key): static;
 
     /**
      * Shall return true if the $valueInQuestion should be kept or false when it should be filtered out.
      */
     public function evaluate(mixed $valueInQuestion): bool;
+
+    public function addOr(FilterInterface $filter): void;
+
+    public function getOr(): ?FilterInterface;
 }

--- a/src/Steps/Loop.php
+++ b/src/Steps/Loop.php
@@ -167,9 +167,16 @@ final class Loop implements StepInterface
         return $this->step->cascades();
     }
 
-    public function filter(FilterInterface $filter): static
+    public function where(string|FilterInterface $keyOrFilter, ?FilterInterface $filter = null): static
     {
-        $this->step->filter($filter);
+        $this->step->where($keyOrFilter, $filter);
+
+        return $this;
+    }
+
+    public function orWhere(string|FilterInterface $keyOrFilter, ?FilterInterface $filter = null): static
+    {
+        $this->step->orWhere($keyOrFilter, $filter);
 
         return $this;
     }

--- a/src/Steps/StepInterface.php
+++ b/src/Steps/StepInterface.php
@@ -4,6 +4,7 @@ namespace Crwlr\Crawler\Steps;
 
 use Crwlr\Crawler\Input;
 use Crwlr\Crawler\Output;
+use Crwlr\Crawler\Steps\Filters\Filter;
 use Crwlr\Crawler\Steps\Filters\FilterInterface;
 use Generator;
 use Psr\Log\LoggerInterface;
@@ -37,7 +38,9 @@ interface StepInterface
 
     public function cascades(): bool;
 
-    public function filter(FilterInterface $filter): static;
+    public function where(string|FilterInterface $keyOrFilter, ?FilterInterface $filter = null): static;
+
+    public function orWhere(string|FilterInterface $keyOrFilter, ?FilterInterface $filter = null): static;
 
     public function resetAfterRun(): void;
 }

--- a/tests/Steps/BaseStepTest.php
+++ b/tests/Steps/BaseStepTest.php
@@ -26,7 +26,7 @@ class TestStep extends BaseStep
 test('You can set a filter and passesAllFilters() tells if an output value passes that filter', function () {
     $step = new TestStep();
 
-    $step->filter(Filter::equal('hello'));
+    $step->where(Filter::equal('hello'));
 
     helper_invokeStepWithInput($step, new Input('hello'));
 
@@ -40,9 +40,9 @@ test('You can set a filter and passesAllFilters() tells if an output value passe
 test('You can set multiple filters and passesAllFilters() tells if an output value passes that filters', function () {
     $step = new TestStep();
 
-    $step->filter(Filter::stringContains('foo'))
-        ->filter(Filter::equal('boo foo too'))
-        ->filter(Filter::notEqual('pew foo tew'));
+    $step->where(Filter::stringContains('foo'))
+        ->where(Filter::equal('boo foo too'))
+        ->where(Filter::notEqual('pew foo tew'));
 
     helper_invokeStepWithInput($step, new Input('boo foo too'));
 
@@ -57,10 +57,37 @@ test('You can set multiple filters and passesAllFilters() tells if an output val
     expect($step->passesAllFilters)->toBeFalse();
 });
 
+test(
+    'you can link filters using orWhere and passesAllFilters() is true when one of those filters evaluates to true',
+    function () {
+        $step = new TestStep();
+
+        $step->where(Filter::stringStartsWith('foo'))
+            ->orWhere(Filter::stringStartsWith('bar'))
+            ->orWhere(Filter::stringEndsWith('foo'));
+
+        helper_invokeStepWithInput($step, new Input('foo bar baz'));
+
+        expect($step->passesAllFilters)->toBeTrue();
+
+        helper_invokeStepWithInput($step, new Input('bar foo baz'));
+
+        expect($step->passesAllFilters)->toBeTrue();
+
+        helper_invokeStepWithInput($step, new Input('bar baz foo'));
+
+        expect($step->passesAllFilters)->toBeTrue();
+
+        helper_invokeStepWithInput($step, new Input('funky town'));
+
+        expect($step->passesAllFilters)->toBeFalse();
+    }
+);
+
 it('uses a key from an array when providing a key to the filter() method', function () {
     $step = new TestStep();
 
-    $step->filter('vendor', Filter::equal('crwlr'));
+    $step->where('vendor', Filter::equal('crwlr'));
 
     helper_invokeStepWithInput($step, new Input(['vendor' => 'crwlr', 'package' => 'url']));
 
@@ -74,7 +101,7 @@ it('uses a key from an array when providing a key to the filter() method', funct
 it('uses a key from an object when providing a key to the filter() method', function () {
     $step = new TestStep();
 
-    $step->filter('vendor', Filter::equal('crwlr'));
+    $step->where('vendor', Filter::equal('crwlr'));
 
     helper_invokeStepWithInput($step, new Input(
         helper_getStdClassWithData(['vendor' => 'crwlr', 'package' => 'url'])
@@ -92,5 +119,5 @@ it('uses a key from an object when providing a key to the filter() method', func
 it('throws an exception when you provide a string as first argument to filter but no second argument', function () {
     $step = new TestStep();
 
-    $step->filter('test');
+    $step->where('test');
 })->throws(InvalidArgumentException::class);

--- a/tests/Steps/CsvTest.php
+++ b/tests/Steps/CsvTest.php
@@ -353,7 +353,7 @@ it('filters rows', function () {
 
     $step = Csv::parseString(['id', 3 => 'isPremium'])
         ->skipFirstLine()
-        ->filter('isPremium', Filter::equal('1'));
+        ->where('isPremium', Filter::equal('1'));
 
     $outputs = helper_invokeStepWithInput($step, $string);
 
@@ -367,7 +367,7 @@ it('filters rows', function () {
 it('filters rows when parsing a file', function () {
     $step = Csv::parseFile(['Stunde', 'Fach'])
         ->skipFirstLine()
-        ->filter('Fach', Filter::equal('Sport'));
+        ->where('Fach', Filter::equal('Sport'));
 
     $outputs = helper_invokeStepWithInput($step, helper_csvFilePath('with-column-headlines.csv'));
 
@@ -388,8 +388,8 @@ it('filters rows by multiple filters', function () {
 
     $step = Csv::parseString(['id', 3 => 'isVip', 4 => 'isQueenBandMember'])
         ->skipFirstLine()
-        ->filter('isVip', Filter::equal('1'))
-        ->filter('isQueenBandMember', Filter::equal('1'));
+        ->where('isVip', Filter::equal('1'))
+        ->where('isQueenBandMember', Filter::equal('1'));
 
     $outputs = helper_invokeStepWithInput($step, $string);
 
@@ -401,8 +401,8 @@ it('filters rows by multiple filters', function () {
 it('filters rows by multiple filters when parsing a file', function () {
     $step = Csv::parseFile(['Stunde', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag'])
         ->skipFirstLine()
-        ->filter('Montag', Filter::equal('Sport'))
-        ->filter('Donnerstag', Filter::equal('Sport'));
+        ->where('Montag', Filter::equal('Sport'))
+        ->where('Donnerstag', Filter::equal('Sport'));
 
     $outputs = helper_invokeStepWithInput($step, helper_csvFilePath('with-column-headlines.csv'));
 
@@ -429,7 +429,7 @@ it('filters rows with a StringCheck filter', function () {
 
     $step = Csv::parseString(['id', 'firstname'])
         ->skipFirstLine()
-        ->filter('firstname', Filter::stringContains('Christian'));
+        ->where('firstname', Filter::stringContains('Christian'));
 
     $outputs = helper_invokeStepWithInput($step, $string);
 


### PR DESCRIPTION
Wasn't happy with the method naming filter() especially as there is also the need to concatenate filters with OR instead of AND. As where and orWhere are pretty common, this is it now.