### PR TITLE
Improve PHPStan config

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,4 +7,4 @@ parameters:
         analyse:
             - tests/_Integration/_Server
     ignoreErrors:
-         - "#^Call to an undefined method Pest\\\\Expectation\\|Pest\\\\Support\\\\Extendable\\:\\:\\S+\\(\\)\\.$#"
+        - "#^Call to an undefined method Pest\\\\Expectation\\|Pest\\\\Support\\\\Extendable\\:\\:\\S+\\(\\)\\.$#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,7 +6,5 @@ parameters:
     excludePaths:
         analyse:
             - tests/_Integration/_Server
-    treatPhpDocTypesAsCertain: false
-
     ignoreErrors:
-        - "/Call to an undefined method Pest\\\\Expectation\\\\|Pest\\\\Support\\\\Extendable.*/"
+         - "#^Call to an undefined method Pest\\\\Expectation\\|Pest\\\\Support\\\\Extendable\\:\\:\\S+\\(\\)\\.$#"


### PR DESCRIPTION
- there is no need for treatPhpDocTypesAsCertain
- complete ignore regexp
