### PR TITLE
Change getLink(s) argument to optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   you can set a closure that'll receive all the outputs from all the
   steps. Should be only for debugging reasons.
 
+### Fixed
+* The static methods `Html::getLink()` and `Html::getLinks()` now
+  also work without argument, like the `GetLink` and `GetLinks`
+  classes.
+
 ## [0.4.1] - 2022-05-10
 ### Fixed
 * The `Json` step now also works with Http responses as input.

--- a/composer.json
+++ b/composer.json
@@ -63,5 +63,11 @@
         "cs": "@php vendor/bin/php-cs-fixer fix -v --dry-run",
         "cs-fix": "@php vendor/bin/php-cs-fixer fix -v",
         "add-git-hooks": "@php bin/add-git-hooks"
+    },
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true,
+            "phpstan/extension-installer": true
+        }
     }
 }

--- a/src/Steps/Html.php
+++ b/src/Steps/Html.php
@@ -9,12 +9,12 @@ use Crwlr\Crawler\Steps\Html\GetLinks;
 
 class Html extends Dom
 {
-    public static function getLink(string $selector): GetLink
+    public static function getLink(?string $selector = null): GetLink
     {
         return new GetLink($selector);
     }
 
-    public static function getLinks(string $selector): GetLinks
+    public static function getLinks(?string $selector = null): GetLinks
     {
         return new GetLinks($selector);
     }

--- a/tests/Loader/Http/Cookies/CookieTest.php
+++ b/tests/Loader/Http/Cookies/CookieTest.php
@@ -260,6 +260,7 @@ test('It should be sent when date of expires attribute is not reached', function
 test('It should not be sent when maxAge attribute is already reached', function () {
     $cookie = new Cookie('https://www.crwlr.software', 'cookie=value; Max-Age=1');
     expect($cookie->shouldBeSentTo('https://www.crwlr.software'))->toBeTrue();
+    // @phpstan-ignore-next-line
     invade($cookie)->receivedAtTimestamp -= 2; // instead of sleep, manipulate the timestamp when it was received.
     expect($cookie->shouldBeSentTo('https://www.crwlr.software'))->toBeFalse();
 });

--- a/tests/Steps/HtmlTest.php
+++ b/tests/Steps/HtmlTest.php
@@ -4,6 +4,8 @@ namespace tests\Steps;
 
 use Crwlr\Crawler\Steps\Dom;
 use Crwlr\Crawler\Steps\Html;
+use Crwlr\Crawler\Steps\Html\GetLink;
+use Crwlr\Crawler\Steps\Html\GetLinks;
 use function tests\helper_invokeStepWithInput;
 
 function helper_getHtmlContent(string $fileName): string
@@ -96,4 +98,12 @@ it('extracts the data of the last matching element when the last method is used'
     expect($output)->toHaveCount(1);
 
     expect($output[0]->get())->toBe(['title' => 'Learning XML', 'author' => 'Erik T. Ray', 'year' => '2003']);
+});
+
+test('the static getLink method works without argument', function () {
+    expect(Html::getLink())->toBeInstanceOf(GetLink::class);
+});
+
+test('the static getLinks method works without argument', function () {
+    expect(Html::getLinks())->toBeInstanceOf(GetLinks::class);
 });


### PR DESCRIPTION
As the selector is optional for the GetLink and GetLinks steps, also make the argument optional in the static methods.