### PR TITLE
Remove second argument from Loop::withInput()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * The static methods `Html::getLink()` and `Html::getLinks()` now also work without argument, like the `GetLink` and `GetLinks` classes.
 * When a `DomQuery` (CSS selector or XPath query) doesn't match anything, its `apply()` method now returns `null` (instead of an empty string). When the `Html(/Xml)::extract()` method is used with a single, not matching selector/query, nothing is yielded. When it's used with an array with a mapping, it yields an array with null values. If the selector for one of the methods `Html(/Xml)::each()`, `Html(/Xml)::first()` or `Html(/Xml)::last()` doesn't match anything, that's not causing an error any longer, it just won't yield anything.
+* Removed the (unnecessary) second argument from the `Loop::withInput()` method because when `keepLoopingWithoutOutput()` is called and `withInput()` is called after that call, it resets the behavior.
 
 ## [0.4.1] - 2022-05-10
 ### Fixed

--- a/src/Steps/Loop.php
+++ b/src/Steps/Loop.php
@@ -80,11 +80,9 @@ final class Loop implements StepInterface
         return $this;
     }
 
-    public function withInput(Closure|StepInterface $closure, bool $callWithoutOutput = false): self
+    public function withInput(Closure|StepInterface $closure): self
     {
         $this->withInput = $closure;
-
-        $this->callWithInputWithoutOutput = $callWithoutOutput;
 
         return $this;
     }

--- a/tests/Steps/LoopTest.php
+++ b/tests/Steps/LoopTest.php
@@ -431,45 +431,7 @@ test('It stops looping when the withInput callback returns null', function () {
     expect($outputs[4]->get())->toBe(5);
 });
 
-test(
-    'It calls the withInput method when there is no output but the callWithoutOutput param is set to true',
-    function () {
-        $step = new class () extends Step {
-            public int $_callcount = 0;
-
-            protected function invoke(mixed $input): Generator
-            {
-                $this->_callcount++;
-
-                if ($input === true) {
-                    yield 'it';
-                }
-            }
-        };
-
-        $firstCall = true;
-
-        $loopStep = (new Loop($step))
-            ->maxIterations(5)
-            ->withInput(function (mixed $input, mixed $output) use (& $firstCall) {
-                expect($output)->toBeNull();
-
-                if ($firstCall === true) {
-                    $firstCall = false;
-
-                    return $input;
-                }
-
-                return null;
-            }, true);
-
-        helper_traverseIterable($loopStep->invokeStep(new Input('yo')));
-
-        expect($step->_callcount)->toBe(2);
-    }
-);
-
-test('It also calls the withInput method without output when keepLoopingWithoutOutput is called', function () {
+it('calls the withInput method when there is no output but keepLoopingWithoutOutput was called', function () {
     $step = new class () extends Step {
         public int $_callcount = 0;
 
@@ -487,6 +449,7 @@ test('It also calls the withInput method without output when keepLoopingWithoutO
 
     $loopStep = (new Loop($step))
         ->maxIterations(10)
+        ->keepLoopingWithoutOutput()
         ->withInput(function (mixed $input, mixed $output) use (& $firstCall) {
             expect($output)->toBeNull();
 
@@ -497,8 +460,7 @@ test('It also calls the withInput method without output when keepLoopingWithoutO
             }
 
             return null;
-        })
-        ->keepLoopingWithoutOutput();
+        });
 
     helper_traverseIterable($loopStep->invokeStep(new Input('don\'t yield output')));
 


### PR DESCRIPTION
Remove the (unnecessary) second argument from the `Loop::withInput()` method because when `keepLoopingWithoutOutput()` is called and `withInput()` is called after that call, it resets the behavior.