### PR TITLE
Get absolute links when extracting data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * With the new `outputHook()` method of the abstract `Crawler` class you can set a closure that'll receive all the outputs from all the steps. Should be only for debugging reasons.
 * The `extract()` method of the `Html` and `Xml` (children of `Dom`) steps now also works with a single selector instead of an array with a mapping. Sometimes you'll want to just get a simple string output e.g. for a next step, instead of an array with mapped extracted data.
 * In addition to `uniqueOutputs()` there is now also `uniqueInputs()`. It works exactly the same as `uniqueOutputs()`, filtering duplicate input values instead. Optionally also by a key when expected input is an array or an object.
+* In order to be able to also get absolute links when using the `extract()` method of Dom steps, the abstract `DomQuery` class now has a method `toAbsoluteUrl()`. The Dom step will automatically provide the `DomQuery` instance with the base url, presumed that the input was an instance of the `RespondedRequest` class and resolve the selected value against that base url.
 
 ### Changed
 * Remove some not so important log messages.

--- a/src/Steps/Html/DomQueryInterface.php
+++ b/src/Steps/Html/DomQueryInterface.php
@@ -13,4 +13,8 @@ interface DomQueryInterface
     public function apply(Crawler $domCrawler): array|string|null;
 
     public function filter(Crawler $domCrawler): Crawler;
+
+    public function setBaseUrl(string $baseUrl): static;
+
+    public function toAbsoluteUrl(): self;
 }

--- a/tests/Steps/DomTest.php
+++ b/tests/Steps/DomTest.php
@@ -262,3 +262,23 @@ it('trims the extracted data', function () {
 
     expect($output[0]->get())->toBe(['foo' => 'foo content']);
 });
+
+it('automatically passes on the base url to dom query instances when the input is a RespondedRequest', function () {
+    $output = helper_invokeStepWithInput(
+        helper_getDomStepInstance()::root()->extract([
+            'one' => Dom::cssSelector('#one')->attribute('href')->toAbsoluteUrl(),
+            'two' => Dom::cssSelector('#two')->attribute('href')->toAbsoluteUrl(),
+        ]),
+        new RespondedRequest(
+            new Request('GET', 'https://www.example.com/home'),
+            new Response(body: '<p><a id="one" href="/foo/bar">foo bar</a> <a id="two" href="yo/lo">yolo</a></p>')
+        ),
+    );
+
+    expect($output)->toHaveCount(1);
+
+    expect($output[0]->get())->toBe([
+        'one' => 'https://www.example.com/foo/bar',
+        'two' => 'https://www.example.com/yo/lo',
+    ]);
+});

--- a/tests/Steps/Html/CssSelectorTest.php
+++ b/tests/Steps/Html/CssSelectorTest.php
@@ -95,3 +95,20 @@ it('gets the contents of an attribute using the attribute method', function () {
 
     expect((new CssSelector('.item'))->attribute('data-attr')->apply($domCrawler))->toBe('content');
 });
+
+it('turns the value into an absolute url when toAbsoluteUrl() is called', function () {
+    $html = '<a href="/packages/crawler/v0.4/getting-started">getting started</a>';
+
+    $domCrawler = new Crawler($html);
+
+    $selector = new CssSelector('a');
+
+    $selector->setBaseUrl('https://www.crwlr.software/')
+        ->attribute('href');
+
+    expect($selector->apply($domCrawler))->toBe('/packages/crawler/v0.4/getting-started');
+
+    $selector->toAbsoluteUrl();
+
+    expect($selector->apply($domCrawler))->toBe('https://www.crwlr.software/packages/crawler/v0.4/getting-started');
+});

--- a/tests/Steps/Html/XPathQueryTest.php
+++ b/tests/Steps/Html/XPathQueryTest.php
@@ -2,6 +2,7 @@
 
 namespace tests\Steps\Html;
 
+use Crwlr\Crawler\Steps\Html\CssSelector;
 use Crwlr\Crawler\Steps\Html\XPathQuery;
 use Symfony\Component\DomCrawler\Crawler;
 
@@ -87,4 +88,19 @@ it('gets the contents of an attribute using the attribute method', function () {
     $domCrawler = new Crawler($xml);
 
     expect((new XPathQuery('//item'))->attribute('attr')->apply($domCrawler))->toBe('content');
+});
+
+it('turns the value into an absolute url when toAbsoluteUrl() is called', function () {
+    $html = '<item>/foo/bar</item>';
+
+    $domCrawler = new Crawler($html);
+
+    $query = (new XPathQuery('//item'))
+        ->setBaseUrl('https://www.example.com');
+
+    expect($query->apply($domCrawler))->toBe('/foo/bar');
+
+    $query->toAbsoluteUrl();
+
+    expect($query->apply($domCrawler))->toBe('https://www.example.com/foo/bar');
 });


### PR DESCRIPTION
In order to be able to also get absolute links when using the `extract()` method of Dom steps, the abstract `DomQuery` class now has a method `toAbsoluteUrl()`. The Dom step will automatically provide the `DomQuery` instance with the base url, presumed that the input was an instance of the `RespondedRequest` class and resolve the selected value against that base url.