### PR TITLE
Add new HTTP::crawl() step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+* New step `Http::crawl()` (class `HttpCrawl` extending the normal `Http` step class) for conventional crawling. It loads all pages of a website (same host or domain) by following links. There's also a lot of options like depth, filtering by paths, and so on.
 * The abstract `DomQuery` class (parent of the `CssSelector` and `XPathQuery` classes) now has some methods to narrow the selected matches further: `first()`, `last()`, `nth(n)`, `even()`, `odd()`.
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
     "require": {
         "ext-dom": "*",
         "php": "^8.1",
-        "crwlr/robots-txt": "^0.1.0",
-        "crwlr/url": "^1.1",
+        "crwlr/robots-txt": "^0.1.2",
+        "crwlr/url": "^2.0",
         "psr/log": "^2.0|^3.0",
         "symfony/dom-crawler": "^6.0",
         "symfony/css-selector": "^6.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,8 +2,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
-         colors="true"
->
+         colors="true">
     <testsuites>
         <testsuite name="Test Suite">
             <directory suffix="Test.php">./tests</directory>

--- a/src/Loader/Http/HttpLoader.php
+++ b/src/Loader/Http/HttpLoader.php
@@ -10,6 +10,7 @@ use Crwlr\Crawler\Loader\Loader;
 use Crwlr\Crawler\UserAgents\UserAgentInterface;
 use Crwlr\Url\Exceptions\InvalidUrlException;
 use Crwlr\Url\Url;
+use Error;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
@@ -62,7 +63,7 @@ class HttpLoader extends Loader
             $logger->info('Loaded ' . $request->getUri()->__toString());
         });
 
