### PR TITLE
Add option to use headless browser with HttpLoader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,8 @@ jobs:
 
       - name: Install chrome
         run: |
-          chmod +x ./install-chrome.sh
-          ./install-chrome.sh
+          chmod +x ${GITHUB_WORKSPACE}/.github/workflows/install-chrome.sh
+          ${GITHUB_WORKSPACE}/.github/workflows/install-chrome.sh
         shell: bash
 
       - name: Add chrome alias for chromedriver

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,15 +73,13 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-suggest
 
       - name: Install chrome
-        uses: nanasess/setup-chromedriver@v1
-
-      - run: |
-          export DISPLAY=:99
-          chromedriver --url-base=/wd/hub &
-          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # optional
+        run: |
+          chmod +x ./install-chrome.sh
+          ./install-chrome.sh
+        shell: bash
 
       - name: Add chrome alias for chromedriver
-        run: alias chrome='chromedriver'
+        run: alias chrome='chromium-browser'
 
       - name: Run integration tests
         run: composer test-integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-suggest
 
       - name: Run tests
-        run: vendor/bin/pest --coverage-clover clover.xml
+        run: composer test
 
   integration-tests:
     name: PestPHP Integration Tests
@@ -71,6 +71,14 @@ jobs:
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Install chrome
+        uses: nanasess/setup-chromedriver@v1
+
+      - run: |
+          export DISPLAY=:99
+          chromedriver --url-base=/wd/hub &
+          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # optional
 
       - name: Run integration tests
         run: composer test-integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,9 @@ jobs:
         shell: bash
 
       - name: Add chrome alias for chromedriver
-        run: alias chrome='chromium-browser'
+        run: |
+          shopt -s expand_aliases
+          alias chrome='chromium-browser'
 
       - name: Run integration tests
         run: composer test-integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,8 @@ jobs:
           ${GITHUB_WORKSPACE}/.github/workflows/install-chrome.sh
         shell: bash
 
-      - name: Add chrome alias for chromedriver
-        run: |
-          shopt -s expand_aliases
-          alias chrome='chromium-browser'
-
       - name: Run integration tests
-        run: composer test-integration
+        run: alias chrome='chromium-browser' && composer test-integration
 
   stan:
     name: PHPStan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,15 +73,10 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-suggest
 
       - name: Install chrome
-        run: |
-          chmod +x ${GITHUB_WORKSPACE}/.github/workflows/install-chrome.sh
-          ${GITHUB_WORKSPACE}/.github/workflows/install-chrome.sh
-        shell: bash
+        uses: browser-actions/setup-chrome@latest
 
       - name: Run integration tests
-        run: |
-          alias chrome='chromium-browser'
-          composer test-integration
+        run: composer test-integration
 
   stan:
     name: PHPStan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,9 @@ jobs:
         shell: bash
 
       - name: Run integration tests
-        run: alias chrome='chromium-browser' && composer test-integration
+        run: |
+          alias chrome='chromium-browser'
+          composer test-integration
 
   stan:
     name: PHPStan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
           chromedriver --url-base=/wd/hub &
           sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 & # optional
 
+      - name: Add chrome alias for chromedriver
+        run: alias chrome='chromedriver'
+
       - name: Run integration tests
         run: composer test-integration
 

--- a/.github/workflows/install-chrome.sh
+++ b/.github/workflows/install-chrome.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-sudo apt-get update
-sudo apt-get install software-properties-common
-sudo add-apt-repository ppa:canonical-chromium-builds/stage
-sudo apt-get update
-sudo apt-get install chromium-browser
-chromium-browser --headless --no-sandbox http://example.org/

