### PR TITLE
Handling 429 - Too Many Requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+* In case of a 429 (Too Many Requests) response, the `HttpLoader` now automatically waits and retries. By default, it retries twice and waits 10 seconds for the first retry and a minute for the second one. In case the response also contains a `Retry-After` header with a value in seconds, it complies to that. Exception: by default it waits at max `60` seconds (you can set your own limit if you want), if the `Retry-After` value is higher, it will stop crawling. If all the retries also receive a `429` it also throws an Exception.
+* Removed logger from `Throttler` as it doesn't log anything.
+
+### Fixed
+* The `CookieJar` now also works with `localhost` or other hosts without a registered domain name.
+
 ## [0.6.0] - 2022-10-03
 
 ### Added

--- a/src/Loader/Http/Politeness/Throttler.php
+++ b/src/Loader/Http/Politeness/Throttler.php
@@ -7,7 +7,6 @@ use Crwlr\Crawler\Loader\Http\Politeness\TimingUnits\MultipleOf;
 use Crwlr\Url\Url;
 use InvalidArgumentException;
 use Psr\Http\Message\UriInterface;
-use Psr\Log\LoggerInterface;
 
 class Throttler
 {
@@ -29,7 +28,6 @@ class Throttler
     protected Microseconds|MultipleOf $from;
     protected Microseconds|MultipleOf $to;
     protected Microseconds $min;
-    protected ?LoggerInterface $logger = null;
 
     /**
      * @throws InvalidArgumentException
@@ -118,11 +116,6 @@ class Throttler
         $wait = $waitUntil->subtract($now);
 
         usleep($wait->value);
-    }
-
-    public function addLogger(LoggerInterface $logger): void
-    {
-        $this->logger = $logger;
     }
 
     protected function time(): Microseconds

--- a/src/Loader/Http/Politeness/TooManyRequestsHandler.php
+++ b/src/Loader/Http/Politeness/TooManyRequestsHandler.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Crwlr\Crawler\Loader\Http\Politeness;
+
+use Closure;
+use Crwlr\Crawler\Loader\Http\Exceptions\LoadingException;
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
+
+class TooManyRequestsHandler
+{
+    /**
+     * @param int[] $wait
+     */
+    public function __construct(
+        protected int $retries = 2,
+        protected array $wait = [10, 60],
+        protected int $maxWait = 60,
+    ) {
+    }
+
+    /**
+     * @throws LoadingException
+     */
+    public function handleRetries(
+        RespondedRequest $respondedRequest,
+        Closure $retryCallback,
+        ?LoggerInterface $logger = null
+    ): RespondedRequest {
+        $logger?->warning(
+            'Request to ' . $respondedRequest->requestedUri() . ' returned 429 - Too Many Requests.'
+        );
+
+        $retries = 0;
+
+        $this->wait[0] = $this->getWaitTimeFromResponse($respondedRequest->response, $logger) ?? $this->wait[0];
+
+        while ($retries < $this->retries) {
+            $logger?->warning('Will wait for ' . $this->wait[$retries] . ' seconds and then retry');
+
+            sleep($this->wait[$retries]);
+
+            $respondedRequest = $retryCallback();
+
+            if ($respondedRequest instanceof RespondedRequest && $respondedRequest->response->getStatusCode() !== 429) {
+                return $respondedRequest;
+            } else {
+                $logger?->warning('Retry received a 429 response again');
+            }
+
+            $retries++;
+        }
+
+        $logger?->error('Stop crawling');
+
+        return throw new LoadingException('Stopped crawling because server responds with 429 - Too Many Requests');
+    }
+
+    protected function getWaitTimeFromResponse(ResponseInterface $response, ?LoggerInterface $logger = null): ?int
+    {
+        $retryAfterHeader = $response->getHeader('Retry-After');
+
+        if (!empty($retryAfterHeader)) {
+            $retryAfterHeader = reset($retryAfterHeader);
+
+            if (is_numeric($retryAfterHeader)) {
+                $waitFor = (int) $retryAfterHeader;
+
+                if ($waitFor > $this->maxWait) {
+                    $message = 'Retry-After header in 429 (Too Many Requests) response, requires to wait longer ' .
+                        'than the defined max wait time for this case. If you want to increase this limit, set it ' .
+                        'in the TooManyRequestsHandler of your HttpLoader instance.';
+
+                    $logger?->error($message);
+
+                    throw new LoadingException($message);
+                }
+
+                return (int) $retryAfterHeader;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Loader/Http/HttpLoaderTest.php
+++ b/tests/Loader/Http/HttpLoaderTest.php
@@ -193,14 +193,14 @@ test('It calls request start and end tracking methods', function (string $loadin
     $throttler = new class () extends Throttler {
         public function trackRequestStartFor(UriInterface $url): void
         {
-            $this->logger?->info('Track request start ' . $url);
+            echo 'Track request start ' . $url . PHP_EOL;
 
             parent::trackRequestStartFor($url);
         }
 
         public function trackRequestEndFor(UriInterface $url): void
         {
-            $this->logger?->info('Track request end ' . $url);
+            echo 'Track request end ' . $url . PHP_EOL;
 
             parent::trackRequestEndFor($url);
         }

--- a/tests/_Integration/Http/HeadlessBrowserTest.php
+++ b/tests/_Integration/Http/HeadlessBrowserTest.php
@@ -3,7 +3,6 @@
 namespace tests\_Integration\Http;
 
 use Crwlr\Crawler\HttpCrawler;
-use Crwlr\Crawler\Loader\Http\HttpLoader;
 use Crwlr\Crawler\Loader\LoaderInterface;
 use Crwlr\Crawler\Steps\Html;
 use Crwlr\Crawler\Steps\Loading\Http;

--- a/tests/_Integration/Http/TooManyRequestsTest.php
+++ b/tests/_Integration/Http/TooManyRequestsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace tests\_Integration\Http;
+
+use Crwlr\Crawler\HttpCrawler;
+use Crwlr\Crawler\Loader\Http\HttpLoader;
+use Crwlr\Crawler\Loader\Http\Politeness\TooManyRequestsHandler;
+use Crwlr\Crawler\Loader\LoaderInterface;
+use Crwlr\Crawler\Steps\Loading\Http;
+use Crwlr\Crawler\UserAgents\UserAgent;
+use Crwlr\Crawler\UserAgents\UserAgentInterface;
+use Psr\Log\LoggerInterface;
+
+use function tests\helper_generatorToArray;
+
+class TooManyRequestsCrawler extends HttpCrawler
+{
+    protected function userAgent(): UserAgentInterface
+    {
+        return new UserAgent('SomeBot');
+    }
+
+    public function loader(UserAgentInterface $userAgent, LoggerInterface $logger): LoaderInterface
+    {
+        return new HttpLoader(
+            $userAgent,
+            logger: $logger,
+            tooManyRequestsHandler: new TooManyRequestsHandler(2, [1, 2], 3),
+        );
+    }
+}
+
+it('retries after defined number of seconds', function () {
+    $crawler = new TooManyRequestsCrawler();
+
+    $crawler->input('http://localhost:8000/too-many-requests')
+        ->addStep(Http::get());
+
+    $start = microtime(true);
+
+    helper_generatorToArray($crawler->run());
+
+    $end = microtime(true);
+
+    $diff = $end - $start;
+
+    expect($diff)->toBeGreaterThan(3.0);
+
+    expect($diff)->toBeLessThan(3.5);
+});
+
+it('starts the first retry after the number of seconds returned in the Retry-After HTTP header', function () {
+    $crawler = new TooManyRequestsCrawler();
+
+    $crawler->input('http://localhost:8000/too-many-requests/retry-after')
+        ->addStep(Http::get());
+
+    $start = microtime(true);
+
+    helper_generatorToArray($crawler->run());
+
+    $end = microtime(true);
+
+    $diff = $end - $start;
+
+    expect($diff)->toBeGreaterThan(4.0);
+
+    expect($diff)->toBeLessThan(4.5);
+});
+
+it('goes on crawling when a retry receives a successful response', function () {
+    $crawler = new TooManyRequestsCrawler();
+
+    $crawler->input('http://localhost:8000/too-many-requests/succeed-on-second-attempt')
+        ->addStep(Http::get());
+
+    $start = microtime(true);
+
+    $results = helper_generatorToArray($crawler->run());
+
+    $end = microtime(true);
+
+    $diff = $end - $start;
+
+    expect($results)->toHaveCount(1);
+
+    expect($diff)->toBeGreaterThan(1.0);
+
+    expect($diff)->toBeLessThan(1.5);
+});

--- a/tests/_Integration/Server.php
+++ b/tests/_Integration/Server.php
@@ -56,3 +56,19 @@ if ($route === '/print-cookie') {
 if (str_starts_with($route, '/crawling/')) {
     return include(__DIR__ . '/_Server/Crawling.php');
 }
+
+if (str_starts_with($route, '/too-many-requests')) {
+    if (str_ends_with($route, '/succeed-on-second-attempt')) {
+        session_start();
+
+        $isSecondRequest = isset($_SESSION["isSecondRequest"]) && $_SESSION["isSecondRequest"] === true;
+
+        if (!$isSecondRequest) {
+            $_SESSION["isSecondRequest"] = true;
+        }
+    }
+
+    $retryAfter = str_ends_with($route, '/retry-after') ? 2 : null;
+
+    return include(__DIR__ . '/_Server/TooManyRequests.php');
+}

--- a/tests/_Integration/_Server/TooManyRequests.php
+++ b/tests/_Integration/_Server/TooManyRequests.php
@@ -1,0 +1,9 @@
+<?php
+
+if (!isset($isSecondRequest) || $isSecondRequest !== true) {
+    http_response_code(429);
+}
+
+if (isset($retryAfter)) {
+    header('Retry-After: ' . $retryAfter);
+}


### PR DESCRIPTION
In case of a 429 (Too Many Requests) response, the `HttpLoader` now automatically waits and retries. By default, it retries twice and waits 10 seconds for the first retry and a minute for the second one. In case the response also contains a `Retry-After` header with a value in seconds, it complies to that. Exception: by default it waits at max `60` seconds (you can set your own limit if you want), if the `Retry-After` value is higher, it will stop crawling. If all the retries also receive a `429` it also throws an Exception and therefor stops crawling.

Besides that also fixed handling cookies for localhost or other hosts without a registrable domain name. And also removed the logger from the Throttler, as it doesn't log anything.