### PR TITLE
Check HTML <base> tag when resolving URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * __BREAKING__: Removed `PoliteHttpLoader` and traits `WaitPolitely` and `CheckRobotsTxt`. Converted the traits to classes `Throttler` and `RobotsTxtHandler` which are dependencies of the `HttpLoader`. The `HttpLoader` internally gets default instances of those classes. The `RobotsTxtHandler` will respect robots.txt rules by default if you use a `BotUserAgent` and it won't if you use a normal `UserAgent`. You can access the loader's `RobotsTxtHandler` via `HttpLoader::robotsTxt()`. You can pass your own instance of the `Throttler` to the loader and also access it via `HttpLoader::throttle()` to change settings.
 
 ### Fixed
+* Getting absolute links via the `GetLink` and `GetLinks` steps and the `toAbsoluteUrl()` method of the `CssSelector` and `XPathQuery` classes, now also look for `<base>` tags in HTML when resolving the URLs.
 * The `SimpleCsvFileStore` can now also save results with nested data (but only second level). It just concatenates the values separated with a ` | `.
 
 ## [0.5.0] - 2022-09-03

--- a/src/Steps/Html/GetLink.php
+++ b/src/Steps/Html/GetLink.php
@@ -51,6 +51,8 @@ class GetLink extends Step
      */
     protected function invoke(mixed $input): Generator
     {
+        $this->getBaseFromDocument($input);
+
         $selector = $this->selector ?? 'a';
 
         foreach ($input->filter($selector) as $link) {
@@ -129,6 +131,15 @@ class GetLink extends Step
         $this->onHost = $this->onHost ? array_merge($this->onHost, $hosts) : $hosts;
 
         return $this;
+    }
+
+    protected function getBaseFromDocument(Crawler $document): void
+    {
+        $baseHref = DomQuery::getBaseHrefFromDocument($document);
+
+        if (!empty($baseHref)) {
+            $this->baseUri = $this->baseUri->resolve($baseHref);
+        }
     }
 
     /**

--- a/src/Steps/Html/GetLinks.php
+++ b/src/Steps/Html/GetLinks.php
@@ -15,6 +15,8 @@ class GetLinks extends GetLink
      */
     protected function invoke(mixed $input): Generator
     {
+        $this->getBaseFromDocument($input);
+
         $selector = $this->selector ?? 'a';
 
         foreach ($input->filter($selector) as $link) {

--- a/tests/Steps/Html/CssSelectorTest.php
+++ b/tests/Steps/Html/CssSelectorTest.php
@@ -115,6 +115,34 @@ it('turns the value into an absolute url when toAbsoluteUrl() is called', functi
     expect($selector->apply($domCrawler))->toBe('https://www.crwlr.software/packages/crawler/v0.4/getting-started');
 });
 
+it(
+    'turns the value into the correct absolute url when toAbsoluteUrl() is called and the HTML contains a base tag',
+    function () {
+        $html = <<<HTML
+            <!DOCTYPE html>
+            <html>
+            <head>
+            <base href="/c/d" />
+            </head>
+            <body><a href="e">link</a></body>
+            </html>
+            HTML;
+
+        $domCrawler = new Crawler($html);
+
+        $selector = new CssSelector('a');
+
+        $selector->setBaseUrl('https://www.example.com/a/b')
+            ->attribute('href');
+
+        expect($selector->apply($domCrawler))->toBe('e');
+
+        $selector->toAbsoluteUrl();
+
+        expect($selector->apply($domCrawler))->toBe('https://www.example.com/c/e');
+    }
+);
+
 it('gets only the first matching element when the first() method is called', function () {
     $domCrawler = new Crawler(helper_getSimpleListHtml());
 

--- a/tests/Steps/Html/GetLinkTest.php
+++ b/tests/Steps/Html/GetLinkTest.php
@@ -344,3 +344,24 @@ test('onHost() can be called multiple times and merges all hosts it was called w
 
     expect($links[0]->get())->toBe('https://www.otsch.codes/blog');
 });
+
+it('works correctly when HTML contains a base tag', function () {
+    $html = <<<HTML
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <base href="/c/d" />
+        </head>
+        <body><a href="e">link</a></body>
+        </html>
+        HTML;
+
+    $step = (new GetLink());
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.example.com/a/b'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links[0]->get())->toBe('https://www.example.com/c/e');
+});

--- a/tests/Steps/Html/GetLinksTest.php
+++ b/tests/Steps/Html/GetLinksTest.php
@@ -353,3 +353,32 @@ test('onHost() can be called multiple times and merges all hosts it was called w
 
     expect($links[1]->get())->toBe('https://www.crwl.io');
 });
+
+it('works correctly when HTML contains a base tag', function () {
+    $html = <<<HTML
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <base href="/c/d" />
+        </head>
+        <body>
+        <a href="e">link</a>
+        <a href="/f/g">link2</a>
+        <a href="./h">link3</a>
+        </body>
+        </html>
+        HTML;
+
+    $step = (new GetLinks());
+
+    $links = helper_invokeStepWithInput($step, new RespondedRequest(
+        new Request('GET', 'https://www.example.com/a/b'),
+        new Response(200, [], $html)
+    ));
+
+    expect($links[0]->get())->toBe('https://www.example.com/c/e');
+
+    expect($links[1]->get())->toBe('https://www.example.com/f/g');
+
+    expect($links[2]->get())->toBe('https://www.example.com/c/h');
+});

--- a/tests/Steps/Html/XPathQueryTest.php
+++ b/tests/Steps/Html/XPathQueryTest.php
@@ -2,6 +2,7 @@
 
 namespace tests\Steps\Html;
 
+use Crwlr\Crawler\Steps\Html\CssSelector;
 use Crwlr\Crawler\Steps\Html\XPathQuery;
 use Symfony\Component\DomCrawler\Crawler;
 

--- a/tests/Steps/Html/XPathQueryTest.php
+++ b/tests/Steps/Html/XPathQueryTest.php
@@ -2,7 +2,6 @@
 
 namespace tests\Steps\Html;
 
-use Crwlr\Crawler\Steps\Html\CssSelector;
 use Crwlr\Crawler\Steps\Html\XPathQuery;
 use Symfony\Component\DomCrawler\Crawler;
 


### PR DESCRIPTION
Getting absolute links via the `GetLink` and `GetLinks` steps and the `toAbsoluteUrl()` method of the `CssSelector` and `XPathQuery` classes, now also look for `<base>` tags in HTML when resolving the URLs.