### PR TITLE
Improve SimpleCsvFileStore for nested results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * The abstract `DomQuery` class (parent of the `CssSelector` and `XPathQuery` classes) now has some methods to narrow the selected matches further: `first()`, `last()`, `nth(n)`, `even()`, `odd()`.
 
+### Fixed
+* The `SimpleCsvFileStore` can now also save results with nested data (but only second level). It just concatenates the values separated with a ` | `.
+
 ## [0.5.0] - 2022-09-03
 ### Added
 * You can now call the new `useHeadlessBrowser` method on the `HttpLoader` class to use a headless Chrome browser to load pages. This is enough to get HTML after executing javascript in the browser. For more sophisticated tasks a separate Loader and/or Steps should better be created.

--- a/src/Stores/SimpleCsvFileStore.php
+++ b/src/Stores/SimpleCsvFileStore.php
@@ -35,7 +35,13 @@ class SimpleCsvFileStore extends Store
             $this->isFirstResult = false;
         }
 
-        fputcsv($fileHandle, array_values($result->toArray()));
+        $resultArray = $result->toArray();
+
+        if ($this->anyPropertyIsArray($result)) {
+            $resultArray = $this->flattenResultArray($resultArray);
+        }
+
+        fputcsv($fileHandle, array_values($resultArray));
 
         fclose($fileHandle);
     }
@@ -44,5 +50,31 @@ class SimpleCsvFileStore extends Store
     {
         return $this->storePath . '/' .
             ($this->filePrefix ? $this->filePrefix . '-' : '') . $this->createTimestamp . '.csv';
+    }
+
+    public function anyPropertyIsArray(Result $result): bool
+    {
+        foreach ($result->toArray() as $value) {
+            if (is_array($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param mixed[] $result
+     * @return array<string|int>
+     */
+    public function flattenResultArray(array $result): array
+    {
+        foreach ($result as $key => $value) {
+            if (is_array($value)) {
+                $result[$key] = implode(' | ', $value);
+            }
+        }
+
+        return $result;
     }
 }

--- a/tests/Stores/SimpleCsvFileStoreTest.php
+++ b/tests/Stores/SimpleCsvFileStoreTest.php
@@ -51,6 +51,24 @@ it('saves Results to a csv file', function () {
     );
 });
 
+test('if the value of a result property is an array, it concatenates the values separated with a pipe', function () {
+    $result1 = helper_getResultWithData(['col1' => 'foo', 'col2' => ['bar', 'baz', 'quz']]);
+
+    $store = new SimpleCsvFileStore(__DIR__ . '/_files', 'test2');
+
+    $store->store($result1);
+
+    expect(file_get_contents($store->filePath()))->toBe("col1,col2\nfoo,\"bar | baz | quz\"\n");
+
+    $result2 = helper_getResultWithData(['col1' => 'Donald', 'col2' => ['Tick', 'Trick', 'Track']]);
+
+    $store->store($result2);
+
+    expect(file_get_contents($store->filePath()))->toBe(
+        "col1,col2\nfoo,\"bar | baz | quz\"\nDonald,\"Tick | Trick | Track\"\n"
+    );
+});
+
 afterAll(function () {
     $dir = __DIR__ . '/_files';
 


### PR DESCRIPTION
If a result property value is an array it just prints them concatenated with ` | ` in the generated CSV file.