--- a/.github/workflows/install-chrome.sh
+++ b/.github/workflows/install-chrome.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+sudo apt-get update
+sudo apt-get install software-properties-common
+sudo add-apt-repository ppa:canonical-chromium-builds/stage
+sudo apt-get update
+sudo apt-get install chromium-browser
+chromium-browser --headless --no-sandbox http://example.org/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+* You can now call the new `useHeadlessBrowser` method on the `HttpLoader` class to use a headless Chrome browser to load pages. This is enough to get HTML after executing javascript in the browser. For more sophisticated tasks a separate Loader and/or Steps should better be created.
 * With the `maxOutputs()` method of the abstract `Step` class you can now limit how many outputs a certain step should yield at max. That's for example helpful during development, when you want to run the crawler only with a small subset of the data/requests it will actually have to process when you eventually remove the limits. When a step has reached its limit, it won't even call the `invoke()` method any longer until the step is reset after a run.
 * With the new `outputHook()` method of the abstract `Crawler` class you can set a closure that'll receive all the outputs from all the steps. Should be only for debugging reasons.
 * The `extract()` method of the `Html` and `Xml` (children of `Dom`) steps now also works with a single selector instead of an array with a mapping. Sometimes you'll want to just get a simple string output e.g. for a next step, instead of an array with mapped extracted data.

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "symfony/css-selector": "^6.0",
         "psr/simple-cache": "^1.0|^2.0|^3.0",
         "guzzlehttp/guzzle": "^7.4",
