### PR TITLE
Get links steps domain and host constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   class. Currently available filters are comparison filters (equal,
   greater/less than,...) and a few string filters (contains,
   starts/ends with).
+* The `GetLink` and `GetLinks` steps now have methods
+  `onSameDomain()`, `notOnSameDomain()`, `onDomain()`,
+  `onSameHost()`, `notOnSameHost()`, `onHost()` to restrict the
+  which links to find.
 
 ### Changed
 * The `Csv` step can now also be used without defining a column

--- a/src/Steps/Html/GetLinks.php
+++ b/src/Steps/Html/GetLinks.php
@@ -27,9 +27,11 @@ class GetLinks extends GetLink
                 continue;
             }
 
-            $link = new Crawler($link);
+            $linkUrl = $this->baseUri->resolve((new Crawler($link))->attr('href') ?? '');
 
-            yield $this->baseUri->resolve($link->attr('href') ?? '')->__toString();
+            if ($this->matchesAdditionalCriteria($linkUrl)) {
+                yield $linkUrl->__toString();
+            }
         }
     }
 }

--- a/tests/Steps/Html/GetLinkTest.php
+++ b/tests/Steps/Html/GetLinkTest.php
@@ -4,7 +4,6 @@ namespace tests\Steps\Html;
 
 use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
 use Crwlr\Crawler\Input;
