### PR TITLE
Make Dom::extract() work with single selector and fix behavior when selectors don't match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,26 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-* With the `maxOutputs()` method of the abstract `Step` class you
-  can now limit how many outputs a certain step should yield at max.
-  That's for example helpful during development, when you want to
-  run the crawler only with a small subset of the data/requests it
-  will actually have to process when you eventually remove the
-  limits. When a step has reached its limit, it won't even call the
-  `invoke()` method any longer until the step is reset after a run.
-* With the new `outputHook()` method of the abstract `Crawler` class
-  you can set a closure that'll receive all the outputs from all the
-  steps. Should be only for debugging reasons.
-* The `extract()` method of the `Html` and `Xml` (children of `Dom`)
-  steps now also works with a single selector instead of an array
-  with a mapping. Sometimes you'll want to just get a simple string
-  output e.g. for a next step, instead of an array with mapped
-  extracted data.
+* With the `maxOutputs()` method of the abstract `Step` class you can now limit how many outputs a certain step should yield at max. That's for example helpful during development, when you want to run the crawler only with a small subset of the data/requests it will actually have to process when you eventually remove the limits. When a step has reached its limit, it won't even call the `invoke()` method any longer until the step is reset after a run.
+* With the new `outputHook()` method of the abstract `Crawler` class you can set a closure that'll receive all the outputs from all the steps. Should be only for debugging reasons.
+* The `extract()` method of the `Html` and `Xml` (children of `Dom`) steps now also works with a single selector instead of an array with a mapping. Sometimes you'll want to just get a simple string output e.g. for a next step, instead of an array with mapped extracted data.
 
 ### Fixed
-* The static methods `Html::getLink()` and `Html::getLinks()` now
-  also work without argument, like the `GetLink` and `GetLinks`
-  classes.
+* The static methods `Html::getLink()` and `Html::getLinks()` now also work without argument, like the `GetLink` and `GetLinks` classes.
+* When a `DomQuery` (CSS selector or XPath query) doesn't match anything, its `apply()` method now returns `null` (instead of an empty string). When the `Html(/Xml)::extract()` method is used with a single, not matching selector/query, nothing is yielded. When it's used with an array with a mapping, it yields an array with null values. If the selector for one of the methods `Html(/Xml)::each()`, `Html(/Xml)::first()` or `Html(/Xml)::last()` doesn't match anything, that's not causing an error any longer, it just won't yield anything.
 
 ## [0.4.1] - 2022-05-10
 ### Fixed
@@ -33,59 +20,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.0] - 2022-05-06
 ### Added
-* The `BaseStep` class now has `where()` and `orWhere()` methods to
-  filter step outputs. You can set multiple filters that will be
-  applied to all outputs. When setting a filter using `orWhere`
-  it's linked to the previously added Filter with "OR". Outputs not
-  matching one of the filters, are not yielded. The available
-  filters can be accessed through static methods on the new `Filter`
-  class. Currently available filters are comparison filters (equal,
-  greater/less than,...), a few string filters (contains,
-  starts/ends with) and url filters (scheme, domain, host,...).
-* The `GetLink` and `GetLinks` steps now have methods
-  `onSameDomain()`, `notOnSameDomain()`, `onDomain()`,
-  `onSameHost()`, `notOnSameHost()`, `onHost()` to restrict the
-  which links to find.
-* Automatically add the crawler's logger to the `Store` so you can
-  also log messages from there. This can be breaking as the
-  `StoreInterface` now also requires the `addLogger` method. The
-  new abstract `Store` class already implements it, so you can just
-  extend it.
+* The `BaseStep` class now has `where()` and `orWhere()` methods to filter step outputs. You can set multiple filters that will be applied to all outputs. When setting a filter using `orWhere` it's linked to the previously added Filter with "OR". Outputs not matching one of the filters, are not yielded. The available filters can be accessed through static methods on the new `Filter` class. Currently available filters are comparison filters (equal, greater/less than,...), a few string filters (contains, starts/ends with) and url filters (scheme, domain, host,...).
+* The `GetLink` and `GetLinks` steps now have methods `onSameDomain()`, `notOnSameDomain()`, `onDomain()`, `onSameHost()`, `notOnSameHost()`, `onHost()` to restrict the which links to find.
+* Automatically add the crawler's logger to the `Store` so you can also log messages from there. This can be breaking as the `StoreInterface` now also requires the `addLogger` method. The new abstract `Store` class already implements it, so you can just extend it.
 
 ### Changed
