### PR TITLE
Reduce log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * With the new `outputHook()` method of the abstract `Crawler` class you can set a closure that'll receive all the outputs from all the steps. Should be only for debugging reasons.
 * The `extract()` method of the `Html` and `Xml` (children of `Dom`) steps now also works with a single selector instead of an array with a mapping. Sometimes you'll want to just get a simple string output e.g. for a next step, instead of an array with mapped extracted data.
 
+### Changed
+* Remove some not so important log messages.
+
 ### Fixed
 * The static methods `Html::getLink()` and `Html::getLinks()` now also work without argument, like the `GetLink` and `GetLinks` classes.
 * When a `DomQuery` (CSS selector or XPath query) doesn't match anything, its `apply()` method now returns `null` (instead of an empty string). When the `Html(/Xml)::extract()` method is used with a single, not matching selector/query, nothing is yielded. When it's used with an array with a mapping, it yields an array with null values. If the selector for one of the methods `Html(/Xml)::each()`, `Html(/Xml)::first()` or `Html(/Xml)::last()` doesn't match anything, that's not causing an error any longer, it just won't yield anything.

--- a/src/Loader/Http/Traits/WaitPolitely.php
+++ b/src/Loader/Http/Traits/WaitPolitely.php
@@ -91,7 +91,7 @@ trait WaitPolitely
         }
 
         $wait = $waitUntil - $now;
-        $this->logger->info('Wait ' . round($wait, 4) . 's for politeness.');
+
         usleep((int) ($wait * 1000000));
     }
 

--- a/src/Steps/Dom.php
+++ b/src/Steps/Dom.php
@@ -167,10 +167,6 @@ abstract class Dom extends Step
             $mappedProperties[$key] = $domQuery->apply($domCrawler);
         }
 
-        $this->logger?->info(
-            'Extracted properties ' . implode(', ', array_keys($mappedProperties)) . ' from document.'
-        );
-
         return $mappedProperties;
     }
 

--- a/src/Steps/Html/GetLink.php
+++ b/src/Steps/Html/GetLink.php
@@ -53,10 +53,6 @@ class GetLink extends Step
     {
         $selector = $this->selector ?? 'a';
 
-        $this->logger?->info(
-            $this->selector === null ? 'Select first link in document.' : 'Select link with CSS selector: ' . $selector
-        );
-
         foreach ($input->filter($selector) as $link) {
             if ($link->nodeName !== 'a') {
                 $this->logger?->warning('Selector matched <' . $link->nodeName . '> html element. Ignored it.');

--- a/src/Steps/Html/GetLinks.php
+++ b/src/Steps/Html/GetLinks.php
@@ -17,10 +17,6 @@ class GetLinks extends GetLink
     {
         $selector = $this->selector ?? 'a';
 
-        $this->logger?->info(
-            $this->selector === null ? 'Select all links in document.' : 'Select links with CSS selector: ' . $selector
-        );
-
         foreach ($input->filter($selector) as $link) {
             if ($link->nodeName !== 'a') {
                 $this->logger?->warning('Selector matched <' . $link->nodeName . '> html element. Ignored it.');

--- a/src/Stores/SimpleCsvFileStore.php
+++ b/src/Stores/SimpleCsvFileStore.php
@@ -35,8 +35,6 @@ class SimpleCsvFileStore extends Store
         fputcsv($fileHandle, array_values($result->toArray()));
 
         fclose($fileHandle);
-
-        $this->logger?->info('Stored a result');
     }
 
     public function filePath(): string

--- a/tests/Loader/Http/Cookies/CookieTest.php
+++ b/tests/Loader/Http/Cookies/CookieTest.php
@@ -259,9 +259,11 @@ test('It should be sent when date of expires attribute is not reached', function
 
 test('It should not be sent when maxAge attribute is already reached', function () {
     $cookie = new Cookie('https://www.crwlr.software', 'cookie=value; Max-Age=1');
+
     expect($cookie->shouldBeSentTo('https://www.crwlr.software'))->toBeTrue();
-    // @phpstan-ignore-next-line
+
     invade($cookie)->receivedAtTimestamp -= 2; // instead of sleep, manipulate the timestamp when it was received.
+
     expect($cookie->shouldBeSentTo('https://www.crwlr.software'))->toBeFalse();
 });
 


### PR DESCRIPTION
When processing large amounts of data, some info messages that aren't really important can bloat the logs. Just remove them.