### PR TITLE
Fix wrong cookie expires date format issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The static methods `Html::getLink()` and `Html::getLinks()` now also work without argument, like the `GetLink` and `GetLinks` classes.
 * When a `DomQuery` (CSS selector or XPath query) doesn't match anything, its `apply()` method now returns `null` (instead of an empty string). When the `Html(/Xml)::extract()` method is used with a single, not matching selector/query, nothing is yielded. When it's used with an array with a mapping, it yields an array with null values. If the selector for one of the methods `Html(/Xml)::each()`, `Html(/Xml)::first()` or `Html(/Xml)::last()` doesn't match anything, that's not causing an error any longer, it just won't yield anything.
 * Removed the (unnecessary) second argument from the `Loop::withInput()` method because when `keepLoopingWithoutOutput()` is called and `withInput()` is called after that call, it resets the behavior.
+* Issue when date format for expires date in cookie doesn't have dashes in `d-M-Y` (so `d M Y`).
 
 ## [0.4.1] - 2022-05-10
 ### Fixed

--- a/src/Loader/Http/Cookies/Date.php
+++ b/src/Loader/Http/Cookies/Date.php
@@ -23,7 +23,11 @@ class Date
             $dateTime = DateTime::createFromFormat(DateTimeInterface::COOKIE, $this->httpDateString);
 
             if (!$dateTime instanceof DateTime) {
-                throw new InvalidArgumentException('Can\'t parse date string ' . $this->httpDateString);
+                $dateTime = DateTime::createFromFormat('l, d M Y H:i:s T', $this->httpDateString);
+
+                if (!$dateTime instanceof DateTime) {
+                    throw new InvalidArgumentException('Can\'t parse date string ' . $this->httpDateString);
+                }
             }
 
             $this->dateTime = $dateTime;

--- a/tests/Loader/Http/Cookies/DateTest.php
+++ b/tests/Loader/Http/Cookies/DateTest.php
@@ -7,13 +7,24 @@ use DateTimeZone;
 
 test('It can be created from a valid http header date format', function () {
     $date = new Date('Tue, 22-Feb-2022 16:04:55 GMT');
+
     expect($date)->toBeInstanceOf(Date::class);
+
     expect($date->dateTime()->format('Y-m-d H:i:s'))->toBe('2022-02-22 16:04:55');
 });
 
 test('It gets the timezone right', function () {
     $date = new Date('Tue, 22-Feb-2022 20:04:29 GMT');
+
     expect(
         $date->dateTime()->setTimezone(new DateTimeZone('Europe/Vienna'))->format('d.m.Y H:i:s')
     )->toBe('22.02.2022 21:04:29');
+});
+
+test('It also works without the dashes between d-M-Y in the format', function () {
+    $date = new Date('Wed, 05 Jul 2023 15:19:55 GMT');
+
+    expect(
+        $date->dateTime()->setTimezone(new DateTimeZone('Europe/Vienna'))->format('d.m.Y H:i:s')
+    )->toBe('05.07.2023 17:19:55');
 });


### PR DESCRIPTION
When a server returns an expires date without dashes, it should still work.