### PR TITLE
Switch order of happy path and unhappy path in GetLink

### DIFF
--- a/src/Steps/Html/GetLink.php
+++ b/src/Steps/Html/GetLink.php
@@ -35,13 +35,13 @@ class GetLink extends Step
 
     protected function validateAndSanitizeInput(mixed $input): Crawler
     {
-        if ($input instanceof RespondedRequest) {
-            $this->baseUri = Url::parse($input->effectiveUri());
-
-            return new Crawler(Http::getBodyString($input));
+        if (!$input instanceof RespondedRequest) {
+            throw new InvalidArgumentException('Input must be an instance of RespondedRequest.');
         }
 
-        throw new InvalidArgumentException('Input must be an instance of RespondedRequest.');
+        $this->baseUri = Url::parse($input->effectiveUri());
+
+        return new Crawler(Http::getBodyString($input));
     }
 
     /**


### PR DESCRIPTION
```
if (error) unhappy path;

happy path;
```

The reverse is mind-twisting to read. It looks like the unhappy path is the desired one.