-* The `Csv` step can now also be used without defining a column
-  mapping. In that case it will use the values from the first line
-  (so this makes sense when there are column headlines) as output
-  array keys.
+* The `Csv` step can now also be used without defining a column mapping. In that case it will use the values from the first line (so this makes sense when there are column headlines) as output array keys.
 
 ## [0.3.0] - 2022-04-27
 ### Added
-* By calling `monitorMemoryUsage()` you can tell the Crawler to add
-  log messages with the current memory usage after every step
-  invocation.
-  You can also set a limit in bytes when to start monitoring and
-  below the limit it won't log memory usage.
+* By calling `monitorMemoryUsage()` you can tell the Crawler to add log messages with the current memory usage after every step invocation. You can also set a limit in bytes when to start monitoring and below the limit it won't log memory usage.
 
 ### Fixed
-* Previously the __use of Generators__ actually didn't make a lot of
-  sense, because the outputs of one step were only iterated and
-  passed on to the next step, after the current step was invoked
-  with all its inputs. That makes steps with a lot of inputs
-  bottlenecks and causes bigger memory consumption. So, changed the
-  crawler to immediately pass on outputs of one step to the next
-  step if there is one.
+* Previously the __use of Generators__ actually didn't make a lot of sense, because the outputs of one step were only iterated and passed on to the next step, after the current step was invoked with all its inputs. That makes steps with a lot of inputs bottlenecks and causes bigger memory consumption. So, changed the crawler to immediately pass on outputs of one step to the next step if there is one.
 
 ## [0.2.0] - 2022-04-25
 ### Added
-* `uniqueOutputs()` method to Steps to get only unique output values.
-  If outputs are array or object, you can provide a key that will be
-  used as identifier to check for uniqueness. Otherwise, the arrays
-  or objects will be serialized for comparison which will probably be 
-  slower.
-* `runAndTraverse()` method to Crawler, so you don't need to manually
-  traverse the Generator, if you don't need the results where you're
-  calling the crawler.
-* Implement the behaviour for when a `Group` step should add
-  something to the Result using `setResultKey()` or
-  `addKeysToResult()`, which was still missing. For groups this will
-  only work when using `combineToSingleOutput`.
+* `uniqueOutputs()` method to Steps to get only unique output values. If outputs are array or object, you can provide a key that will be used as identifier to check for uniqueness. Otherwise, the arrays or objects will be serialized for comparison which will probably be slower.
+* `runAndTraverse()` method to Crawler, so you don't need to manually traverse the Generator, if you don't need the results where you're calling the crawler.
+* Implement the behaviour for when a `Group` step should add something to the Result using `setResultKey()` or `addKeysToResult()`, which was still missing. For groups this will only work when using `combineToSingleOutput`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * With the new `outputHook()` method of the abstract `Crawler` class
   you can set a closure that'll receive all the outputs from all the
   steps. Should be only for debugging reasons.
+* The `extract()` method of the `Html` and `Xml` (children of `Dom`)
+  steps now also works with a single selector instead of an array
+  with a mapping. Sometimes you'll want to just get a simple string
+  output e.g. for a next step, instead of an array with mapped
+  extracted data.
 
 ### Fixed
 * The static methods `Html::getLink()` and `Html::getLinks()` now

--- a/src/Steps/Dom.php
+++ b/src/Steps/Dom.php
@@ -114,6 +114,10 @@ abstract class Dom extends Step
     {
         $base = $this->getBase($input);
 
+        if ($base->count() === 0) {
+            return;
+        }
+
         if (empty($this->mapping) && $this->singleSelector) {
             yield from $this->singleSelector($base);
         } else {
@@ -143,7 +147,7 @@ abstract class Dom extends Step
             foreach ($outputs as $output) {
                 yield $output;
             }
-        } else {
+        } elseif ($outputs !== null) {
             yield $outputs;
         }
     }

