### PR TITLE
Add JsonFileStore feature

### DIFF
--- a/src/Stores/JsonFileStore.php
+++ b/src/Stores/JsonFileStore.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Crwlr\Crawler\Stores;
+
+use Crwlr\Crawler\Result;
+use Exception;
+
+class JsonFileStore extends Store
+{
+    private int $createTimestamp;
+
+    private bool $isFirstResult = true;
+
+    public function __construct(private readonly string $storePath, private readonly ?string $filePrefix = null)
+    {
+        $this->createTimestamp = time();
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function store(Result $result): void
+    {
+        $resultArray = $result->toArray();
+        if (!$this->isFirstResult) {
+            $currentFile = file_get_contents($this->filePath());
+            $tempArray = json_decode($currentFile, true);
+            array_push($tempArray, $resultArray);
+            $resultArray = $tempArray;
+        } else {
+            $this->isFirstResult = false;
+        }
+        file_put_contents($this->filePath(), json_encode([$resultArray]));
+    }
+
+    public function filePath(): string
+    {
+        return $this->storePath . '/' .
+          ($this->filePrefix ? $this->filePrefix . '-' : '') . $this->createTimestamp . '.json';
+    }
+}

--- a/tests/Stores/JsonFileStoreTest.php
+++ b/tests/Stores/JsonFileStoreTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace tests\Stores;
+
+use Crwlr\Crawler\Result;
+use Crwlr\Crawler\Stores\JsonFileStore;
+
+/**
+ * @param mixed[] $data
+ */
+function helper_getResultWithJsonData(array $data): Result
+{
+    $result = new Result();
+
+    foreach ($data as $key => $value) {
+        $result->set($key, $value);
+    }
+
+    return $result;
+}
+
+beforeAll(function () {
+    if (!file_exists(__DIR__ . '/_files')) {
+        mkdir(__DIR__ . '/_files');
+    }
+});
+
+it('saves Results to a JSON file', function () {
+    $result1 = helper_getResultWithJsonData(['user' => 'otsch', 'firstname' => 'Christian', 'surname' => 'Olear']);
+
+    $store = new JsonFileStore(__DIR__ . '/_files', 'test');
+
+    $store->store($result1);
+
+    expect(file_get_contents($store->filePath()))->toBe('[{"user":"otsch","firstname":"Christian","surname":"Olear"}]');
+
+    $result2 = helper_getResultWithJsonData(['user' => 'hader', 'firstname' => 'Josef', 'surname' => 'Hader']);
+
+    $store->store($result2);
+
+    expect(file_get_contents($store->filePath()))->toBe(
+        '[[{"user":"otsch","firstname":"Christian","surname":"Olear"},{"user":"hader","firstname":"Josef","surname":"Hader"}]]'
+    );
+
+    $result3 = helper_getResultWithJsonData(['user' => 'evamm', 'firstname' => 'Eva Maria', 'surname' => 'Maier']);
+
+    $store->store($result3);
+
+    expect(file_get_contents($store->filePath()))->toBe(
+        '[[[{"user":"otsch","firstname":"Christian","surname":"Olear"},{"user":"hader","firstname":"Josef","surname":"Hader"}],{"user":"evamm","firstname":"Eva Maria","surname":"Maier"}]]'
+    );
+});
+
+afterAll(function () {
+    $dir = __DIR__ . '/_files';
+
+    if (file_exists($dir)) {
+        $files = scandir($dir);
+
+        if (is_array($files)) {
+            foreach ($files as $file) {
+                if ($file === '.' || $file === '..') {
+                    continue;
+                }
+
+                unlink($dir . '/' . $file);
+            }
+        }
+
+        rmdir(__DIR__ . '/_files');
+    }
+});

--- a/tests/Stores/JsonFileStoreTest.php
+++ b/tests/Stores/JsonFileStoreTest.php
@@ -19,12 +19,6 @@ function helper_getResultWithJsonData(array $data): Result
     return $result;
 }
 
-beforeAll(function () {
-    if (!file_exists(__DIR__ . '/_files')) {
-        mkdir(__DIR__ . '/_files');
-    }
-});
-
 it('saves Results to a JSON file', function () {
     $result1 = helper_getResultWithJsonData(['user' => 'otsch', 'firstname' => 'Christian', 'surname' => 'Olear']);
 
@@ -39,7 +33,8 @@ it('saves Results to a JSON file', function () {
     $store->store($result2);
 
     expect(file_get_contents($store->filePath()))->toBe(
-        '[[{"user":"otsch","firstname":"Christian","surname":"Olear"},{"user":"hader","firstname":"Josef","surname":"Hader"}]]'
+        '[{"user":"otsch","firstname":"Christian","surname":"Olear"},' .
+        '{"user":"hader","firstname":"Josef","surname":"Hader"}]'
     );
 
     $result3 = helper_getResultWithJsonData(['user' => 'evamm', 'firstname' => 'Eva Maria', 'surname' => 'Maier']);
@@ -47,7 +42,9 @@ it('saves Results to a JSON file', function () {
     $store->store($result3);
 
     expect(file_get_contents($store->filePath()))->toBe(
-        '[[[{"user":"otsch","firstname":"Christian","surname":"Olear"},{"user":"hader","firstname":"Josef","surname":"Hader"}],{"user":"evamm","firstname":"Eva Maria","surname":"Maier"}]]'
+        '[{"user":"otsch","firstname":"Christian","surname":"Olear"},' .
+        '{"user":"hader","firstname":"Josef","surname":"Hader"},' .
+        '{"user":"evamm","firstname":"Eva Maria","surname":"Maier"}]'
     );
 });
 
@@ -59,14 +56,12 @@ afterAll(function () {
 
         if (is_array($files)) {
             foreach ($files as $file) {
-                if ($file === '.' || $file === '..') {
+                if ($file === '.' || $file === '..' || !str_ends_with($file, '.json')) {
                     continue;
                 }
 
-                unlink($dir . '/' . $file);
+                @unlink($dir . '/' . $file);
             }
         }
-
-        rmdir(__DIR__ . '/_files');
     }
 });

--- a/tests/Stores/SimpleCsvFileStoreTest.php
+++ b/tests/Stores/SimpleCsvFileStoreTest.php
@@ -19,12 +19,6 @@ function helper_getResultWithData(array $data): Result
     return $result;
 }
 
-beforeAll(function () {
-    if (!file_exists(__DIR__ . '/_files')) {
-        mkdir(__DIR__ . '/_files');
-    }
-});
-
 it('saves Results to a csv file', function () {
     $result1 = helper_getResultWithData(['user' => 'otsch', 'firstname' => 'Christian', 'surname' => 'Olear']);
 
@@ -77,14 +71,12 @@ afterAll(function () {
 
         if (is_array($files)) {
             foreach ($files as $file) {
-                if ($file === '.' || $file === '..') {
+                if ($file === '.' || $file === '..' || !str_ends_with($file, '.csv')) {
                     continue;
                 }
 
                 unlink($dir . '/' . $file);
             }
         }
-
-        rmdir(__DIR__ . '/_files');
     }
 });


### PR DESCRIPTION
I found your great project during #hacktoberfest and gave it a spin. I noticed that there is currently only an option for saving results as CSV and thought having the option for saving to a JSON file would be a nice addition to your project.

Usage is fairly simple, instead of adding the CSV Store to your crawler just add the new store instead:

`$crawler->setStore(new JsonFileStore(YOUR_STORE_PATH));`