### PR TITLE
New step to get Metadata from HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * New step `Http::crawl()` (class `HttpCrawl` extending the normal `Http` step class) for conventional crawling. It loads all pages of a website (same host or domain) by following links. There's also a lot of options like depth, filtering by paths, and so on.
 * New steps `Sitemap::getSitemapsFromRobotsTxt()` (`GetSitemapsFromRobotsTxt`) and `Sitemap::getUrlsFromSitemap()` (`GetUrlsFromSitemap`) to get sitemap (URLs) from a robots.txt file and to get all the URLs from those sitemaps.
+* New step `Html::metaData()` to get data from meta tags (and title tag) in HTML documents.
 * The abstract `DomQuery` class (parent of the `CssSelector` and `XPathQuery` classes) now has some methods to narrow the selected matches further: `first()`, `last()`, `nth(n)`, `even()`, `odd()`.
 
 ### Changed

--- a/src/Steps/Html.php
+++ b/src/Steps/Html.php
@@ -6,6 +6,7 @@ use Crwlr\Crawler\Steps\Html\CssSelector;
 use Crwlr\Crawler\Steps\Html\DomQueryInterface;
 use Crwlr\Crawler\Steps\Html\GetLink;
 use Crwlr\Crawler\Steps\Html\GetLinks;
+use Crwlr\Crawler\Steps\Html\MetaData;
 
 class Html extends Dom
 {
@@ -17,6 +18,11 @@ class Html extends Dom
     public static function getLinks(?string $selector = null): GetLinks
     {
         return new GetLinks($selector);
+    }
+
+    public static function metaData(): MetaData
+    {
+        return new MetaData();
     }
 
     protected function makeDefaultDomQueryInstance(string $query): DomQueryInterface

--- a/src/Steps/Html/MetaData.php
+++ b/src/Steps/Html/MetaData.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Html;
+
+use Crwlr\Crawler\Steps\Step;
+use DOMElement;
+use Generator;
+use Symfony\Component\DomCrawler\Crawler;
+
+class MetaData extends Step
+{
+    /**
+     * @var string[]
+     */
+    protected array $onlyKeys = [];
+
+    /**
+     * @param string[] $keys
+     */
+    public function only(array $keys): static
+    {
+        $this->onlyKeys = $keys;
+
+        return $this;
+    }
+
+    /**
+     * @param Crawler $input
+     */
+    protected function invoke(mixed $input): Generator
+    {
+        $data = ['title' => $this->getTitle($input)];
+
+        foreach ($input->filter('meta') as $metaElement) {
+            /** @var DOMElement $metaElement */
+            $metaName = $metaElement->getAttribute('name');
+
+            if (empty($metaName)) {
+                $metaName = $metaElement->getAttribute('property');
+            }
+
+            if (!empty($metaName) && (empty($this->onlyKeys) || in_array($metaName, $this->onlyKeys, true))) {
+                $data[$metaName] = $metaElement->getAttribute('content');
+            }
+        }
+
+        yield $data;
+    }
+
+    protected function validateAndSanitizeInput(mixed $input): mixed
+    {
+        return $this->validateAndSanitizeToDomCrawlerInstance($input);
+    }
+
+    protected function getTitle(Crawler $document): string
+    {
+        $titleElement = $document->filter('title');
+
+        if ($titleElement->count() > 0) {
+            return $titleElement->first()->text();
+        }
+
+        return '';
+    }
+}

--- a/tests/Steps/Html/MetaDataTest.php
+++ b/tests/Steps/Html/MetaDataTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace tests\Steps\Html;
+
+use Crwlr\Crawler\Steps\Html;
+use Crwlr\Crawler\Steps\Html\MetaData;
+
+use function tests\helper_invokeStepWithInput;
+
+it('returns an array with key title and empty string if the HTML document doesn\'t even contain a title', function () {
+    $html = <<<HTML
+        <!DOCTYPE html>
+        <html>
+        <head>
+        </head>
+        <body>Hello World!</body>
+        </html>
+        HTML;
+
+    $outputs = helper_invokeStepWithInput(new MetaData(), $html);
+
+    expect($outputs[0]->get())->toBe(['title' => '']);
+});
+
+it('returns an array with the title and all meta tags having a name or property attribute', function () {
+    $html = <<<HTML
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta charset="UTF-8">
+        <title>
+            Hello World!
+        </title>
+        <meta name="description" content="This is a page saying: Hello World!" />
+        <meta name="keywords" content="lorem, ipsum, hello, world" />
+        <meta property="og:title" content="Hello World!" />
+        <meta property="og:type" content="website" />
+        </head>
+        <body>Hello World!</body>
+        </html>
+        HTML;
+
+    $outputs = helper_invokeStepWithInput(new MetaData(), $html);
+
+    expect($outputs[0]->get())->toBe([
+        'title' => 'Hello World!',
+        'description' => 'This is a page saying: Hello World!',
+        'keywords' => 'lorem, ipsum, hello, world',
+        'og:title' => 'Hello World!',
+        'og:type' => 'website',
+    ]);
+});
+
+it('returns only the meta tags defined via the only() method', function () {
+    $html = <<<HTML
+        <!DOCTYPE html>
+        <html>
+        <head>
+        <meta charset="UTF-8">
+        <title>
+            Hello World!
+        </title>
+        <meta name="description" content="This is a page saying: Hello World!" />
+        <meta name="keywords" content="lorem, ipsum, hello, world" />
+        <meta property="og:title" content="Hello World!" />
+        <meta property="og:type" content="website" />
+        </head>
+        <body>Hello World!</body>
+        </html>
+        HTML;
+
+    $outputs = helper_invokeStepWithInput(Html::metaData()->only(['title', 'description']), $html);
+
+    expect($outputs[0]->get())->toBe([
+        'title' => 'Hello World!',
+        'description' => 'This is a page saying: Hello World!',
+    ]);
+});


### PR DESCRIPTION
New step `Html::metaData()` to get data from meta tags (and title tag) in HTML documents.