--- a/src/Steps/Html/DomQuery.php
+++ b/src/Steps/Html/DomQuery.php
@@ -15,21 +15,21 @@ abstract class DomQuery implements DomQueryInterface
     }
 
     /**
-     * @return string|string[]
+     * @return string[]|string|null
      */
-    public function apply(Crawler $domCrawler): array|string
+    public function apply(Crawler $domCrawler): array|string|null
     {
         $filtered = $this->filter($domCrawler);
 
-        if ($filtered->count() === 0) {
-            return '';
+        if ($filtered->count() > 1) {
+            return $filtered->each(function ($element) {
+                return $this->getTarget($element);
+            });
         } elseif ($filtered->count() === 1) {
             return $this->getTarget($filtered);
         }
 
-        return $filtered->each(function ($element) {
-            return $this->getTarget($element);
-        });
+        return null;
     }
 
     public function text(): self

--- a/src/Steps/Html/DomQueryInterface.php
+++ b/src/Steps/Html/DomQueryInterface.php
@@ -8,9 +8,9 @@ interface DomQueryInterface
 {
     /**
      * @param Crawler $domCrawler
-     * @return string[]|string
+     * @return string[]|string|null
      */
-    public function apply(Crawler $domCrawler): array|string;
+    public function apply(Crawler $domCrawler): array|string|null;
 
     public function filter(Crawler $domCrawler): Crawler;
 }

--- a/tests/Steps/DomTest.php
+++ b/tests/Steps/DomTest.php
@@ -41,7 +41,7 @@ test('string is valid input', function () {
 test('ResponseInterface is a valid input', function () {
     $output = helper_invokeStepWithInput(helper_getDomStepInstance()::root(), new Response());
 
-    expect($output[0]->get())->toBe([]);
+    expect($output)->toHaveCount(0);
 });
 
 test('RequestResponseAggregate is a valid input', function () {
@@ -50,7 +50,7 @@ test('RequestResponseAggregate is a valid input', function () {
         new RespondedRequest(new Request('GET', '/'), new Response())
     );
 
-    expect($output[0]->get())->toBe([]);
+    expect($output)->toHaveCount(0);
 });
 
 test('For other inputs an InvalidArgumentException is thrown', function (mixed $input) {
@@ -127,6 +127,15 @@ test('Extracting with single selector also works with last', function () {
     expect($outputs[0]->get())->toBe('match 3');
 });
 
+test('Extracting with single selector that doesn\'t match anything doesn\'t yield any output', function () {
+    $outputs = helper_invokeStepWithInput(
+        helper_getDomStepInstance()::last('.list .item')->extract('.mätch'),
+        helper_getStepFilesContent('Html/basic.html')
+    );
+
+    expect($outputs)->toHaveCount(0);
+});
+
 it('extracts one result from the root node when the root method is used', function () {
     $output = helper_invokeStepWithInput(
         helper_getDomStepInstance()::root()->extract(['matches' => '.match']),
@@ -171,6 +180,44 @@ it('extracts the last matching result when the last method is used', function ()
     expect($output)->toHaveCount(1);
 
     expect($output[0]->get())->toBe(['match' => 'match 3']);
+});
+
+it('doesn\'t yield any output when the each selector doesn\'t match anything', function () {
+    $output = helper_invokeStepWithInput(
+        helper_getDomStepInstance()::each('.list .ytem')->extract(['match' => '.match']),
+        helper_getStepFilesContent('Html/basic.html')
+    );
+
+    expect($output)->toHaveCount(0);
+});
+
+it('doesn\'t yield any output when the first selector doesn\'t match anything', function () {
+    $output = helper_invokeStepWithInput(
+        helper_getDomStepInstance()::first('.list .ytem')->extract(['match' => '.match']),
+        helper_getStepFilesContent('Html/basic.html')
+    );
+
+    expect($output)->toHaveCount(0);
+});
+
+it('doesn\'t yield any output when the last selector doesn\'t match anything', function () {
+    $output = helper_invokeStepWithInput(
+        helper_getDomStepInstance()::last('.list .otem')->extract(['match' => '.match']),
+        helper_getStepFilesContent('Html/basic.html')
+    );
+
+    expect($output)->toHaveCount(0);
+});
+
+it('returns an array with null values when selectors in an extract array mapping don\'t match anything', function () {
+    $output = helper_invokeStepWithInput(
+        helper_getDomStepInstance()::last('.list .item')->extract(['match' => '.match', 'noMatch' => '.doesntMatch']),
+        helper_getStepFilesContent('Html/basic.html')
+    );
+
+    expect($output)->toHaveCount(1);
+
+    expect($output[0]->get())->toBe(['match' => 'match 3', 'noMatch' => null]);
 });
 
 test('The static cssSelector method returns an instance of CssSelector using the provided selector', function () {

--- a/tests/Steps/DomTest.php
+++ b/tests/Steps/DomTest.php
@@ -57,6 +57,76 @@ test('For other inputs an InvalidArgumentException is thrown', function (mixed $
     helper_traverseIterable(helper_getDomStepInstance()::root()->invokeStep(new Input($input)));
 })->throws(InvalidArgumentException::class)->with([123, 123.456, new stdClass()]);
 
+it('outputs a single string when argument for extract is a selector string matching only one element', function () {
+    $outputs = helper_invokeStepWithInput(
+        helper_getDomStepInstance()::root()->extract('.list .item:first-child .match'),
+        helper_getStepFilesContent('Html/basic.html')
+    );
+
+    expect($outputs)->toHaveCount(1);
+
+    expect($outputs[0]->get())->toBe('match 2');
+});
+
+it('outputs multiple strings when argument for extract is a selector string matching multiple elements', function () {
+    $outputs = helper_invokeStepWithInput(
+        helper_getDomStepInstance()::root()->extract('.match'),
+        helper_getStepFilesContent('Html/basic.html')
+    );
+
+    expect($outputs)->toHaveCount(3);
+
+    expect($outputs[0]->get())->toBe('match 1');
+
+    expect($outputs[2]->get())->toBe('match 3');
+});
+
+it('also takes a DomQuery instance as argument for extract', function () {
+    $outputs = helper_invokeStepWithInput(
+        helper_getDomStepInstance()::root()->extract(Dom::cssSelector('.list .item:first-child .match')),
+        helper_getStepFilesContent('Html/basic.html')
+    );
+
+    expect($outputs)->toHaveCount(1);
+
+    expect($outputs[0]->get())->toBe('match 2');
+});
+
+test('Extracting with single selector also works with each', function () {
+    $outputs = helper_invokeStepWithInput(
+        helper_getDomStepInstance()::each('.list .item')->extract('.match'),
+        helper_getStepFilesContent('Html/basic.html')
+    );
+
+    expect($outputs)->toHaveCount(2);
+
+    expect($outputs[0]->get())->toBe('match 2');
+
+    expect($outputs[1]->get())->toBe('match 3');
+});
+
+test('Extracting with single selector also works with first', function () {
+    $outputs = helper_invokeStepWithInput(
+        helper_getDomStepInstance()::first('.list .item')->extract('.match'),
+        helper_getStepFilesContent('Html/basic.html')
+    );
+
+    expect($outputs)->toHaveCount(1);
+
+    expect($outputs[0]->get())->toBe('match 2');
+});
+
+test('Extracting with single selector also works with last', function () {
+    $outputs = helper_invokeStepWithInput(
+        helper_getDomStepInstance()::last('.list .item')->extract('.match'),
+        helper_getStepFilesContent('Html/basic.html')
+    );
+
+    expect($outputs)->toHaveCount(1);
+
+    expect($outputs[0]->get())->toBe('match 3');
+});
+
 it('extracts one result from the root node when the root method is used', function () {
     $output = helper_invokeStepWithInput(
         helper_getDomStepInstance()::root()->extract(['matches' => '.match']),

--- a/tests/Steps/Html/CssSelectorTest.php
+++ b/tests/Steps/Html/CssSelectorTest.php
@@ -21,12 +21,12 @@ test('The apply method returns an array of strings for multiple matches', functi
     expect((new CssSelector('.item'))->apply($domCrawler))->toBe(['test', 'test 2 sub', 'test 3']);
 });
 
-test('The apply method returns an empty string if nothing matches', function () {
+test('The apply method returns null if nothing matches', function () {
     $html = '<div class="item">test</div>';
 
     $domCrawler = new Crawler($html);
 
-    expect((new CssSelector('.aitem'))->apply($domCrawler))->toBe('');
+    expect((new CssSelector('.aitem'))->apply($domCrawler))->toBeNull();
 });
 
 it('trims whitespace', function () {

--- a/tests/Steps/Html/XPathQueryTest.php
+++ b/tests/Steps/Html/XPathQueryTest.php
@@ -21,12 +21,12 @@ test('The apply method returns an array of strings for multiple matches', functi
     expect((new XPathQuery('//item'))->apply($domCrawler))->toBe(['test', 'test 2 sub', 'test 3']);
 });
 
-test('The apply method returns an empty string if nothing matches', function () {
+test('The apply method returns null if nothing matches', function () {
     $xml = '<item>test</item>';
 
     $domCrawler = new Crawler($xml);
 
-    expect((new XPathQuery('//aitem'))->apply($domCrawler))->toBe('');
+    expect((new XPathQuery('//aitem'))->apply($domCrawler))->toBeNull();
 });
 
 it('trims whitespace', function () {

--- a/tests/Steps/HtmlTest.php
+++ b/tests/Steps/HtmlTest.php
@@ -19,6 +19,19 @@ function helper_getHtmlContent(string $fileName): string
     return $content;
 }
 
+it('returns single strings when extract is called with a selector only', function () {
+    $output = helper_invokeStepWithInput(
+        Html::each('#bookstore .book')->extract('.title'),
+        helper_getHtmlContent('bookstore.html')
+    );
+
+    expect($output)->toHaveCount(4);
+
+    expect($output[0]->get())->toBe('Everyday Italian');
+
+    expect($output[3]->get())->toBe('Learning XML');
+});
+
 it('extracts data from an HTML document with CSS selectors by default', function () {
     $output = helper_invokeStepWithInput(
         Html::each('#bookstore .book')->extract(['title' => '.title', 'author' => '.author', 'year' => '.year']),

--- a/tests/Steps/XmlTest.php
+++ b/tests/Steps/XmlTest.php
@@ -17,6 +17,19 @@ function helper_getXmlContent(string $fileName): string
     return $content;
 }
 
+it('returns single strings when extract is called with a selector only', function () {
+    $output = helper_invokeStepWithInput(
+        Xml::each('bookstore/book')->extract('//title'),
+        helper_getXmlContent('bookstore.xml')
+    );
+
+    expect($output)->toHaveCount(4);
+
+    expect($output[0]->get())->toBe('Everyday Italian');
+
+    expect($output[3]->get())->toBe('Learning XML');
+});
+
 it('extracts data from an XML document with XPath queries per default', function () {
     $output = helper_invokeStepWithInput(
         Xml::each('bookstore/book')->extract(['title' => '//title', 'author' => '//author', 'year' => '//year']),


### PR DESCRIPTION
The `extract()` method of the `Html` and `Xml` (children of `Dom`) steps now also works with a single selector instead of an array with a mapping. Sometimes you'll want to just get a simple string output e.g. for a next step, instead of an array with mapped extracted data.

When a `DomQuery` (CSS selector or XPath query) doesn't match anything, its `apply()` method now returns `null` (instead of an empty string). When the `Html(/Xml)::extract()` method is used with a single, not matching selector/query, nothing is yielded. When it's used with an array with a mapping, it yields an array with null values. If the selector for one of the methods `Html(/Xml)::each()`, `Html(/Xml)::first()` or `Html(/Xml)::last()` doesn't match anything, that's not causing an error any longer, it just won't yield anything.