### PR TITLE
New functionality to paginate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+* New functionality to paginate: There is the new `Paginate` child class of the `Http` step class (easy access via `Http::get()->paginate()`). It takes an instance of the `PaginatorInterface` and uses it to iterate through pagination links. There is one implementation of that interface, the `SimpleWebsitePaginator`. The `Http::get()->paginate()` method uses it by default, when called just with a CSS selector to get pagination links. Paginators receive all loaded pages and implement the logic to find pagination links. The paginator class is also called before sending a request, with the request object that is about to be sent as an argument (`prepareRequest()`). This way, it should even be doable to implement more complex pagination functionality. For example when pagination is built using POST request with query strings in the request body.
 * New methods `stopOnErrorResponse()` and `yieldErrorResponses()` that can be used with `Http` steps. By calling `stopOnErrorResponse()` the step will throw a `LoadingException` when a response has a 4xx or 5xx status code. By calling the `yieldErrorResponse()` even error responses will be yielded and passed on to the next steps (this was default behaviour until this version. See the breaking change below).
 
 ### Changed

--- a/src/Steps/Loading/Http/Paginate.php
+++ b/src/Steps/Loading/Http/Paginate.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading\Http;
+
+use Crwlr\Crawler\Steps\Loading\Http;
+use Crwlr\Url\Url;
+use Generator;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+
+class Paginate extends Http
+{
+    public function __construct(
+        protected Http\PaginatorInterface $paginator,
+        string $method = 'GET',
+        array $headers = [],
+        string|StreamInterface|null $body = null,
+        string $httpVersion = '1.1',
+    ) {
+        parent::__construct($method, $headers, $body, $httpVersion);
+    }
+
+    /**
+     * @param UriInterface $input
+     */
+    protected function invoke(mixed $input): Generator
+    {
+        $request = $this->paginator->prepareRequest($this->getRequestFromInputUri($input));
+
+        $response = $this->getResponseFromRequest($request);
+
+        if ($response) {
+            yield $response;
+        }
+
+        $this->paginator->processLoaded($input, $request, $response);
+
+        while (!$this->paginator->hasFinished()) {
+            $nextUrl = $this->paginator->getNextUrl();
+
+            if (!$nextUrl) {
+                break;
+            }
+
+            $nextUrl = Url::parsePsr7($nextUrl);
+
+            $request = $this->paginator->prepareRequest($this->getRequestFromInputUri($nextUrl), $response);
+
+            $response = $this->getResponseFromRequest($request);
+
+            if ($response) {
+                yield $response;
+            }
+
+            $this->paginator->processLoaded($nextUrl, $request, $response);
+        }
+
+        if ($this->logger) {
+            $this->paginator->logWhenFinished($this->logger);
+        }
+    }
+}

--- a/src/Steps/Loading/Http/Paginator.php
+++ b/src/Steps/Loading/Http/Paginator.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading\Http;
+
+use Crwlr\Crawler\Steps\Html\DomQueryInterface;
+use Crwlr\Crawler\Steps\Loading\Http\Paginators\SimpleWebsitePaginator;
+
+class Paginator
+{
+    public const MAX_PAGES_DEFAULT = 1000;
+
+    public static function simpleWebsite(
+        string|DomQueryInterface $paginationLinksSelector,
+        int $maxPages = self::MAX_PAGES_DEFAULT,
+    ): SimpleWebsitePaginator {
+        return new SimpleWebsitePaginator($paginationLinksSelector, $maxPages);
+    }
+}

--- a/src/Steps/Loading/Http/PaginatorInterface.php
+++ b/src/Steps/Loading/Http/PaginatorInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading\Http;
+
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
+use Psr\Log\LoggerInterface;
+
+interface PaginatorInterface
+{
+    public function hasFinished(): bool;
+
+    public function getNextUrl(): ?string;
+
+    public function prepareRequest(
+        RequestInterface $request,
+        ?RespondedRequest $previousResponse = null
+    ): RequestInterface;
+
+    public function processLoaded(
+        UriInterface $url,
+        RequestInterface $request,
+        ?RespondedRequest $respondedRequest,
+    ): void;
+
+    public function logWhenFinished(LoggerInterface $logger): void;
+}