-use Crwlr\Crawler\Logger\CliLogger;
 use Crwlr\Crawler\Steps\Html\GetLink;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -76,4 +75,271 @@ test('When selector matches on a non-link element it\'s ignored', function () {
     expect($link)->toHaveCount(1);
 
     expect($link[0]->get())->toBe('https://www.otsch.codes/foo');
+});
+
+it('finds only links on the same domain when onSameDomain() was called', function () {
+    $html = <<<HTML
+        <a href="https://www.crwlr.software/packages">link1</a>
+        <a href="https://blog.otsch.codes/articles">link2</a>
+        HTML;
+
+    $step = (new GetLink())->onSameDomain();
+
+    $link = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($link)->toHaveCount(1);
+
+    expect($link[0]->get())->toBe('https://blog.otsch.codes/articles');
+});
+
+it('doesn\'t find a link on the same domain when notOnSameDomain() was called', function () {
+    $html = <<<HTML
+        <a href="https://www.otsch.codes/contact">link1</a>
+        <a href="https://www.crwlr.software/packages">link2</a>
+        HTML;
+
+    $step = (new GetLink())->notOnSameDomain();
+
+    $link = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($link)->toHaveCount(1);
+
+    expect($link[0]->get())->toBe('https://www.crwlr.software/packages');
+});
+
+it('finds only links from domains the onDomain() method was called with', function () {
+    $html = <<<HTML
+        <a href="https://www.otsch.codes/contact">link1</a>
+        <a href="https://www.crwlr.software/packages">link2</a>
+        <a href="https://www.crwl.io">link3</a>
+        <a href="https://www.example.com">link4</a>
+        HTML;
+
+    $step = (new GetLink())->onDomain('example.com');
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(1);
+
+    expect($links[0]->get())->toBe('https://www.example.com');
+});
+
+test('onDomain() also takes an array of domains', function () {
+    $html = <<<HTML
+        <a href="https://www.otsch.codes/contact">link1</a>
+        <a href="https://www.crwlr.software/packages">link2</a>
+        HTML;
+
+    $step = (new GetLink())->onDomain(['otsch.codes', 'example.com']);
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(1);
+
+    expect($links[0]->get())->toBe('https://www.otsch.codes/contact');
+
+    $html = <<<HTML
+        <a href="https://www.crwlr.software/packages">link1</a>
+        <a href="https://www.example.com/foo">link2</a>
+        HTML;
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(1);
+
+    expect($links[0]->get())->toBe('https://www.example.com/foo');
+});
+
+test('onDomain() can be called multiple times and merges all domains it was called with', function () {
+    $html = <<<HTML
+        <a href="https://www.otsch.codes/contact">link1</a>
+        HTML;
+
+    $step = (new GetLink())->onDomain('crwl.io');
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(0);
+
+    $step->onDomain(['otsch.codes', 'crwlr.software']);
+
+    $html = <<<HTML
+        <a href="https://www.crwl.io">link1</a>
+        <a href="https://www.otsch.codes/contact">link2</a>
+        HTML;
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(1);
+
+    expect($links[0]->get())->toBe('https://www.crwl.io');
+
+    $html = <<<HTML
+        <a href="https://www.otsch.codes/contact">link1</a>
+        <a href="https://www.crwl.io">link2</a>
+        HTML;
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(1);
+
+    expect($links[0]->get())->toBe('https://www.otsch.codes/contact');
+});
+
+it('finds only links on the same host when onSameHost() was called', function () {
+    $html = <<<HTML
+        <a href="https://www.crwlr.software/packages">link1</a>
+        <a href="https://jobs.otsch.codes">link2</a>
+        <a href="https://www.otsch.codes/contact">link3</a>
+        HTML;
+
+    $step = (new GetLink())->onSameHost();
+
+    $link = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($link)->toHaveCount(1);
+
+    expect($link[0]->get())->toBe('https://www.otsch.codes/contact');
+});
+
+it('doesn\'t find a link on the same host when notOnSameHost() was called', function () {
+    $html = <<<HTML
+        <a href="https://www.otsch.codes/contact">link1</a>
+        <a href="https://jobs.otsch.codes">link2</a>
+        HTML;
+
+    $step = (new GetLink())->notOnSameHost();
+
+    $link = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($link)->toHaveCount(1);
+
+    expect($link[0]->get())->toBe('https://jobs.otsch.codes');
+});
+
+it('finds only links from hosts the onHost() method was called with', function () {
+    $html = <<<HTML
+        <a href="https://www.otsch.codes/contact">link1</a>
+        <a href="https://www.crwlr.software/packages">link2</a>
+        <a href="https://www.crwl.io">link3</a>
+        <a href="https://www.example.com">link4</a>
+        HTML;
+
+    $step = (new GetLink())->onHost('www.example.com');
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(1);
+
+    expect($links[0]->get())->toBe('https://www.example.com');
+});
+
+test('onHost() also takes an array of hosts', function () {
+    $html = <<<HTML
+        <a href="https://www.otsch.codes/contact">link1</a>
+        <a href="https://www.crwlr.software/packages">link2</a>
+        HTML;
+
+    $step = (new GetLink())->onHost(['www.otsch.codes', 'blog.example.com']);
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(1);
+
+    expect($links[0]->get())->toBe('https://www.otsch.codes/contact');
+
+    $html = <<<HTML
+        <a href="https://www.example.com/foo">link1</a>
+        <a href="https://www.crwlr.software/packages">link2</a>
+        <a href="https://blog.example.com/articles/1">link3</a>
+        HTML;
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(1);
+
+    expect($links[0]->get())->toBe('https://blog.example.com/articles/1');
+});
+
+test('onHost() can be called multiple times and merges all hosts it was called with', function () {
+    $html = <<<HTML
+        <a href="https://www.otsch.codes/contact">link1</a>
+        HTML;
+
+    $step = (new GetLink())->onHost('www.crwl.io');
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(0);
+
+    $step->onHost(['www.otsch.codes', 'www.crwlr.software']);
+
+    $html = <<<HTML
+        <a href="https://www.crwl.io">link1</a>
+        HTML;
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(1);
+
+    expect($links[0]->get())->toBe('https://www.crwl.io');
+
+    $html = <<<HTML
+        <a href="https://www.otsch.codes/blog">link1</a>
+        <a href="https://www.crwl.io">link2</a>
+        HTML;
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(1);
+
+    expect($links[0]->get())->toBe('https://www.otsch.codes/blog');
 });

