### PR TITLE
New schema.org step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * New step `Http::crawl()` (class `HttpCrawl` extending the normal `Http` step class) for conventional crawling. It loads all pages of a website (same host or domain) by following links. There's also a lot of options like depth, filtering by paths, and so on.
 * New steps `Sitemap::getSitemapsFromRobotsTxt()` (`GetSitemapsFromRobotsTxt`) and `Sitemap::getUrlsFromSitemap()` (`GetUrlsFromSitemap`) to get sitemap (URLs) from a robots.txt file and to get all the URLs from those sitemaps.
 * New step `Html::metaData()` to get data from meta tags (and title tag) in HTML documents.
+* New step `Html::schemaOrg()` (`SchemaOrg`) to get schema.org structured data in JSON-LD format from HTML documents.
 * The abstract `DomQuery` class (parent of the `CssSelector` and `XPathQuery` classes) now has some methods to narrow the selected matches further: `first()`, `last()`, `nth(n)`, `even()`, `odd()`.
 
 ### Changed

--- a/src/Steps/Html.php
+++ b/src/Steps/Html.php
@@ -7,6 +7,7 @@ use Crwlr\Crawler\Steps\Html\DomQueryInterface;
 use Crwlr\Crawler\Steps\Html\GetLink;
 use Crwlr\Crawler\Steps\Html\GetLinks;
 use Crwlr\Crawler\Steps\Html\MetaData;