-        "adbario/php-dot-notation": "^3.1"
+        "adbario/php-dot-notation": "^3.1",
+        "chrome-php/chrome": "^1.6"
     },
     "require-dev": {
         "pestphp/pest": "^1.21",

--- a/src/Loader/Http/HttpLoader.php
+++ b/src/Loader/Http/HttpLoader.php
@@ -13,6 +13,13 @@ use Crwlr\Url\Url;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use HeadlessChromium\Browser;
+use HeadlessChromium\BrowserFactory;
+use HeadlessChromium\Exception\CommunicationException;
+use HeadlessChromium\Exception\NavigationExpired;
+use HeadlessChromium\Exception\NoResponseAvailable;
+use HeadlessChromium\Exception\OperationTimedOut;
 use InvalidArgumentException;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
@@ -24,8 +31,23 @@ use Throwable;
 class HttpLoader extends Loader
 {
     protected ClientInterface $httpClient;
+
     protected CookieJar $cookieJar;
+
     protected bool $useCookies = true;
+
+    protected bool $useHeadlessBrowser = false;
+
+    /**
+     * @var mixed[]
+     */
+    protected array $headlessBrowserOptions = [
+        'windowSize' => [1920, 1000],
+    ];
+
+    protected bool $headlessBrowserOptionsDirty = false;
+
+    protected ?Browser $headlessBrowser = null;
 
     public function __construct(
         UserAgentInterface $userAgent,
@@ -65,14 +87,16 @@ class HttpLoader extends Loader
         }
 
         $request = $this->prepareRequest($request);
+
         $this->callHook('beforeLoad', $request);
 
         try {
             $respondedRequest = $this->getFromCache($request);
+
             $isFromCache = $respondedRequest !== null;
 
             if (!$respondedRequest) {
-                $respondedRequest  = $this->handleRedirects($request);
+                $respondedRequest = $this->loadViaClientOrHeadlessBrowser($request);
             }
 
             if ($respondedRequest->response->getStatusCode() < 400) {
@@ -83,12 +107,14 @@ class HttpLoader extends Loader
 
             if (!$isFromCache && $this->cache) {
                 $responseCacheItem = HttpResponseCacheItem::fromAggregate($respondedRequest);
+
                 $this->cache->set($responseCacheItem->key(), $responseCacheItem);
             }
 
             return $respondedRequest;
         } catch (Throwable $exception) {
             $this->trackRequestEnd(); // Don't move to finally so hooks don't run before it.
+
             $this->callHook('onError', $request, $exception);
 
             return null;
@@ -99,20 +125,33 @@ class HttpLoader extends Loader
 
     /**
      * @throws ClientExceptionInterface
+     * @throws CommunicationException
+     * @throws CommunicationException\CannotReadResponse
+     * @throws CommunicationException\InvalidResponse
+     * @throws CommunicationException\ResponseHasError
      * @throws LoadingException
+     * @throws NavigationExpired
+     * @throws NoResponseAvailable
+     * @throws OperationTimedOut
+     * @throws Throwable
      * @throws \Psr\SimpleCache\InvalidArgumentException
      */
     public function loadOrFail(mixed $subject): RespondedRequest
     {
         $request = $this->validateSubjectType($subject);
+
         $this->isAllowedToBeLoaded($request->getUri(), true);
+
         $request = $this->prepareRequest($request);
+
         $this->callHook('beforeLoad', $request);
+
         $respondedRequest = $this->getFromCache($request);
+
         $isFromCache = $respondedRequest !== null;
 
         if (!$respondedRequest) {
-            $respondedRequest = $this->handleRedirects($request);
+            $respondedRequest = $this->loadViaClientOrHeadlessBrowser($request);
         }
 
         if ($respondedRequest->response->getStatusCode() >= 400) {
@@ -120,10 +159,12 @@ class HttpLoader extends Loader
         }
 
         $this->callHook('onSuccess', $request, $respondedRequest->response);
+
         $this->callHook('afterLoad', $request);
 
         if (!$isFromCache && $this->cache) {
             $responseCacheItem = HttpResponseCacheItem::fromAggregate($respondedRequest);
+
             $this->cache->set($responseCacheItem->key(), $responseCacheItem);
         }
 
@@ -142,6 +183,48 @@ class HttpLoader extends Loader
         $this->cookieJar->flush();
     }
 
+    public function useHeadlessBrowser(): static
+    {
+        $this->useHeadlessBrowser = true;
+
+        return $this;
+    }
+
+    public function useHttpClient(): static
+    {
+        $this->useHeadlessBrowser = false;
+
+        $this->headlessBrowser = null;
+
+        return $this;
+    }
+
+    /**
+     * @param mixed[] $options
+     */
+    public function setHeadlessBrowserOptions(array $options): static
+    {
+        $this->headlessBrowserOptions = $options;
+
+        $this->headlessBrowserOptionsDirty = true;
+
+        return $this;
+    }
+
+    /**
+     * @param mixed[] $options
+     */
+    public function addHeadlessBrowserOptions(array $options): static
+    {
+        foreach ($options as $key => $value) {
+            $this->headlessBrowserOptions[$key] = $value;
+        }
+
+        $this->headlessBrowserOptionsDirty = true;
+
+        return $this;
+    }
+
     /**
      * @throws \Psr\SimpleCache\InvalidArgumentException
      */
@@ -155,6 +238,7 @@ class HttpLoader extends Loader
 
         if ($this->cache->has($key)) {
             $this->logger->info('Found ' . $request->getUri()->__toString() . ' in cache.');
+
             $responseCacheItem = $this->cache->get($key);
 
             return $responseCacheItem->aggregate();
@@ -179,9 +263,30 @@ class HttpLoader extends Loader
     protected function prepareRequest(RequestInterface $request): RequestInterface
     {
         $request = $request->withHeader('User-Agent', $this->userAgent->__toString());
-        $request = $this->addCookiesToRequest($request);
 
-        return $request;
+        return $this->addCookiesToRequest($request);
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @return RespondedRequest
+     * @throws ClientExceptionInterface
+     * @throws CommunicationException
+     * @throws CommunicationException\CannotReadResponse
+     * @throws CommunicationException\InvalidResponse
+     * @throws CommunicationException\ResponseHasError
+     * @throws NavigationExpired
+     * @throws NoResponseAvailable
+     * @throws OperationTimedOut
+     * @throws Throwable
+     */
+    private function loadViaClientOrHeadlessBrowser(RequestInterface $request): RespondedRequest
+    {
+        if ($this->useHeadlessBrowser) {
+            return $this->loadViaHeadlessBrowser($request);
+        }
+
+        return $this->handleRedirects($request);
     }
 
     /**
@@ -192,7 +297,9 @@ class HttpLoader extends Loader
         ?RespondedRequest $aggregate = null
     ): RespondedRequest {
         $this->trackRequestStart();
+
         $response = $this->httpClient->sendRequest($request);
+
         $this->trackRequestEnd();
 
         if (!$aggregate) {
@@ -205,12 +312,74 @@ class HttpLoader extends Loader
 
         if ($aggregate->isRedirect()) {
             $this->logger()->info('Load redirect to: ' . $aggregate->effectiveUri());
+
             $newRequest = $request->withUri(Url::parsePsr7($aggregate->effectiveUri()));
 
             return $this->handleRedirects($newRequest, $aggregate);
         }
 
         return $aggregate;
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @return RespondedRequest
+     * @throws CommunicationException
+     * @throws CommunicationException\CannotReadResponse
+     * @throws CommunicationException\InvalidResponse
+     * @throws CommunicationException\ResponseHasError
+     * @throws NavigationExpired
+     * @throws NoResponseAvailable
+     * @throws OperationTimedOut
+     * @throws Throwable
+     */
+    private function loadViaHeadlessBrowser(RequestInterface $request): RespondedRequest
+    {
+        $browser = $this->getBrowser($request);
+
+        $page = $browser->createPage();
+
+        $statusCode = 500;
+
+        $responseHeaders = [];
+
+        $page->getSession()->once(
+            "method:Network.responseReceived",
+            function ($params) use (& $statusCode, & $responseHeaders) {
+                $statusCode = $params['response']['status'];
+
+                $responseHeaders = $this->sanitizeResponseHeaders($params['response']['headers']);
+            }
+        );
+
+        $page->navigate($request->getUri()->__toString())
+            ->waitForNavigation();
+
+        $html = $page->getHtml();
+
+        return new RespondedRequest(
+            $request,
+            new Response($statusCode, $responseHeaders, $html)
+        );
+    }
+
+    private function getBrowser(RequestInterface $request): Browser
+    {
+        if (!$this->headlessBrowser || $this->headlessBrowserOptionsDirty) {
+            $this->headlessBrowser?->close();
+
+            $options = $this->headlessBrowserOptions;
+
+            $options['userAgent'] = $this->userAgent->__toString();
+
+            $options['headers'] = array_merge($options['headers'] ?? [], $request->getHeaders());
+
+            $this->headlessBrowser = (new BrowserFactory())->createBrowser($options);
+
+            $this->headlessBrowserOptionsDirty = false;
+        }
+
+        return $this->headlessBrowser;
     }
 
     private function addCookiesToJar(RespondedRequest $aggregate): void
@@ -235,5 +404,18 @@ class HttpLoader extends Loader
         }
 
         return $request;
+    }
+
+    /**
+     * @param string[] $headers
+     * @return string[]
+     */
+    private function sanitizeResponseHeaders(array $headers): array
+    {
+        foreach ($headers as $key => $value) {
+            $headers[$key] = explode(PHP_EOL, $value)[0];
+        }
+
+        return $headers;
     }
 }

--- a/src/Loader/Loader.php
+++ b/src/Loader/Loader.php
@@ -11,6 +11,7 @@ use Psr\SimpleCache\CacheInterface;
 abstract class Loader implements LoaderInterface
 {
     protected LoggerInterface $logger;
+
     protected ?CacheInterface $cache = null;
 
     /**

--- a/tests/_Integration/Http/HeadlessBrowserTest.php
+++ b/tests/_Integration/Http/HeadlessBrowserTest.php
@@ -1,0 +1,114 @@
+<?php
+
+use Crwlr\Crawler\HttpCrawler;
+use Crwlr\Crawler\Loader\Http\HttpLoader;
+use Crwlr\Crawler\Loader\LoaderInterface;
+use Crwlr\Crawler\Steps\Html;
+use Crwlr\Crawler\Steps\Loading\Http;
+use Crwlr\Crawler\Steps\Step;
+use Crwlr\Crawler\UserAgents\BotUserAgent;
+use Crwlr\Crawler\UserAgents\UserAgentInterface;
+use Psr\Log\LoggerInterface;
+
+use Symfony\Component\DomCrawler\Crawler;
+
+use function tests\helper_generatorToArray;
+
+class HeadlessBrowserCrawler extends HttpCrawler
+{
+    protected function userAgent(): UserAgentInterface
+    {
+        return new BotUserAgent('HeadlessBrowserBot');
+    }
+
+    public function loader(UserAgentInterface $userAgent, LoggerInterface $logger): LoaderInterface
+    {
+        $loader = new HttpLoader($userAgent, logger: $logger);
+
+        $loader->useHeadlessBrowser();
+
+        return $loader;
+    }
+}
+
+class GetJsonFromResponseHtmlBody extends Step
+{
+    protected function invoke(mixed $input): Generator
+    {
+        $html = Http::getBodyString($input->response);
+
+        $jsonString = (new Crawler($html))->filter('body pre')->text();
+
+        yield json_decode($jsonString, true);
+    }
+}
+
+class GetStringFromResponseHtmlBody extends Step
+{
+    protected function invoke(mixed $input): Generator
+    {
+        $html = Http::getBodyString($input->response);
+
+        yield (new Crawler($html))->filter('body')->text();
+    }
+}
+
+it('automatically uses the Loader\'s user agent', function () {
+    $crawler = new HeadlessBrowserCrawler();
+
+    $crawler->input('http://localhost:8000/print-headers')
+        ->addStep(Http::get())
+        ->addStep('responseBody', new GetJsonFromResponseHtmlBody());
+
+    $results = helper_generatorToArray($crawler->run());
+
+    expect($results)->toHaveCount(1);
+
+    expect($results[0]->get('responseBody'))->toBeArray();
+
+    expect($results[0]->get('responseBody'))->toHaveKey('User-Agent');
+
+    expect($results[0]->get('responseBody')['User-Agent'])->toBe('Mozilla/5.0 (compatible; HeadlessBrowserBot)');
+});
+
+it('uses cookies', function () {
+    $crawler = new HeadlessBrowserCrawler();
+
+    $crawler->input('http://localhost:8000/set-cookie')
+        ->addStep(Http::get())
+        ->addStep(new class () extends Step {
+            protected function invoke(mixed $input): Generator
+            {
+                yield 'http://localhost:8000/print-cookie';
+            }
+        })
+        ->addStep(Http::get())
+        ->addStep('printed-cookie', new GetStringFromResponseHtmlBody());
+
+    $results = helper_generatorToArray($crawler->run());
+
+    expect($results)->toHaveCount(1);
+
+    expect($results[0]->get('printed-cookie'))->toBeString();
+
+    expect($results[0]->get('printed-cookie'))->toBe('foo123');
+});
+
+it('renders javascript', function () {
+    $crawler = new HeadlessBrowserCrawler();
+
+    $crawler->input('http://localhost:8000/js-rendering')
+        ->addStep(Http::get())
+        ->addStep(
+            Html::root()
+                ->extract(['content' => '#content p'])
+        );
+
+    $results = helper_generatorToArray($crawler->run());
+
+    expect($results)->toHaveCount(1);
+
+    expect($results[0]->toArray())->toBe([
+        'content' => 'This was added through javascript',
+    ]);
+});

--- a/tests/_Integration/Server.php
+++ b/tests/_Integration/Server.php
@@ -36,3 +36,19 @@ if (str_starts_with($route, '/paginated-listing')) {
 if ($route === '/blog-post-with-json-ld') {
     return include(__DIR__ . '/_Server/BlogPostWithJsonLd.php');
 }
+
+if ($route === '/js-rendering') {
+    return include(__DIR__ . '/_Server/JsGeneratedContent.php');
+}
+
+if ($route === '/print-headers') {
+    return include(__DIR__ . '/_Server/PrintHeaders.php');
+}
+
+if ($route === '/set-cookie') {
+    return include(__DIR__ . '/_Server/SetCookie.php');
+}
+
+if ($route === '/print-cookie') {
+    return include(__DIR__ . '/_Server/PrintCookie.php');
+}

--- a/tests/_Integration/_Server/JsGeneratedContent.php
+++ b/tests/_Integration/_Server/JsGeneratedContent.php
@@ -1,0 +1,13 @@
+<!Doctype html>
+<html lang="en">
+<head>
+    <title>JS Generated Content</title>
+</head>
+<body>
+<div id="content">
+</div>
+<script>
+    document.querySelector('#content').innerHTML = '<p>This was added through javascript</p>';
+</script>
+</body>
+</html>

--- a/tests/_Integration/_Server/PrintCookie.php
+++ b/tests/_Integration/_Server/PrintCookie.php
@@ -1,0 +1,3 @@
+<?php
+
+echo $_COOKIE['testcookie'];

--- a/tests/_Integration/_Server/PrintHeaders.php
+++ b/tests/_Integration/_Server/PrintHeaders.php
@@ -1,0 +1,5 @@
+<?php
+
+header('Content-Type: application/json');
+
+echo json_encode(getallheaders());

--- a/tests/_Integration/_Server/SetCookie.php
+++ b/tests/_Integration/_Server/SetCookie.php
@@ -1,0 +1,5 @@
+<?php
+
+setcookie('testcookie', 'foo123');
+
+echo "set cookie";


### PR DESCRIPTION
Add chrome-php/chrome composer dependency and simple option to use a headless chrome browser with the HttpLoader. So this is enough to get HTML after executing javascript in the browser. For more sophisticated tasks better not extend the HttpLoader further, but instead maybe create a separate Loader and/or Steps.