### PR TITLE
Improve default results from last step outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * Remove some not so important log messages.
 * Improve behavior of group step's `combineToSingleOutput()`. When steps yield multiple outputs, don't combine all yielded outputs to one. Instead, combine the first output from the first step with the first output from the second step, and so on.
+* When result is not explicitly composed, but the outputs of the last step are arrays with string keys, it sets those keys on the Result object instead of setting a key `unnamed` with the whole array as value.
 
 ### Fixed
 * The static methods `Html::getLink()` and `Html::getLinks()` now also work without argument, like the `GetLink` and `GetLinks` classes.

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -277,7 +277,15 @@ abstract class Crawler
     private function storeAndReturnOutputsAsResults(Generator $outputs): Generator
     {
         foreach ($outputs as $output) {
-            $result = (new Result())->set('unnamed', $output->get());
+            $result = new Result();
+
+            if ($output->isArrayWithStringKeys()) {
+                foreach ($output->get() as $key => $value) {
+                    $result->set($key, $value);
+                }
+            } else {
+                $result->set('unnamed', $output->get());
+            }
 
             $this->store?->store($result);
 

--- a/src/Io.php
+++ b/src/Io.php
@@ -49,6 +49,21 @@ class Io
         return $this->key;
     }
 
+    public function isArrayWithStringKeys(): bool
+    {
+        if (!is_array($this->value)) {
+            return false;
+        }
+
+        foreach ($this->value as $key => $value) {
+            if (!is_string($key)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     private function valueToString(mixed $value): string
     {
         if (is_array($value) || is_object($value)) {

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -565,3 +565,17 @@ it('sends all outputs to the outputHook when defined', function () {
 
     expect($outputs[1][4])->toBe(7);
 });
+
+test(
+    'When result is not explicitly composed and last step produces array output with string keys, it uses those keys ' .
+    'for the result.',
+    function () {
+        $crawler = helper_getDummyCrawler()
+            ->input('hello')
+            ->addStep(helper_getValueReturningStep(['foo' => 'bar', 'baz' => 'quz']));
+
+        $results = helper_generatorToArray($crawler->run());
+
+        expect($results[0]->toArray())->toBe(['foo' => 'bar', 'baz' => 'quz']);
+    }
+);

--- a/tests/IoTest.php
+++ b/tests/IoTest.php
@@ -4,6 +4,7 @@ namespace tests;
 
 use Crwlr\Crawler\Io;
 use Crwlr\Crawler\Result;
+use stdClass;
 
 function helper_getIoInstance(mixed $value, ?Result $result = null): Io
 {
@@ -117,3 +118,20 @@ test('getKey returns a key when setKey was not called yet', function () {
 
     expect($io->getKey())->toBe('test');
 });
+
+test('isArrayWithStringKeys returns true when the value is an array with string keys', function () {
+    $io = helper_getIoInstance(['foo' => 'one', 'bar' => 'two', 'baz' => 'three']);
+
+    expect($io->isArrayWithStringKeys())->toBeTrue();
+});
+
+test('isArrayWithStringKeys returns false when the value is not an array with string keys', function ($value) {
+    $io = helper_getIoInstance($value);
+
+    expect($io->isArrayWithStringKeys())->toBeFalse();
+})->with([
+    123,
+    true,
+    ['foo', 'bar'],
+    helper_getStdClassWithData(['foo' => 'bar']),
+]);


### PR DESCRIPTION
When result is not explicitly composed, but the outputs of the last step are arrays with string keys, it sets those keys on the Result object instead of setting a key `unnamed` with the whole array as value.