-        $this->onError(function (RequestInterface $request, Exception|ResponseInterface $exceptionOrResponse, $logger) {
+        $this->onError(function (RequestInterface $request, Exception|Error|ResponseInterface $exceptionOrResponse, $logger) {
             $logMessage = 'Failed to load ' . $request->getUri()->__toString() . ': ';
 
             if ($exceptionOrResponse instanceof ResponseInterface) {

--- a/src/Steps/Loading/HttpCrawl.php
+++ b/src/Steps/Loading/HttpCrawl.php
@@ -1,0 +1,330 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading;
+
+use Closure;
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Url\Url;
+use Exception;
+use Generator;
+use Psr\Http\Message\UriInterface;
+use Symfony\Component\DomCrawler\Crawler;
+
+class HttpCrawl extends Http
+{
+    protected ?int $depth = null;
+
+    protected bool $sameHost = true;
+
+    protected string $host = '';
+
+    protected bool $sameDomain = false;
+
+    protected string $domain = '';
+
+    protected ?string $pathStartsWith = null;
+
+    protected ?string $pathRegex = null;
+
+    protected ?Closure $customClosure = null;
+
+    protected bool $inputIsSitemap = false;
+
+    protected bool $loadAll = false;
+
+    /**
+     * @var array<string,array<string,bool>>
+     */
+    protected array $urls = [];
+
+    /**
+     * @var array<string,true>
+     */
+    protected array $loadedUrls = [];
+
+    public function __construct(array $headers = [], string $httpVersion = '1.1')
+    {
+        parent::__construct(headers: $headers, httpVersion: $httpVersion);
+    }
+
+    public function depth(int $depth): static
+    {
+        $this->depth = $depth;
+
+        return $this;
+    }
+
+    public function sameHost(): static
+    {
+        $this->sameHost = true;
+
+        $this->sameDomain = false;
+
+        return $this;
+    }
+
+    public function sameDomain(): static
+    {
+        $this->sameDomain = true;
+
+        $this->sameHost = false;
+
+        return $this;
+    }
+
+    public function pathStartsWith(string $startsWith = ''): static
+    {
+        $this->pathStartsWith = $startsWith;
+
+        return $this;
+    }
+
+    public function pathMatches(string $regexPattern = ''): static
+    {
+        $this->pathRegex = $regexPattern;
+
+        return $this;
+    }
+
+    public function customFilter(Closure $closure): static
+    {
+        $this->customClosure = $closure;
+
+        return $this;
+    }
+
+    public function inputIsSitemap(): static
+    {
+        $this->inputIsSitemap = true;
+
+        return $this;
+    }
+
+    public function loadAllButYieldOnlyMatching(): static
+    {
+        $this->loadAll = true;
+
+        return $this;
+    }
+
+    protected function invoke(mixed $input): Generator
+    {
+        $this->setHostOrDomain($input);
+
+        $response = $this->loader->load($this->getRequestFromInputUri($input));
+
+        $this->addLoadedUrlsFromResponse($response);
+
+        if ($response !== null) {
+            if (!$this->inputIsSitemap && $this->matchesAllCriteria(Url::parse($input))) {
+                yield $response;
+            }
+
+            $this->urls = $this->getUrlsFromInitialResponse($response);
+
+            $depth = 1;
+
+            while (!$this->depthIsExceeded($depth) && !empty($this->urls)) {
+                yield from $this->loadUrls();
+
+                $depth++;
+            }
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function setHostOrDomain(UriInterface $uri): void
+    {
+        if ($this->sameHost) {
+            $this->host = $uri->getHost();
+        } else {
+            $domain = Url::parse($uri)->domain();
+
+            if (!is_string($domain) || empty($domain)) {
+                throw new Exception('No domain in input url');
+            }
+
+            $this->domain = $domain;
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function loadUrls(): Generator
+    {
+        $newUrls = [];
+
+        foreach ($this->urls as $url => $yieldResponse) {
+            $uri = Url::parsePsr7($url);
+
+            $response = $this->loader->load($this->getRequestFromInputUri($uri));
+
+            $this->addLoadedUrlsFromResponse($response);
+
+            if ($response !== null) {
+                if ($yieldResponse['yield'] === true) {
+                    yield $response;
+                }
+
+                $newUrls = array_merge($newUrls, $this->getUrlsFromHtmlDocument($response));
+            }
+        }
+
+        $this->urls = $newUrls;
+    }
+
+    /**
+     * @return array<string,array<string,bool>>
+     * @throws Exception
+     */
+    protected function getUrlsFromInitialResponse(RespondedRequest $respondedRequest): array
+    {
+        if ($this->inputIsSitemap) {
+            return $this->getUrlsFromSitemap($respondedRequest);
+        } else {
+            return $this->getUrlsFromHtmlDocument($respondedRequest);
+        }
+    }
+
+    /**
+     * @return array<string,array<string,bool>>
+     * @throws Exception
+     */
+    protected function getUrlsFromSitemap(RespondedRequest $respondedRequest): array
+    {
+        $domCrawler = new Crawler(Http::getBodyString($respondedRequest));
+
+        $urls = [];
+
+        foreach ($domCrawler->filter('urlset url loc') as $url) {
+            $url = Url::parse($url->textContent);
+
+            if (!$this->isOnSameHostOrDomain($url)) {
+                continue;
+            }
+
+            $matchesCriteria = $this->matchesCriteriaBesidesHostOrDomain($url);
+
+            if (!$matchesCriteria && !$this->loadAll) {
+                continue;
+            }
+
+            $url = $url->toString();
+
+            if (!isset($urls[$url]) && !isset($this->urls[$url]) && !isset($this->loadedUrls[$url])) {
+                $urls[$url] = ['yield' => $matchesCriteria];
+            }
+        }
+
+        return $urls;
+    }
+
+    /**
+     * @return array<string,array<string,bool>>
+     * @throws Exception
+     */
+    protected function getUrlsFromHtmlDocument(RespondedRequest $respondedRequest): array
+    {
+        $domCrawler = new Crawler(Http::getBodyString($respondedRequest));
+
+        $baseUrl = Url::parse($respondedRequest->effectiveUri());
+
+        $urls = [];
+
+        foreach ($domCrawler->filter('a') as $link) {
+            $linkElement = new Crawler($link);
+
+            $url = $baseUrl->resolve($linkElement->attr('href') ?? '');
+
+            if (!$this->isOnSameHostOrDomain($url)) {
+                continue;
+            }
+
+            $matchesCriteria = $this->matchesCriteriaBesidesHostOrDomain($url, $linkElement);
+
+            if (!$matchesCriteria && !$this->loadAll) {
+                continue;
+            }
+
+            $url = $url->toString();
+
+            if (!isset($urls[$url]) && !isset($this->urls[$url]) && !isset($this->loadedUrls[$url])) {
+                $urls[$url] = ['yield' => $matchesCriteria];
+            }
+        }
+
+        return $urls;
+    }
+
+    protected function addLoadedUrlsFromResponse(RespondedRequest $respondedRequest): void
+    {
+        $loadedUrls = [$respondedRequest->requestedUri() => true];
+
+        foreach ($respondedRequest->redirects() as $redirectUrl) {
+            $loadedUrls[$redirectUrl] = true;
+        }
+
+        foreach ($loadedUrls as $loadedUrl => $true) {
+            if (!isset($this->loadedUrls[$loadedUrl])) {
+                $this->loadedUrls[$loadedUrl] = true;
+            }
+        }
+    }
+
+    protected function depthIsExceeded(int $depth): bool
+    {
+        return $this->depth !== null && $depth > $this->depth;
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function matchesAllCriteria(Url $url, ?Crawler $linkElement = null): bool
+    {
+        return $this->isOnSameHostOrDomain($url) && $this->matchesCriteriaBesidesHostOrDomain($url, $linkElement);
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function matchesCriteriaBesidesHostOrDomain(Url $url, ?Crawler $linkElement = null): bool
+    {
+        return $this->matchesPathCriteria($url) &&
+            $this->matchesCustomCriteria($url, $linkElement);
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function isOnSameHostOrDomain(Url $url): bool
+    {
+        if ($this->sameHost) {
+            return $this->host === $url->host();
+        } else {
+            return $this->domain === $url->domain();
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function matchesPathCriteria(Url $url): bool
+    {
+        if ($this->pathStartsWith === null && $this->pathRegex === null) {
+            return true;
+        }
+
+        $path = $url->path() ?? '';
+
+        return ($this->pathStartsWith === null || str_starts_with($path, $this->pathStartsWith)) &&
+            ($this->pathRegex === null || preg_match($this->pathRegex, $path) === 1);
+    }
+
+    protected function matchesCustomCriteria(Url $url, ?Crawler $linkElement): bool
+    {
+        return $this->customClosure === null || $this->customClosure->call($this, $url, $linkElement);
+    }
+}

--- a/tests/_Integration/Http/CrawlingTest.php
+++ b/tests/_Integration/Http/CrawlingTest.php
@@ -1,0 +1,332 @@
+<?php
+
+namespace tests\_Integration\Http;
+
+use Crwlr\Crawler\HttpCrawler;
+use Crwlr\Crawler\Loader\Http\HttpLoader;
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Loading\Http;
+use Crwlr\Crawler\UserAgents\BotUserAgent;
+use Crwlr\Crawler\UserAgents\UserAgentInterface;
+use Crwlr\Url\Url;
+use GuzzleHttp\Client;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
+
+use function tests\helper_generatorToArray;
+
+/**
+ * A TestLoader that tracks all the loaded URLs in a public property.
+ */
+
+class TestLoader extends HttpLoader
+{
+    /**
+     * @var string[]
+     */
+    public array $loadedUrls = [];
+
+    public function load(mixed $subject): ?RespondedRequest
+    {
+        $request = $this->validateSubjectType($subject);
+
+        $this->loadedUrls[] = $request->getUri()->__toString();
+
+        return parent::load($subject);
+    }
+}
+
+/**
+ * To check if the Crawler stays on the same host or same domain when crawling, the PSR-18 HTTP ClientInterface
+ * of this Crawler's Loader, replaces the host in the request URI just before sending the Request. The Loader thinks
+ * it actually loaded the page from the incoming URI and the returned RespondedRequest object also has that original URI
+ * as effectiveUri (except if the requested page redirects).
+ */
+
+class Crawler extends HttpCrawler
+{
+    public function loader(UserAgentInterface $userAgent, LoggerInterface $logger): TestLoader
+    {
+        $client = new class () implements ClientInterface {
+            private Client $guzzleClient;
+
+            public function __construct()
+            {
+                $this->guzzleClient = new Client();
+            }
+
+            public function sendRequest(RequestInterface $request): ResponseInterface
+            {
+                $request = $request->withUri($request->getUri()->withHost('localhost')->withPort(8000));
+
+                return $this->guzzleClient->sendRequest($request);
+            }
+        };
+
+        return new TestLoader($userAgent, $client, $logger);
+    }
+
+    protected function userAgent(): UserAgentInterface
+    {
+        return new BotUserAgent('TestBot');
+    }
+
+    public function getLoader(): TestLoader
+    {
+        return parent::getLoader(); // @phpstan-ignore-line
+    }
+}
+
+it('stays on the same host by default', function () {
+    $crawler = (new Crawler())
+        ->input('http://www.example.com/crawling/main')
+        ->addStep(Http::crawl());
+
+    $crawler->runAndTraverse();
+
+    expect($crawler->getLoader()->loadedUrls)->not()->toContain('http://foo.example.com/crawling/main-on-subdomain');
+});
+
+it('stays on the same domain when method sameDomain() is called', function () {
+    $crawler = (new Crawler())
+        ->input('http://www.example.com/crawling/main')
+        ->addStep(Http::crawl()->sameDomain());
+
+    $crawler->runAndTraverse();
+
+    expect($crawler->getLoader()->loadedUrls)->toContain('http://foo.example.com/crawling/main-on-subdomain');
+
+    expect($crawler->getLoader()->loadedUrls)->not()->toContain('https://www.crwlr.software/packages/crawler');
+});
+
+it('stays on the same host when method sameHost() is called', function () {
+    $crawler = (new Crawler())
+        ->input('http://www.example.com/crawling/main')
+        ->addStep(
+            Http::crawl()
+                ->sameDomain()
+                ->sameHost()
+        );
+
+    $crawler->runAndTraverse();
+
+    expect($crawler->getLoader()->loadedUrls)->not()->toContain('http://foo.example.com/crawling/main-on-subdomain');
+});
+
+it('crawls every page of a website that is linked somewhere', function () {
+    $crawler = (new Crawler())
+        ->input('http://www.example.com/crawling/main')
+        ->addStep(Http::crawl());
+
+    $crawler->runAndTraverse();
+
+    expect($crawler->getLoader()->loadedUrls)->toHaveCount(6);
+
+    expect($crawler->getLoader()->loadedUrls)->toContain('http://www.example.com/crawling/main');
+
+    expect($crawler->getLoader()->loadedUrls)->toContain('http://www.example.com/crawling/sub1');
+
+    expect($crawler->getLoader()->loadedUrls)->toContain('http://www.example.com/crawling/sub1/sub1');
+
+    expect($crawler->getLoader()->loadedUrls)->toContain('http://www.example.com/crawling/sub2');
+
+    expect($crawler->getLoader()->loadedUrls)->toContain('http://www.example.com/crawling/sub2/sub1');
+
+    expect($crawler->getLoader()->loadedUrls)->toContain('http://www.example.com/crawling/sub2/sub1/sub1');
+});
+
+it('crawls only to a certain depth when the crawl depth is defined', function () {
+    $crawler = (new Crawler())
+        ->input('http://www.example.com/crawling/main')
+        ->addStep(Http::crawl()->depth(1));
+
+    $crawler->runAndTraverse();
+
+    expect($crawler->getLoader()->loadedUrls)->toHaveCount(3);
+
+    $crawler = (new Crawler())
+        ->input('http://www.example.com/crawling/main')
+        ->addStep(Http::crawl()->depth(2));
+
+    $crawler->runAndTraverse();
+
+    expect($crawler->getLoader()->loadedUrls)->toHaveCount(5);
+});
+
+it('extracts URLs from a sitemap if you call method inputIsSitemap()', function () {
+    $crawler = (new Crawler())
+        ->input('http://www.example.com/crawling/sitemap.xml')
+        ->addStep(Http::crawl()->inputIsSitemap());
+
+    $crawler->runAndTraverse();
+
+    expect($crawler->getLoader()->loadedUrls)->toHaveCount(7);
+});
+
+it('fails to extract URLs if you provide a sitemap as input and don\'t call inputIsSitemap()', function () {
+    $crawler = (new Crawler())
+        ->input('http://www.example.com/crawling/sitemap.xml')
+        ->addStep(Http::crawl());
+
+    $crawler->runAndTraverse();
+
+    expect($crawler->getLoader()->loadedUrls)->toHaveCount(1);
+});
+
+it('loads only pages where the path starts with a certain string when method pathStartsWith() is called', function () {
+    $crawler = (new Crawler())
+        ->input('http://www.example.com/crawling/sitemap.xml')
+        ->addStep(
+            Http::crawl()
+                ->inputIsSitemap()
+                ->pathStartsWith('/crawling/sub1')
+        );
+
+    $crawler->runAndTraverse();
+
+    expect($crawler->getLoader()->loadedUrls)->toHaveCount(3);
+
+    expect($crawler->getLoader()->loadedUrls)->toContain('http://www.example.com/crawling/sitemap.xml');
+
+    expect($crawler->getLoader()->loadedUrls)->toContain('http://www.example.com/crawling/sub1');
+
+    expect($crawler->getLoader()->loadedUrls)->toContain('http://www.example.com/crawling/sub1/sub1');
+});
+
+it('loads only URLs where the path matches a regex when method pathMatches() is used', function () {
+    $crawler = (new Crawler())
+        ->input('http://www.example.com/crawling/sitemap.xml')
+        ->addStep(
+            Http::crawl()
+                ->inputIsSitemap()
+                ->pathMatches('/^\/crawling\/sub[12]$/')
+        );
+
+    $crawler->runAndTraverse();
+
+    expect($crawler->getLoader()->loadedUrls)->toHaveCount(3);
+});
+
+it('loads only URLs where the Closure passed to method customFilter() returns true', function () {
+    $crawler = (new Crawler())
+        ->input('http://www.example.com/crawling/sitemap.xml')
+        ->addStep(
+            Http::crawl()
+                ->inputIsSitemap()
+                ->customFilter(function (Url $url) {
+                    return in_array($url->path(), [
+                        '/crawling/main',
+                        '/crawling/sub1/sub1',
+                        '/crawling/sub2/sub1/sub1'
+                    ], true);
+                })
+        );
+
+    $crawler->runAndTraverse();
+
+    expect($crawler->getLoader()->loadedUrls)->toHaveCount(4);
+
+    expect($crawler->getLoader()->loadedUrls)->toContain('http://www.example.com/crawling/main');
+
+    expect($crawler->getLoader()->loadedUrls)->toContain('http://www.example.com/crawling/sub1/sub1');
+
+    expect($crawler->getLoader()->loadedUrls)->toContain('http://www.example.com/crawling/sub2/sub1/sub1');
+});
+
+it(
+    'receives the link element where the URL was found, as second param in the Closure passed to method ' .
+    'customFilter() when it was found in an HTML document',
+    function () {
+        $crawler = (new Crawler())
+            ->input('http://www.example.com/crawling/main')
+            ->addStep(
+                Http::crawl()
+                    ->customFilter(function (Url $url, ?\Symfony\Component\DomCrawler\Crawler $linkElement) {
+                        return $linkElement && str_contains($linkElement->text(), 'Subpage 2');
+                    })
+            );
+
+        $crawler->runAndTraverse();
+
+        expect($crawler->getLoader()->loadedUrls)->toHaveCount(4);
+
+        expect($crawler->getLoader()->loadedUrls)->toContain('http://www.example.com/crawling/main');
+
+        expect($crawler->getLoader()->loadedUrls)->toContain('http://www.example.com/crawling/sub2');
+
+        expect($crawler->getLoader()->loadedUrls)->toContain('http://www.example.com/crawling/sub2/sub1');
+
+        expect($crawler->getLoader()->loadedUrls)->toContain('http://www.example.com/crawling/sub2/sub1/sub1');
+    }
+);
+
+it(
+    'loads all pages, but yields only responses where the URL path starts with a certain string, when methods ' .
+    'pathStartsWith() and loadAllButYieldOnlyMatching() are called',
+    function () {
+        $crawler = (new Crawler())
+            ->input('http://www.example.com/crawling/sitemap.xml')
+            ->addStep(
+                Http::crawl()
+                    ->inputIsSitemap()
+                    ->pathStartsWith('/crawling/sub2')
+                    ->loadAllButYieldOnlyMatching()
+            );
+
+        $results = helper_generatorToArray($crawler->run());
+
+        expect($crawler->getLoader()->loadedUrls)->toHaveCount(7);
+
+        expect($results)->toHaveCount(3);
+    }
+);
+
+it(
+    'loads all URLs, but yields only responses where the URL path matches a regex, when methods pathMatches() and ' .
+    'loadAllButYieldOnlyMatching() are called',
+    function () {
+        $crawler = (new Crawler())
+            ->input('http://www.example.com/crawling/sitemap.xml')
+            ->addStep(
+                Http::crawl()
+                    ->inputIsSitemap()
+                    ->pathMatches('/^\/crawling\/sub[12]$/')
+                    ->loadAllButYieldOnlyMatching()
+            );
+
+        $results = helper_generatorToArray($crawler->run());
+
+        expect($crawler->getLoader()->loadedUrls)->toHaveCount(7);
+
+        expect($results)->toHaveCount(2);
+    }
+);
+
+it(
+    'loads all URLs but yields only responses where the Closure passed to method customFilter() returns true, when ' .
+    'methods customFilter() and loadAllButYieldOnlyMatching() are called',
+    function () {
+        $crawler = (new Crawler())
+            ->input('http://www.example.com/crawling/sitemap.xml')
+            ->addStep(
+                Http::crawl()
+                    ->inputIsSitemap()
+                    ->customFilter(function (Url $url) {
+                        return in_array($url->path(), [
+                            '/crawling/main',
+                            '/crawling/sub1/sub1',
+                            '/crawling/sub2/sub1/sub1'
+                        ], true);
+                    })
+                    ->loadAllButYieldOnlyMatching()
+            );
+
+        $results = helper_generatorToArray($crawler->run());
+
+        expect($crawler->getLoader()->loadedUrls)->toHaveCount(7);
+
+        expect($results)->toHaveCount(3);
+    }
+);

--- a/tests/_Integration/Http/HeadlessBrowserTest.php
+++ b/tests/_Integration/Http/HeadlessBrowserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace tests\_Integration\Http;
+
 use Crwlr\Crawler\HttpCrawler;
 use Crwlr\Crawler\Loader\Http\HttpLoader;
 use Crwlr\Crawler\Loader\LoaderInterface;
@@ -8,6 +10,7 @@ use Crwlr\Crawler\Steps\Loading\Http;
 use Crwlr\Crawler\Steps\Step;
 use Crwlr\Crawler\UserAgents\BotUserAgent;
 use Crwlr\Crawler\UserAgents\UserAgentInterface;
+use Generator;
 use Psr\Log\LoggerInterface;
 
 use Symfony\Component\DomCrawler\Crawler;

--- a/tests/_Integration/Server.php
+++ b/tests/_Integration/Server.php
@@ -52,3 +52,7 @@ if ($route === '/set-cookie') {
 if ($route === '/print-cookie') {
     return include(__DIR__ . '/_Server/PrintCookie.php');
 }
+
+if (str_starts_with($route, '/crawling/')) {
+    return include(__DIR__ . '/_Server/Crawling.php');
+}

--- a/tests/_Integration/_Server/Crawling.php
+++ b/tests/_Integration/_Server/Crawling.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Structure:
+ *
+ * /crawling/main
+ *  => /crawling/sub1
+ *      => /crawling/sub1/sub1
+ *  => /crawling/sub2
+ *      => /crawling/sub2/sub1
+ *          => /crawling/sub2/sub1/sub1
+ */
+
+if ($route === '/crawling/sitemap.xml') {
+    echo <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<url><loc>http://www.example.com/crawling/main</loc></url>
+<url><loc>http://www.example.com/crawling/sub1</loc></url>
+<url><loc>http://www.example.com/crawling/sub1/sub1</loc></url>
+<url><loc>http://www.example.com/crawling/sub2</loc></url>
+<url><loc>http://www.example.com/crawling/sub2/sub1</loc></url>
+<url><loc>http://www.example.com/crawling/sub2/sub1/sub1</loc></url>
+</urlset>
+XML;
+}
+
+if ($route === '/crawling/main') {
+    echo <<<HTML
+        <!doctype html>
+        <html lang="en">
+        <body>
+            <a href="/crawling/sub1">Subpage 1</a> <br>
+            <a href="/crawling/sub2">Subpage 2</a> <br>
+            
+            <a href="https://www.crwlr.software/packages/crawler">External link</a>
+        </body>
+        </html>
+        HTML;
+}
+
+if ($route === '/crawling/sub1') {
+    echo <<<HTML
+        <!doctype html>
+        <html lang="en">
+        <body>
+            <a href="/crawling/sub1/sub1">Subpage 1 of Subpage 1</a> <br>
+            
+            <a href="https://www.foo.com">External link</a>
+            
+            <a href="http://foo.example.com/crawling/main-on-subdomain">Link to subdomain</a>
+        </body>
+        </html>
+        HTML;
+}
+
+if ($route === '/crawling/sub1/sub1') {
+    echo <<<HTML
+        <!doctype html>
+        <html lang="en">
+        <body>
+            <h1>Final level of sub1</h1>
+            <h2>Subpage 1 of Subpage 1</h2>
+            <a href="/crawling/main">Back to main</a>
+        </body>
+        </html>
+        HTML;
+}
+
+if ($route === '/crawling/sub2') {
+    echo <<<HTML
+        <!doctype html>
+        <html lang="en">
+        <body>
+            <a href="/crawling/sub2/sub1">Subpage 1 of Subpage 2</a>
+        </body>
+        </html>
+        HTML;
+}
+
+if ($route === '/crawling/sub2/sub1') {
+    echo <<<HTML
+        <!doctype html>
+        <html lang="en">
+        <body>
+            <a href="/crawling/sub2/sub1/sub1">Subpage 1 of Subpage 1 of Subpage 2</a>
+        </body>
+        </html>
+        HTML;
+}
+
+if ($route === '/crawling/sub2/sub1/sub1') {
+    echo <<<HTML
+        <!doctype html>
+        <html lang="en">
+        <body>
+            <h1>Final level of sub2</h1>
+            <h2>Subpage 1 of Subpage 1 of Subpage 2</h2>
+            <a href="/crawling/sub2">Back to Subpage 2</a>
+        </body>
+        </html>
+        HTML;
+}
+
+if ($route === '/crawling/main-on-subdomain') {
+    echo <<<HTML
+        <!doctype html>
+        <html lang="en">
+        <body>
+            <h1>Main page on subdomain</h1>
+        </body>
+        </html>
+        HTML;
+}


### PR DESCRIPTION
It's for classic crawling all pages of a website. By default it follows all links on the same host, optionally all on same domain, including subdomains. You can start with any HTML document or optionally with one or more sitemaps. You can tell it to only load pages to a certain depth. You can filter URLs to load, by the path or even check the link element where it was found to decide if it should follow. You can also decide to load all pages, but yield only the responses matching your criteria (path, link element, custom URL check) to the next step. Besides that, improve the onError callback in the HttpLoader, fix a forgotten namespace in a test file and update the url and robots-txt package dependencies.