--- a/src/Steps/Loading/Http/Paginators/AbstractPaginator.php
+++ b/src/Steps/Loading/Http/Paginators/AbstractPaginator.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading\Http\Paginators;
+
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Loading\Http\Paginator;
+use Crwlr\Crawler\Steps\Loading\Http\PaginatorInterface;
+use Psr\Http\Message\RequestInterface;
+
+abstract class AbstractPaginator implements PaginatorInterface
+{
+    public function __construct(protected int $maxPages = Paginator::MAX_PAGES_DEFAULT)
+    {
+    }
+
+    public function prepareRequest(
+        RequestInterface $request,
+        ?RespondedRequest $previousResponse = null,
+    ): RequestInterface {
+        return $request;
+    }
+}

--- a/src/Steps/Loading/Http/Paginators/SimpleWebsitePaginator.php
+++ b/src/Steps/Loading/Http/Paginators/SimpleWebsitePaginator.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading\Http\Paginators;
+
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Dom;
+use Crwlr\Crawler\Steps\Html\DomQuery;
+use Crwlr\Crawler\Steps\Html\DomQueryInterface;
+use Crwlr\Crawler\Steps\Loading\Http;
+use Crwlr\Url\Url;
+use Exception;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DomCrawler\Crawler;
+
+class SimpleWebsitePaginator extends AbstractPaginator
+{
+    /**
+     * @var array<string, string>
+     */
+    protected array $found = [];
+
+    /**
+     * @var array<string, true>
+     */
+    protected array $loaded = [];
+
+    protected int $loadedPagesCount = 0;
+
+    protected DomQueryInterface $paginationLinksSelector;
+
+    public function __construct(string|DomQueryInterface $paginationLinksSelector, int $maxPages = 1000)
+    {
+        if (is_string($paginationLinksSelector)) {
+            $this->paginationLinksSelector = Dom::cssSelector($paginationLinksSelector);
+        } else {
+            $this->paginationLinksSelector = $paginationLinksSelector;
+        }
+
+        parent::__construct($maxPages);
+    }
+
+    public function hasFinished(): bool
+    {
+        return $this->loadedPagesCount >= $this->maxPages || empty($this->found);
+    }
+
+    public function getNextUrl(): ?string
+    {
+        return array_shift($this->found);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function processLoaded(
+        UriInterface $url,
+        RequestInterface $request,
+        ?RespondedRequest $respondedRequest,
+    ): void {
+        $this->loaded[$url->__toString()] = true;
+
+        $this->loadedPagesCount++;
+
+        if ($respondedRequest) {
+            foreach ($respondedRequest->redirects() as $redirectUrl) {
+                $this->loaded[$redirectUrl] = true;
+            }
+
+            $this->getPaginationLinksFromResponse($respondedRequest);
+        }
+    }
+
+    public function logWhenFinished(LoggerInterface $logger): void
+    {
+        if ($this->loadedPagesCount >= $this->maxPages && !empty($this->found)) {
+            $logger->warning('Max pages limit reached');
+        } else {
+            $logger->info('All found pagination links loaded');
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function getPaginationLinksFromResponse(RespondedRequest $respondedRequest): void
+    {
+        $responseBody = Http::getBodyString($respondedRequest);
+
+        $dom = new Crawler($responseBody);
+
+        $paginationLinksElements = $this->paginationLinksSelector->filter($dom);
+
+        foreach ($paginationLinksElements as $paginationLinksElement) {
+            $paginationLinksElement = new Crawler($paginationLinksElement);
+
+            $this->addFoundUrlFromLinkElement(
+                $paginationLinksElement,
+                $dom,
+                $respondedRequest->effectiveUri(),
+            );
+
+            foreach ($paginationLinksElement->filter('a') as $linkInPaginationLinksElement) {
+                $linkInPaginationLinksElement = new Crawler($linkInPaginationLinksElement);
+
+                $this->addFoundUrlFromLinkElement(
+                    $linkInPaginationLinksElement,
+                    $dom,
+                    $respondedRequest->effectiveUri(),
+                );
+            }
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function addFoundUrlFromLinkElement(
+        Crawler $linkElement,
+        Crawler $document,
+        string $documentUrl,
+    ): void {
+        if ($this->isRelevantLinkElement($linkElement)) {
+            $url = $this->getAbsoluteUrlFromLinkElement($linkElement, $document, $documentUrl);
+
+            $this->addFoundUrl($url);
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function getAbsoluteUrlFromLinkElement(
+        Crawler $linkElement,
+        Crawler $document,
+        string $documentUrl,
+    ): string {
+        $baseUrl = Url::parse($documentUrl);
+
+        $baseHref = DomQuery::getBaseHrefFromDocument($document);
+
+        if ($baseHref) {
+            $baseUrl = $baseUrl->resolve($baseHref);
+        }
+
+        $linkHref = $linkElement->attr('href') ?? '';
+
+        return $baseUrl->resolve($linkHref)->__toString();
+    }
+
+    protected function isRelevantLinkElement(Crawler $element): bool
+    {
+        if ($element->nodeName() !== 'a') {
+            return false;
+        }
+
+        $href = $element->attr('href');
+
+        return !empty($href) && !str_starts_with($href, '#');
+    }
+
+    protected function addFoundUrl(string $url): void
+    {
+        if (!isset($this->found[$url]) && !isset($this->loaded[$url])) {
+            $this->found[$url] = $url;
+        }
+    }
+}

--- a/src/Steps/Loading/HttpCrawl.php
+++ b/src/Steps/Loading/HttpCrawl.php
@@ -160,11 +160,11 @@ class HttpCrawl extends Http
         foreach ($this->urls as $url => $yieldResponse) {
             $uri = Url::parsePsr7($url);
 
-            $response = $this->loader->load($this->getRequestFromInputUri($uri));
-
-            $this->addLoadedUrlsFromResponse($response);
+            $response = $this->getResponseFromInputUri($uri);
 
             if ($response !== null) {
+                $this->addLoadedUrlsFromResponse($response);
+
                 if ($yieldResponse['yield'] === true) {
                     yield $response;
                 }

--- a/tests/Steps/Loading/GetSitemapsFromRobotsTxtTest.php
+++ b/tests/Steps/Loading/GetSitemapsFromRobotsTxtTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Crwlr\Crawler\Steps\Loading;
+namespace tests\Steps\Loading;
 
 use Crwlr\Crawler\Input;
 use Crwlr\Crawler\Loader\Http\HttpLoader;
@@ -20,10 +20,10 @@ it('gets all the sitemaps listed in the robots.txt file on a host, based on some
     $robotsTxt = <<<ROBOTSTXT
         User-agent: *
         Disallow:
-        
+
         Sitemap: https://www.crwlr.software/sitemap.xml
         Sitemap: https://www.crwlr.software/sitemap2.xml
-        
+
         Sitemap: https://www.crwlr.software/sitemap3.xml
         ROBOTSTXT;
 

--- a/tests/Steps/Loading/Http/Paginators/SimpleWebsitePaginatorTest.php
+++ b/tests/Steps/Loading/Http/Paginators/SimpleWebsitePaginatorTest.php
@@ -1,0 +1,254 @@
+<?php
+
+namespace tests\Steps\Loading\Http\Paginators;
+
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Logger\CliLogger;
+use Crwlr\Crawler\Steps\Loading\Http\Paginators\SimpleWebsitePaginator;
+use Crwlr\Url\Url;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
+use PHPUnit\Framework\TestCase;
+
+function helper_getRespondedRequestWithResponseBody(string $urlPath, string $body): RespondedRequest
+{
+    return new RespondedRequest(
+        new Request('GET', 'https://www.example.com' . $urlPath),
+        new Response(200, body: Utils::streamFor($body)),
+    );
+}
+
+/**
+ * @param array<string, string> $links
+ */
+function helper_createResponseBodyWithPaginationLinks(array $links): string
+{
+    $body = '<div class="pagination">';
+
+    foreach ($links as $url => $text) {
+        $body .= '<a href="' . $url .'">' . $text . '</a> ' . PHP_EOL;
+    }
+
+    return $body . '</div>';
+}
+
+/** @var TestCase $this */
+
+it('says it has finished when no initial response was provided yet', function () {
+    $paginator = new SimpleWebsitePaginator('.pagination');
+
+    expect($paginator->hasFinished())->toBeTrue();
+});
+
+it('says it has finished when a response is provided, but it has no pagination links', function () {
+    $paginator = new SimpleWebsitePaginator('.pagination', 3);
+
+    $respondedRequest = helper_getRespondedRequestWithResponseBody('listing', '<div class="listing"></div>');
+
+    $paginator->processLoaded(
+        $respondedRequest->request->getUri(),
+        $respondedRequest->request,
+        $respondedRequest,
+    );
+
+    expect($paginator->hasFinished())->toBeTrue();
+});
+
+it('says it has not finished when an initial response with pagination links is provided', function () {
+    $paginator = new SimpleWebsitePaginator('.pagination', 3);
+
+    $responseBody = helper_createResponseBodyWithPaginationLinks([
+        '/listing?page=1' => 'First page',
+        '/listing?page=2' => 'Next page',
+        '/listing?page12' => 'Last page',
+    ]);
+
+    $respondedRequest = helper_getRespondedRequestWithResponseBody('/listing', $responseBody);
+
+    $paginator->processLoaded(
+        Url::parsePsr7('https://www.example.com/listing'),
+        $respondedRequest->request,
+        $respondedRequest,
+    );
+});
+
+it('has finished when the loaded pages count exceeds the max pages limit', function () {
+    $paginator = new SimpleWebsitePaginator('.pagination', 3);
+
+    $responseBody = helper_createResponseBodyWithPaginationLinks([
+        '/listing?page=1' => 'First page',
+        '/listing?page=2' => 'Next page',
+        '/listing?page12' => 'Last page',
+    ]);
+
+    $respondedRequest = helper_getRespondedRequestWithResponseBody('/listing', $responseBody);
+
+    $paginator->processLoaded(
+        Url::parsePsr7('https://www.example.com/listing'),
+        $respondedRequest->request,
+        $respondedRequest,
+    );
+
+    expect($paginator->hasFinished())->toBeFalse();
+
+    $respondedRequest = helper_getRespondedRequestWithResponseBody('/listing?page=1', $responseBody);
+
+    $paginator->processLoaded(
+        Url::parsePsr7('https://www.example.com/listing?page=1'),
+        $respondedRequest->request,
+        $respondedRequest,
+    );
+
+    expect($paginator->hasFinished())->toBeFalse();
+
+    $responseBody = helper_createResponseBodyWithPaginationLinks([
+        '/listing?page=1' => 'First page',
+        '/listing?page=3' => 'Next page',
+        '/listing?page12' => 'Last page',
+    ]);
+
+    $respondedRequest = helper_getRespondedRequestWithResponseBody('/listing?page=2', $responseBody);
+
+    $paginator->processLoaded(
+        Url::parsePsr7('https://www.example.com/listing?page=2'),
+        $respondedRequest->request,
+        $respondedRequest,
+    );
+
+    expect($paginator->hasFinished())->toBeTrue();
+});
+
+it('says it has finished when there are no more found pagination links, that haven\'t been loaded yet', function () {
+    $paginator = new SimpleWebsitePaginator('.pagination', 3);
+
+    $responseBody = helper_createResponseBodyWithPaginationLinks(['/listing?page=2' => 'Page Two']);
+
+    $respondedRequest = helper_getRespondedRequestWithResponseBody('/listing?page=1', $responseBody);
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    expect($paginator->hasFinished())->toBeFalse();
+
+    $paginator->getNextUrl();
+
+    $responseBody = helper_createResponseBodyWithPaginationLinks(['/listing?page=2' => 'Page Two']);
+
+    $respondedRequest = helper_getRespondedRequestWithResponseBody('/listing?page=2', $responseBody);
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    expect($paginator->hasFinished())->toBeTrue();
+});
+
+it('finds pagination links when the selector matches the link itself', function () {
+    $paginator = new SimpleWebsitePaginator('.nextPageLink', 3);
+
+    $responseBody = '<a class="nextPageLink" href="/listing?page=2">Next Page</a>';
+
+    $respondedRequest = helper_getRespondedRequestWithResponseBody('/listing?page=1', $responseBody);
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    expect($paginator->getNextUrl())->toBe('https://www.example.com/listing?page=2');
+});
+
+it('finds pagination links when the selected element is a wrapper for pagination links', function () {
+    $paginator = new SimpleWebsitePaginator('.pagination', 3);
+
+    $responseBody = '<div class="pagination"><a href="/listing?page=2">Next Page</a></div>';
+
+    $respondedRequest = helper_getRespondedRequestWithResponseBody('/listing?page=1', $responseBody);
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    expect($paginator->getNextUrl())->toBe('https://www.example.com/listing?page=2');
+});
+
+it('finds all pagination links, when multiple elements match the pagination links selector', function () {
+    $paginator = new SimpleWebsitePaginator('.pagination', 3);
+
+    $responseBody = <<<HTML
+        <div class="pagination"><a href="/listing?page=2">Next Page</a></div>
+        <div class="pagination"><a href="/listing?page=12">Last Page</a></div>
+        HTML;
+
+    $respondedRequest = helper_getRespondedRequestWithResponseBody('/listing?page=1', $responseBody);
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    expect($paginator->getNextUrl())->toBe('https://www.example.com/listing?page=2');
+
+    expect($paginator->getNextUrl())->toBe('https://www.example.com/listing?page=12');
+});
+
+it('logs that max pages limit was reached when it was reached', function () {
+    $paginator = new SimpleWebsitePaginator('.pagination', 3);
+
+    $responseBody = <<<HTML
+        <div class="pagination">
+            <a href="/listing?page=1">Page One</a>
+            <a href="/listing?page=2">Page Two</a>
+            <a href="/listing?page=3">Page Three</a>
+            <a href="/listing?page=4">Page Four</a>
+        </div>
+        HTML;
+
+    $respondedRequest = helper_getRespondedRequestWithResponseBody('/listing?page=1', $responseBody);
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    $respondedRequest = helper_getRespondedRequestWithResponseBody('/listing?page=2', $responseBody);
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    $respondedRequest = helper_getRespondedRequestWithResponseBody('/listing?page=3', $responseBody);
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    expect($paginator->hasFinished())->toBeTrue();
+
+    $paginator->logWhenFinished(new CliLogger());
+
+    $output = $this->getActualOutput();
+
+    expect($output)->toContain('Max pages limit reached');
+});
+
+it('logs that all found pagination links have been loaded when max pages limit was not reached', function () {
+    $paginator = new SimpleWebsitePaginator('.pagination', 3);
+
+    $responseBody = <<<HTML
+        <div class="pagination">
+            <a href="/listing?page=1">Page One</a>
+            <a href="/listing?page=2">Page Two</a>
+            <a href="/listing?page=3">Page Three</a>
+        </div>
+        HTML;
+
+    $respondedRequest = helper_getRespondedRequestWithResponseBody('/listing?page=1', $responseBody);
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    $paginator->getNextUrl();
+
+    $respondedRequest = helper_getRespondedRequestWithResponseBody('/listing?page=2', $responseBody);
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    $paginator->getNextUrl();
+
+    $respondedRequest = helper_getRespondedRequestWithResponseBody('/listing?page=3', $responseBody);
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    expect($paginator->hasFinished())->toBeTrue();
+
+    $paginator->logWhenFinished(new CliLogger());
+
+    $output = $this->getActualOutput();
+
+    expect($output)->not()->toContain('Max pages limit reached');
+
+    expect($output)->toContain('All found pagination links loaded');
+});

--- a/tests/_Integration/Http/PaginationTest.php
+++ b/tests/_Integration/Http/PaginationTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace tests\_Integration\Http;
+
+use Crwlr\Crawler\HttpCrawler;
+use Crwlr\Crawler\Loader\LoaderInterface;
+use Crwlr\Crawler\Steps\Loading\Http;
+use Crwlr\Crawler\UserAgents\UserAgent;
+use Crwlr\Crawler\UserAgents\UserAgentInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+use function tests\helper_generatorToArray;
+use function tests\helper_getFastLoader;
+
+class PaginationCrawler extends HttpCrawler
+{
+    protected function userAgent(): UserAgentInterface
+    {
+        return new UserAgent('PaginationCrawler');
+    }
+
+    protected function loader(UserAgentInterface $userAgent, LoggerInterface $logger): LoaderInterface
+    {
+        return helper_getFastLoader($userAgent, $logger);
+    }
+}
+
+/** @var TestCase $this */
+
+it('iterates through pagination with the simple website paginator', function () {
+    $crawler = new PaginationCrawler();
+
+    $crawler->input('http://localhost:8000/paginated-listing')
+        ->addStep(Http::get()->paginate('#pagination'));
+
+    $results = helper_generatorToArray($crawler->run());
+
+    expect($results)->toHaveCount(5);
+});
+
+it('only iterates pagination until max pages limit is reached', function () {
+    $crawler = new PaginationCrawler();
+
+    $crawler->input('http://localhost:8000/paginated-listing')
+        ->addStep(Http::get()->paginate('#pagination', 2));
+
+    $results = helper_generatorToArray($crawler->run());
+
+    expect($results)->toHaveCount(2);
+
+    expect($this->getActualOutput())->toContain('Max pages limit reached');
+});


### PR DESCRIPTION
There is the new `Paginate` child class of the `Http` step class (easy access via `Http::get()->paginate()`). It takes an instance of the `PaginatorInterface` and uses it to iterate through pagination links. There is one implementation of that interface, the `SimpleWebsitePaginator`. The `Http::get()->paginate()` method uses it by default, when called just with a CSS selector to get pagination links. Paginators receive all loaded pages and implement the logic to find pagination links. The paginator class is also called before sending a request, with the request object that is about to be sent as an argument (`prepareRequest()`). This way, it should even be doable to implement more complex pagination functionality. For example when pagination is built using POST request with query strings in the request body.