### PR TITLE
Controll what to do in case of error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+* New methods `stopOnErrorResponse()` and `yieldErrorResponses()` that can be used with `Http` steps. By calling `stopOnErrorResponse()` the step will throw a `LoadingException` when a response has a 4xx or 5xx status code. By calling the `yieldErrorResponse()` even error responses will be yielded and passed on to the next steps (this was default behaviour until this version. See the breaking change below).
+
 ### Changed
+* __BREAKING__: Error responses (4xx as well as 5xx), by default, won't produce any step outputs any longer. If you want to receive error responses, use the new `yieldErrorResponses()` method.
 * In case of a 429 (Too Many Requests) response, the `HttpLoader` now automatically waits and retries. By default, it retries twice and waits 10 seconds for the first retry and a minute for the second one. In case the response also contains a `Retry-After` header with a value in seconds, it complies to that. Exception: by default it waits at max `60` seconds (you can set your own limit if you want), if the `Retry-After` value is higher, it will stop crawling. If all the retries also receive a `429` it also throws an Exception.
 * Removed logger from `Throttler` as it doesn't log anything.
 

--- a/tests/_Integration/Http/ErrorResponsesTest.php
+++ b/tests/_Integration/Http/ErrorResponsesTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace tests\_Integration\Http;
+
+use Crwlr\Crawler\HttpCrawler;
+use Crwlr\Crawler\Loader\Http\Exceptions\LoadingException;
+use Crwlr\Crawler\Loader\LoaderInterface;
+use Crwlr\Crawler\Steps\Loading\Http;
+use Crwlr\Crawler\UserAgents\UserAgent;
+use Crwlr\Crawler\UserAgents\UserAgentInterface;
+use Psr\Log\LoggerInterface;
+
+use function tests\helper_generatorToArray;
+use function tests\helper_getFastLoader;
+
+class ErrorCrawler extends HttpCrawler
+{
+    protected function userAgent(): UserAgentInterface
+    {
+        return new UserAgent('SomeBot');
+    }
+
+    public function loader(UserAgentInterface $userAgent, LoggerInterface $logger): LoaderInterface
+    {
+        return helper_getFastLoader($userAgent, $logger);
+    }
+}
+
+it('does not yield client error responses by default', function (string $method) {
+    $crawler = new ErrorCrawler();
+
+    $crawler->inputs(['http://localhost:8000/client-error-response'])
+        ->addStep('response', Http::{$method}());
+
+    $results = helper_generatorToArray($crawler->run());
+
+    expect($results)->toBeEmpty();
+})->with(['get', 'post', 'put', 'patch', 'delete']);
+
+it('does not yield server error responses by default', function (string $method) {
+    $crawler = new ErrorCrawler();
+
+    $crawler->inputs(['http://localhost:8000/server-error-response'])
+        ->addStep('response', Http::{$method}());
+
+    $results = helper_generatorToArray($crawler->run());
+
+    expect($results)->toBeEmpty();
+})->with(['get', 'post', 'put', 'patch', 'delete']);
+
+it('yields client error responses when yieldErrorResponses() was called', function (string $method) {
+    $crawler = new ErrorCrawler();
+
+    $crawler->inputs(['http://localhost:8000/client-error-response'])
+        ->addStep('response', Http::{$method}()->yieldErrorResponses());
+
+    $results = helper_generatorToArray($crawler->run());
+
+    expect($results)->toHaveCount(1);
+})->with(['get', 'post', 'put', 'patch', 'delete']);
+
+it('yields server error responses when yieldErrorResponses() was called', function (string $method) {
+    $crawler = new ErrorCrawler();
+
+    $crawler->inputs(['http://localhost:8000/server-error-response'])
+        ->addStep('response', Http::{$method}()->yieldErrorResponses());
+
+    $results = helper_generatorToArray($crawler->run());
+
+    expect($results)->toHaveCount(1);
+})->with(['get', 'post', 'put', 'patch', 'delete']);
+
+it(
+    'goes on crawling after a client error response when stopOnErrorResponse() wasn\'t called',
+    function (string $method) {
+        $crawler = new ErrorCrawler();
+
+        $crawler->inputs(['http://localhost:8000/client-error-response', 'http://localhost:8000/simple-listing'])
+            ->addStep('response', Http::{$method}());
+
+        $results = helper_generatorToArray($crawler->run());
+
+        expect($results)->toHaveCount(1);
+    }
+)->with(['get', 'post', 'put', 'patch', 'delete']);
+
+it(
+    'goes on crawling after a server error response when stopOnErrorResponse() wasn\'t called',
+    function (string $method) {
+        $crawler = new ErrorCrawler();
+
+        $crawler->inputs(['http://localhost:8000/server-error-response', 'http://localhost:8000/simple-listing'])
+            ->addStep('response', Http::{$method}());
+
+        $results = helper_generatorToArray($crawler->run());
+
+        expect($results)->toHaveCount(1);
+    }
+)->with(['get', 'post', 'put', 'patch', 'delete']);
+
+it(
+    'stops crawling (throws exception) after a client error response when the stopOnErrorResponse() method was called',
+    function (string $method) {
+        $crawler = new ErrorCrawler();
+
+        $crawler->inputs(['http://localhost:8000/client-error-response', 'http://localhost:8000/simple-listing'])
+            ->addStep(
+                Http::{$method}()
+                    ->stopOnErrorResponse()
+            );
+
+        $crawler->runAndTraverse();
+    }
+)->with(['get', 'post', 'put', 'patch', 'delete'])->throws(LoadingException::class);
+
+it(
+    'stops crawling (throws exception) after a server error response when the stopOnErrorResponse() method was called',
+    function (string $method) {
+        $crawler = new ErrorCrawler();
+
+        $crawler->inputs(['http://localhost:8000/client-error-response', 'http://localhost:8000/simple-listing'])
+            ->addStep(
+                Http::{$method}()
+                    ->stopOnErrorResponse()
+            );
+
+        $crawler->runAndTraverse();
+    }
+)->with(['get', 'post', 'put', 'patch', 'delete'])->throws(LoadingException::class);

--- a/tests/_Integration/Server.php
+++ b/tests/_Integration/Server.php
@@ -72,3 +72,19 @@ if (str_starts_with($route, '/too-many-requests')) {
 
     return include(__DIR__ . '/_Server/TooManyRequests.php');
 }
+
+if (str_starts_with($route, '/client-error-response')) {
+    $responseCodes = [400, 401, 404, 405, 410];
+
+    http_response_code($responseCodes[rand(0, 4)]);
+
+    return;
+}
+
+if (str_starts_with($route, '/server-error-response')) {
+    $responseCodes = [500, 502, 503, 505, 521];
+
+    http_response_code($responseCodes[rand(0, 4)]);
+
+    return;
+}


### PR DESCRIPTION
New methods `stopOnErrorResponse()` and `yieldErrorResponses()` that can be used with `Http` steps. By calling `stopOnErrorResponse()` the step will throw a `LoadingException` when a response has a 4xx or 5xx status code. By calling the `yieldErrorResponse()` even error responses will be yielded and passed on to the next steps.

The latter actually was the default behavior until now, but I think most people would either like to just ignore error responses or the whole crawler to fail/stop, so I changed this.