+use Crwlr\Crawler\Steps\Html\SchemaOrg;
 
 class Html extends Dom
 {
@@ -23,6 +24,11 @@ class Html extends Dom
     public static function metaData(): MetaData
     {
         return new MetaData();
+    }
+
+    public static function schemaOrg(): SchemaOrg
+    {
+        return new SchemaOrg();
     }
 
     protected function makeDefaultDomQueryInstance(string $query): DomQueryInterface

--- a/src/Steps/Html/SchemaOrg.php
+++ b/src/Steps/Html/SchemaOrg.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Html;
+
+use Adbar\Dot;
+use Crwlr\Crawler\Steps\Step;
+use Generator;
+use Spatie\SchemaOrg\BaseType;
+
+class SchemaOrg extends Step
+{
+    protected bool $toArray = false;
+    protected ?string $onlyType = null;
+
+    /**
+     * @var array<int|string, string>
+     */
+    protected array $mapping = [];
+
+    public function toArray(): static
+    {
+        $this->toArray = true;
+
+        return $this;
+    }
+
+    public function onlyType(string $type = ''): static
+    {
+        $this->onlyType = $type;
+
+        return $this;
+    }
+
+    /**
+     * @param array<int|string, string> $mapping
+     */
+    public function extract(array $mapping): static
+    {
+        $this->mapping = $mapping;
+
+        return $this;
+    }
+
+    protected function invoke(mixed $input): Generator
+    {
+        $data = \Crwlr\SchemaOrg\SchemaOrg::fromHtml($input);
+
+        foreach ($data as $schemaOrgObject) {
+            if ($this->onlyType && $schemaOrgObject->getType() !== $this->onlyType) {
+                yield from $this->scanChildrenForType($schemaOrgObject);
+
+                continue;
+            }
+
+            yield $this->prepareReturnValue($schemaOrgObject);
+        }
+    }
+
+    protected function validateAndSanitizeInput(mixed $input): string
+    {
+        return $this->validateAndSanitizeStringOrHttpResponse($input);
+    }
+
+    protected function scanChildrenForType(BaseType $schemaOrgObject): Generator
+    {
+        foreach ($schemaOrgObject->getProperties() as $propertyName => $property) {
+            $propertyValue = $schemaOrgObject->getProperty($propertyName);
+
+            if ($propertyValue instanceof BaseType && $propertyValue->getType() === $this->onlyType) {
+                yield $this->prepareReturnValue($propertyValue);
+            } elseif ($propertyValue instanceof BaseType) {
+                yield from $this->scanChildrenForType($propertyValue);
+            }
+        }
+    }
+
+    /**
+     * @return BaseType|mixed[]
+     */
+    protected function prepareReturnValue(BaseType $object): BaseType|array
+    {
+        if ($this->toArray || !empty($this->mapping)) {
+            if (empty($this->mapping)) {
+                return $object->toArray();
+            }
+
+            return $this->applyMapping($object->toArray());
+        }
+
+        return $object;
+    }
+
+    /**
+     * @param mixed[] $schemaOrgData
+     * @return mixed[]
+     */
+    protected function applyMapping(array $schemaOrgData): array
+    {
+        $extractedData = [];
+
+        $dot = new Dot($schemaOrgData);
+
+        foreach ($this->mapping as $outputKey => $dotNotationKey) {
+            if (is_int($outputKey)) {
+                $outputKey = $dotNotationKey;
+            }
+
+            $extractedData[$outputKey] = $dot->get($dotNotationKey);
+        }
+
+        return $extractedData;
+    }
+}

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -207,6 +207,8 @@ test('The static loop method wraps a Step in a LoopStep object', function () {
     $loop = Crawler::loop($step);
 
     $loop->invokeStep(new Input('foo'));
+
+    expect(true)->toBeTrue(); // So pest doesn't complain that there is no assertion.
 });
 
 test('You can add steps and the Crawler class passes on its Logger and also its Loader if needed', function () {
@@ -305,6 +307,8 @@ test('You can add a step group as a step and all it\'s steps are invoked when th
             ->addStep($step2)
             ->addStep($step3)
     );
+
+    expect(true)->toBeTrue(); // So pest doesn't complain that there is no assertion.
 });
 
 test('Result objects are created when defined and passed on through all the steps', function () {

--- a/tests/Loader/Http/HttpLoaderTest.php
+++ b/tests/Loader/Http/HttpLoaderTest.php
@@ -208,7 +208,7 @@ test('It calls request start and end tracking methods', function (string $loadin
 
     $httpLoader = new HttpLoader(helper_nonBotUserAgent(), $httpClient, throttler: $throttler);
 
-    $httpLoader->load('https://www.twitter.com');
+    $httpLoader->{$loadingMethod}('https://www.twitter.com');
 
     $output = $this->getActualOutput();
 
@@ -338,7 +338,7 @@ test('By default it uses the cookie jar and passes on cookies', function () {
             $cookiesHeader === ['cookie1=foo2', 'cookie2=bar2', 'cookie3=baz'];
     })->andReturn(new Response());
 
-    $httpLoader = new HttpLoader(new BotUserAgent('Foo'), $httpClient);
+    $httpLoader = new HttpLoader(helper_nonBotUserAgent(), $httpClient);
     $httpLoader->load('https://www.crwlr.software/');
     $httpLoader->load('https://www.crwlr.software/blog');
     $httpLoader->loadOrFail('https://www.crwlr.software/contact');
@@ -372,7 +372,7 @@ test('You can turn off using the cookie jar', function () {
         return $request->getUri()->__toString() === 'https://www.crwlr.software/packages' && $cookiesHeader === [];
     })->andReturn(new Response());
 
-    $httpLoader = new HttpLoader(new BotUserAgent('Foo'), $httpClient);
+    $httpLoader = new HttpLoader(helper_nonBotUserAgent(), $httpClient);
     $httpLoader->dontUseCookies();
     $httpLoader->load('https://www.crwlr.software/');
     $httpLoader->load('https://www.crwlr.software/blog');

--- a/tests/Steps/Html/SchemaOrgTest.php
+++ b/tests/Steps/Html/SchemaOrgTest.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace tests\Steps\Html;
+
+use Crwlr\Crawler\Steps\Html;
+use Spatie\SchemaOrg\Article;
+use Spatie\SchemaOrg\JobPosting;
+
+use function tests\helper_invokeStepWithInput;
+
+function helper_schemaOrgExampleOneJobPostingInBody(): string
+{
+    return <<<HTML
+        <!DOCTYPE html>
+        <html lang="de">
+        <head><title>Foo Bar</title></head>
+        <body>
+        <script type="application/ld+json">{"@context":"https:\/\/schema.org","@type":"JobPosting","title":"Senior Full Stack PHP Developer (w\/m\/d)","employmentType":["FULL_TIME"],"datePosted":"2022-07-25","description":"foo bar baz","hiringOrganization":{"@type":"Organization","name":"Foo Ltd.","logo":"https:\/\/www.example.com\/logo.png"},"jobLocation":{"@type":"Place","address":{"@type":"PostalAddress","addressLocality":"Linz","addressRegion":"Upper Austria","addressCountry":"Austria"}},"identifier":{"@type":"PropertyValue","name":"foo","value":123456},"directApply":true} </script>
+        <h1>Baz</h1> <p>Other content</p>
+        </body>
+        </html>
+        HTML;
+}
+
+function helper_schemaOrgExampleMultipleObjects(): string
+{
+    return <<<HTML
+        <!DOCTYPE html>
+        <html lang="de-AT">
+        <head>
+        <title>Foo Bar</title>
+        <script type="application/ld+json">
+        {
+            "mainEntity": [{
+                "name": "Some Question?",
+                "acceptedAnswer": {
+                    "text": "bli bla blub!",
+                    "@type": "Answer"
+                },
+                "@type": "Question"
+            }, {
+                "name": "Another question?",
+                "acceptedAnswer": {
+                    "text": "bla blu blo!",
+                    "@type": "Answer"
+                },
+                "@type": "Question"
+            }],
+            "@type": "FAQPage",
+            "@context": "http://schema.org"
+        }
+        </script>
+        <meta property="og:title" content="Some Article" />
+        <meta property="og:type" content="website" />
+        <script type="application/ld+json">
+        { "@context": "http://schema.org",
+        "@type": "Organization",
+        "name": "Example Company",
+        "url": "https://www.example.com",
+        "logo": "https://www.example.com/logo.png", "sameAs": [ "https://some.social-media.app/example-company" ] }
+        </script>
+        </head>
+        <body>
+        <h1>Some Article</h1>
+        <h2>This is some article about something.</h2>
+        <script type="application/ld+json">
+        {
+            "@context": "https:\/\/schema.org",
+            "@type": "Article",
+            "name": "Some Article",
+            "url": "https:\/\/de.example.org\/articles\/some",
+            "sameAs": "http:\/\/www.example.org\/articles\/A123456789",
+            "mainEntity": "http:\/\/www.example.org\/articles\/A123456789",
+            "author": {
+                "@type": "Person",
+                "name": "Jane Doe",
+                "url": "https://example.com/profile/janedoe123"
+            },
+            "publisher": {
+                "@type": "Organization",
+                "name": "Some Organization, Inc.",
+                "logo": {
+                    "@type": "ImageObject",
+                    "url": "https:\/\/www.example.org\/images\/organization-logo.png"
+                }
+            },
+            "datePublished": "2023-09-07T21:57:44Z",
+            "image": "https:\/\/images.example.org\/2023\/A123456789.jpg",
+            "headline": "This is some article about something."
+        }
+        </script>
+        </body>
+        </html>
+        HTML;
+}
+
+it('extracts schema.org data in JSON-LD format from an HTML document', function () {
+    $html = helper_schemaOrgExampleOneJobPostingInBody();
+
+    $outputs = helper_invokeStepWithInput(Html::schemaOrg(), $html);
+
+    expect($outputs)->toHaveCount(1);
+
+    expect($outputs[0]->get())->toBeInstanceOf(JobPosting::class);
+});
+
+it('converts the spatie schema.org objects to arrays when calling the toArray() method', function () {
+    $html = helper_schemaOrgExampleOneJobPostingInBody();
+
+    $outputs = helper_invokeStepWithInput(Html::schemaOrg()->toArray(), $html);
+
+    expect($outputs)->toHaveCount(1);
+
+    expect($outputs[0]->get())->toBeArray();
+
+    expect($outputs[0]->get()['hiringOrganization'])->toBeArray();
+
+    expect($outputs[0]->get()['hiringOrganization'])->toHaveKey('name');
+
+    expect($outputs[0]->get()['hiringOrganization']['name'])->toBe('Foo Ltd.');
+});
+
+it('gets all the schema.org objects contained in a document', function () {
+    $html = helper_schemaOrgExampleMultipleObjects();
+
+    $outputs = helper_invokeStepWithInput(Html::schemaOrg(), $html);
+
+    expect($outputs)->toHaveCount(3);
+});
+
+it('gets only schema.org objects of a certain type if you use the onlyType method', function () {
+    $html = helper_schemaOrgExampleMultipleObjects();
+
+    $outputs = helper_invokeStepWithInput(
+        Html::schemaOrg()->onlyType('Article'),
+        $html
+    );
+
+    expect($outputs)->toHaveCount(1);
+
+    expect($outputs[0]->get())->toBeInstanceOf(Article::class);
+});
+
+it('also finds schema.org objects of a certain type in children of another schema.org object', function () {
+    $html = helper_schemaOrgExampleMultipleObjects();
+
+    $outputs = helper_invokeStepWithInput(
+        Html::schemaOrg()->onlyType('Organization'),
+        $html
+    );
+
+    expect($outputs)->toHaveCount(2);
+
+    expect($outputs[0]->get()->getProperty('name'))->toBe('Example Company');
+
+    expect($outputs[1]->get()->getProperty('name'))->toBe('Some Organization, Inc.');
+});
+
+it('extracts certain data from schema.org objects when using the extract() method', function () {
+    $html = helper_schemaOrgExampleMultipleObjects();
+
+    $outputs = helper_invokeStepWithInput(
+        Html::schemaOrg()->onlyType('Article')->extract(['url', 'headline', 'publisher' => 'publisher.name']),
+        $html
+    );
+
+    expect($outputs)->toHaveCount(1);
+
+    expect($outputs[0]->get())->toBe([
+        'url' => 'https://de.example.org/articles/some',
+        'headline' => 'This is some article about something.',
+        'publisher' => 'Some Organization, Inc.',
+    ]);
+});
+
+test('If an object doesn\'t contain a property from the extract mapping, it\'s just null in the output', function () {
+    $html = helper_schemaOrgExampleMultipleObjects();
+
+    $outputs = helper_invokeStepWithInput(
+        Html::schemaOrg()->onlyType('Article')->extract(['url', 'headline', 'alternativeHeadline']),
+        $html
+    );
+
+    expect($outputs)->toHaveCount(1);
+
+    expect($outputs[0]->get())->toBe([
+        'url' => 'https://de.example.org/articles/some',
+        'headline' => 'This is some article about something.',
+        'alternativeHeadline' => null,
+    ]);
+});


### PR DESCRIPTION
New step `Html::schemaOrg()` (`SchemaOrg`) to get schema.org structured data in JSON-LD format from HTML documents.
Also fix a few minor things in existing tests.