### PR TITLE
Add logger to the store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.4.0] - 2022-05-06
 ### Added
 * The `BaseStep` class now has `where()` and `orWhere()` methods to
   filter step outputs. You can set multiple filters that will be
@@ -19,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `onSameDomain()`, `notOnSameDomain()`, `onDomain()`,
   `onSameHost()`, `notOnSameHost()`, `onHost()` to restrict the
   which links to find.
+* Automatically add the crawler's logger to the `Store` so you can
+  also log messages from there. This can be breaking as the
+  `StoreInterface` now also requires the `addLogger` method. The
+  new abstract `Store` class already implements it, so you can just
+  extend it.
 
 ### Changed
 * The `Csv` step can now also be used without defining a column

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 This package provides kind of a framework and a lot of ready
 to use, so-called steps, that you can combine to build your
-own crawlers or scrapers with.
+own crawlers and scrapers with.
 
 ## Documentation
 
 You can find the documentation at 
-[crwlr.software](https://www.crwlr.software/packages/crawler/v0.2/getting-started).
+[crwlr.software](https://www.crwlr.software/packages/crawler/v0.4/getting-started).
 
 ## Contributing
 

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -80,6 +80,8 @@ abstract class Crawler
 
     public function setStore(StoreInterface $store): static
     {
+        $store->addLogger($this->logger);
+
         $this->store = $store;
 
         return $this;

--- a/src/Stores/SimpleCsvFileStore.php
+++ b/src/Stores/SimpleCsvFileStore.php
@@ -5,13 +5,13 @@ namespace Crwlr\Crawler\Stores;
 use Crwlr\Crawler\Result;
 use Exception;
 
-class SimpleCsvFileStore implements StoreInterface
+class SimpleCsvFileStore extends Store
 {
     private int $createTimestamp;
 
     private bool $isFirstResult = true;
 
-    public function __construct(private string $storePath, private ?string $filePrefix = null)
+    public function __construct(private readonly string $storePath, private readonly ?string $filePrefix = null)
     {
         $this->createTimestamp = time();
 
@@ -35,6 +35,8 @@ class SimpleCsvFileStore implements StoreInterface
         fputcsv($fileHandle, array_values($result->toArray()));
 
         fclose($fileHandle);
+
+        $this->logger?->info('Stored a result');
     }
 
     public function filePath(): string

--- a/src/Stores/Store.php
+++ b/src/Stores/Store.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Crwlr\Crawler\Stores;
+
+use Psr\Log\LoggerInterface;
+
+abstract class Store implements StoreInterface
+{
+    protected ?LoggerInterface $logger = null;
+
+    public function addLogger(LoggerInterface $logger): static
+    {
+        $this->logger = $logger;
+
+        return $this;
+    }
+}

--- a/src/Stores/StoreInterface.php
+++ b/src/Stores/StoreInterface.php
@@ -3,8 +3,11 @@
 namespace Crwlr\Crawler\Stores;
 
 use Crwlr\Crawler\Result;
+use Psr\Log\LoggerInterface;
 
 interface StoreInterface
 {
     public function store(Result $result): void;
+
+    public function addLogger(LoggerInterface $logger): static;
 }


### PR DESCRIPTION
Automatically add the crawler's logger to the `Store` so you can also log messages from there. This can be breaking as the `StoreInterface` now also requires the `addLogger` method. The new abstract `Store` class already implements it, so you can just extend it.
Also prepare for v0.4 release tag.