--- a/tests/Steps/Html/GetLinksTest.php
+++ b/tests/Steps/Html/GetLinksTest.php
@@ -4,13 +4,11 @@ namespace tests\Steps\Html;
 
 use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
 use Crwlr\Crawler\Input;
-use Crwlr\Crawler\Logger\CliLogger;
 use Crwlr\Crawler\Steps\Html\GetLinks;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use InvalidArgumentException;
 use stdClass;
-use function tests\helper_generatorToArray;
 use function tests\helper_invokeStepWithInput;
 use function tests\helper_traverseIterable;
 
@@ -89,4 +87,268 @@ test('When selector matches on a non-link element it\'s ignored', function () {
     expect($links)->toHaveCount(1);
 
     expect($links[0]->get())->toBe('https://www.otsch.codes/foo');
+});
+
+it('finds only links on the same domain when onSameDomain() was called', function () {
+    $html = <<<HTML
+        <a href="https://www.crwlr.software/packages">link1</a>
+        <a href="https://blog.otsch.codes/articles">link2</a>
+        <a href="https://www.otsch.codes/blog">link3</a>
+        HTML;
+
+    $step = (new GetLinks())->onSameDomain();
+
+    $link = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($link)->toHaveCount(2);
+
+    expect($link[0]->get())->toBe('https://blog.otsch.codes/articles');
+
+    expect($link[1]->get())->toBe('https://www.otsch.codes/blog');
+});
+
+it('doesn\'t find links on the same domain when notOnSameDomain() was called', function () {
+    $html = <<<HTML
+        <a href="https://www.otsch.codes/contact">link1</a>
+        <a href="https://www.crwlr.software/packages">link2</a>
+        <a href="https://www.example.com/foo">link3</a>
+        HTML;
+
+    $step = (new GetLinks())->notOnSameDomain();
+
+    $link = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($link)->toHaveCount(2);
+
+    expect($link[0]->get())->toBe('https://www.crwlr.software/packages');
+
+    expect($link[1]->get())->toBe('https://www.example.com/foo');
+});
+
+it('finds only links from domains the onDomain() method was called with', function () {
+    $html = <<<HTML
+        <a href="https://www.otsch.codes/contact">link1</a>
+        <a href="https://www.crwlr.software/packages">link2</a>
+        <a href="https://www.crwl.io">link3</a>
+        <a href="https://www.crwlr.software/blog">link4</a>
+        HTML;
+
+    $step = (new GetLinks())->onDomain('crwlr.software');
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(2);
+
+    expect($links[0]->get())->toBe('https://www.crwlr.software/packages');
+
+    expect($links[1]->get())->toBe('https://www.crwlr.software/blog');
+});
+
+test('onDomain() also takes an array of domains', function () {
+    $html = <<<HTML
+        <a href="https://www.otsch.codes/contact">link1</a>
+        <a href="https://www.crwlr.software/packages">link2</a>
+        <a href="https://www.example.com/yolo">link3</a>
+        HTML;
+
+    $step = (new GetLinks())->onDomain(['otsch.codes', 'crwlr.software']);
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(2);
+
+    expect($links[0]->get())->toBe('https://www.otsch.codes/contact');
+
+    expect($links[1]->get())->toBe('https://www.crwlr.software/packages');
+});
+
+test('onDomain() can be called multiple times and merges all domains it was called with', function () {
+    $html = <<<HTML
+        <a href="https://www.otsch.codes/contact">link1</a>
+        <a href="https://www.crwlr.software/packages">link2</a>
+        <a href="https://www.example.com/yolo">link3</a>
+        HTML;
+
+    $step = (new GetLinks())->onDomain('crwl.io');
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(0);
+
+    $step->onDomain(['otsch.codes', 'crwlr.software']);
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(2);
+
+    $step->onDomain('example.com');
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(3);
+});
+
+it('finds only links on the same host when onSameHost() was called', function () {
+    $html = <<<HTML
+        <a href="https://www.crwlr.software/packages">link1</a>
+        <a href="https://www.otsch.codes/contact">link2</a>
+        <a href="https://jobs.otsch.codes">link3</a>
+        <a href="https://www.otsch.codes/blog">link4</a>
+        HTML;
+
+    $step = (new GetLinks())->onSameHost();
+
+    $link = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($link)->toHaveCount(2);
+
+    expect($link[0]->get())->toBe('https://www.otsch.codes/contact');
+
+    expect($link[1]->get())->toBe('https://www.otsch.codes/blog');
+});
+
+it('doesn\'t find links on the same host when notOnSameHost() was called', function () {
+    $html = <<<HTML
+        <a href="https://www.otsch.codes/contact">link1</a>
+        <a href="https://jobs.otsch.codes">link2</a>
+        <a href="https://www.crwlr.software/packages">link3</a>
+        HTML;
+
+    $step = (new GetLinks())->notOnSameHost();
+
+    $link = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($link)->toHaveCount(2);
+
+    expect($link[0]->get())->toBe('https://jobs.otsch.codes');
+
+    expect($link[1]->get())->toBe('https://www.crwlr.software/packages');
+});
+
+it('finds only links from hosts the onHost() method was called with', function () {
+    $html = <<<HTML
+        <a href="https://www.otsch.codes/contact">link1</a>
+        <a href="https://www.crwlr.software/packages">link2</a>
+        <a href="https://blog.crwlr.software">link3</a>
+        <a href="https://www.crwlr.software/packages/crawler/v0.4/getting-started">link4</a>
+        HTML;
+
+    $step = (new GetLinks())->onHost('www.crwlr.software');
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(2);
+
+    expect($links[0]->get())->toBe('https://www.crwlr.software/packages');
+
+    expect($links[1]->get())->toBe('https://www.crwlr.software/packages/crawler/v0.4/getting-started');
+});
+
+test('onHost() also takes an array of hosts', function () {
+    $html = <<<HTML
+        <a href="https://www.otsch.codes/contact">link1</a>
+        <a href="https://www.crwlr.software/packages">link2</a>
+        HTML;
+
+    $step = (new GetLinks())->onHost(['www.otsch.codes', 'blog.example.com']);
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(1);
+
+    expect($links[0]->get())->toBe('https://www.otsch.codes/contact');
+
+    $html = <<<HTML
+        <a href="https://www.otsch.codes/contact">link1</a>
+        <a href="https://www.crwlr.software/packages">link2</a>
+        <a href="https://blog.example.com/articles/1">link3</a>
+        HTML;
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(2);
+
+    expect($links[1]->get())->toBe('https://blog.example.com/articles/1');
+});
+
+test('onHost() can be called multiple times and merges all hosts it was called with', function () {
+    $html = <<<HTML
+        <a href="https://www.otsch.codes/contact">link1</a>
+        HTML;
+
+    $step = (new GetLinks())->onHost('www.crwl.io');
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(0);
+
+    $step->onHost(['www.otsch.codes', 'www.crwlr.software']);
+
+    $html = <<<HTML
+        <a href="https://www.crwl.io">link1</a>
+        HTML;
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(1);
+
+    expect($links[0]->get())->toBe('https://www.crwl.io');
+
+    $html = <<<HTML
+        <a href="https://www.otsch.codes/blog">link1</a>
+        <a href="https://www.crwl.io">link2</a>
+        HTML;
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.otsch.codes'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links)->toHaveCount(2);
+
+    expect($links[0]->get())->toBe('https://www.otsch.codes/blog');
+
+    expect($links[1]->get())->toBe('https://www.crwl.io');
 });


### PR DESCRIPTION
The `GetLink` and `GetLinks` steps now have methods `onSameDomain()`, `notOnSameDomain()`, `onDomain()`, `onSameHost()`, `notOnSameHost()`, `onHost()` to restrict the which links to find.