### PR TITLE
Add default timeouts for the default guzzle client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 * __BREAKING__: Error responses (4xx as well as 5xx), by default, won't produce any step outputs any longer. If you want to receive error responses, use the new `yieldErrorResponses()` method.
+* __BREAKING__: Removed the `httpClient()` method in the `HttpCrawler` class. If you want to provide your own HTTP client, implement a custom `loader` method passing your client to the `HttpLoader` instead.
 * In case of a 429 (Too Many Requests) response, the `HttpLoader` now automatically waits and retries. By default, it retries twice and waits 10 seconds for the first retry and a minute for the second one. In case the response also contains a `Retry-After` header with a value in seconds, it complies to that. Exception: by default it waits at max `60` seconds (you can set your own limit if you want), if the `Retry-After` value is higher, it will stop crawling. If all the retries also receive a `429` it also throws an Exception.
 * Removed logger from `Throttler` as it doesn't log anything.
 * Fail silently when `robots.txt` can't be parsed.
+* Default timeout configuration for the default guzzle HTTP client: `connect_timeout` is `10` seconds and `timeout` is `60` seconds.
 
 ### Fixed
 * The `CookieJar` now also works with `localhost` or other hosts without a registered domain name.

--- a/src/HttpCrawler.php
+++ b/src/HttpCrawler.php
@@ -5,26 +5,12 @@ namespace Crwlr\Crawler;
 use Crwlr\Crawler\Loader\Http\HttpLoader;
 use Crwlr\Crawler\Loader\LoaderInterface;
 use Crwlr\Crawler\UserAgents\UserAgentInterface;
-use GuzzleHttp\Client;
-use Psr\Http\Client\ClientInterface;
 use Psr\Log\LoggerInterface;
 
 abstract class HttpCrawler extends Crawler
 {
     protected function loader(UserAgentInterface $userAgent, LoggerInterface $logger): LoaderInterface
     {
-        return new HttpLoader($userAgent, $this->httpClient(), $logger);
-    }
-
-    /**
-     * Returns the default http client.
-     * If you want to use a customized http client instance, implement the same method in the child class,
-     * returning your customized Client instance.
-     *
-     * @return ClientInterface
-     */
-    protected function httpClient(): ClientInterface
-    {
-        return new Client();
+        return new HttpLoader($userAgent, logger: $logger);
     }
 }

--- a/tests/_Integration/Http/TimeoutTest.php
+++ b/tests/_Integration/Http/TimeoutTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace _Integration\Http;
+
+use Crwlr\Crawler\HttpCrawler;
+use Crwlr\Crawler\Loader\Http\HttpLoader;
+use Crwlr\Crawler\Loader\LoaderInterface;
+use Crwlr\Crawler\Steps\Loading\Http;
+use Crwlr\Crawler\UserAgents\UserAgent;
+use Crwlr\Crawler\UserAgents\UserAgentInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+/** @var TestCase $this */
+
+it('Fails when timeout is exceeded', function () {
+    $crawler = new class () extends HttpCrawler {
+        protected function userAgent(): UserAgentInterface
+        {
+            return new UserAgent('SomeUserAgent');
+        }
+
+        public function loader(UserAgentInterface $userAgent, LoggerInterface $logger): LoaderInterface
+        {
+            return new HttpLoader($userAgent, logger: $logger, defaultGuzzleClientConfig: [
+                'connect_timeout' => 1,
+                'timeout' => 1,
+            ]);
+        }
+    };
+
+    $crawler->input('http://localhost:8000/sleep')
+        ->addStep(Http::get());
+
+    $crawler->runAndTraverse();
+
+    expect($this->getActualOutput())->toContain('Operation timed out');
+});

--- a/tests/_Integration/Http/TooManyRequestsTest.php
+++ b/tests/_Integration/Http/TooManyRequestsTest.php
@@ -53,7 +53,7 @@ it('retries after defined number of seconds', function () {
     expect($diff)->toBeGreaterThan(3.0);
 
     expect($diff)->toBeLessThan(3.5);
-})->only();
+});
 
 it('starts the first retry after the number of seconds returned in the Retry-After HTTP header', function () {
     $crawler = new TooManyRequestsCrawler();
@@ -72,7 +72,7 @@ it('starts the first retry after the number of seconds returned in the Retry-Aft
     expect($diff)->toBeGreaterThan(4.0);
 
     expect($diff)->toBeLessThan(4.5);
-})->only();
+});
 
 it('goes on crawling when a retry receives a successful response', function () {
     $crawler = new TooManyRequestsCrawler();
@@ -93,4 +93,4 @@ it('goes on crawling when a retry receives a successful response', function () {
     expect($diff)->toBeGreaterThan(1.0);
 
     expect($diff)->toBeLessThan(1.5);
-})->only();
+});

--- a/tests/_Integration/Http/TooManyRequestsTest.php
+++ b/tests/_Integration/Http/TooManyRequestsTest.php
@@ -38,17 +38,11 @@ it('retries after defined number of seconds', function () {
 
     $start = microtime(true);
 
-    var_dump($start);
-
     helper_generatorToArray($crawler->run());
 
     $end = microtime(true);
 
-    var_dump($end);
-
     $diff = $end - $start;
-
-    var_dump($diff);
 
     expect($diff)->toBeGreaterThan(3.0);
 

--- a/tests/_Integration/Http/TooManyRequestsTest.php
+++ b/tests/_Integration/Http/TooManyRequestsTest.php
@@ -38,16 +38,22 @@ it('retries after defined number of seconds', function () {
 
     $start = microtime(true);
 
+    var_dump($start);
+
     helper_generatorToArray($crawler->run());
 
     $end = microtime(true);
 
+    var_dump($end);
+
     $diff = $end - $start;
+
+    var_dump($diff);
 
     expect($diff)->toBeGreaterThan(3.0);
 
     expect($diff)->toBeLessThan(3.5);
-});
+})->only();
 
 it('starts the first retry after the number of seconds returned in the Retry-After HTTP header', function () {
     $crawler = new TooManyRequestsCrawler();

--- a/tests/_Integration/Http/TooManyRequestsTest.php
+++ b/tests/_Integration/Http/TooManyRequestsTest.php
@@ -72,7 +72,7 @@ it('starts the first retry after the number of seconds returned in the Retry-Aft
     expect($diff)->toBeGreaterThan(4.0);
 
     expect($diff)->toBeLessThan(4.5);
-});
+})->only();
 
 it('goes on crawling when a retry receives a successful response', function () {
     $crawler = new TooManyRequestsCrawler();
@@ -93,4 +93,4 @@ it('goes on crawling when a retry receives a successful response', function () {
     expect($diff)->toBeGreaterThan(1.0);
 
     expect($diff)->toBeLessThan(1.5);
-});
+})->only();

--- a/tests/_Integration/Server.php
+++ b/tests/_Integration/Server.php
@@ -98,3 +98,9 @@ if (str_starts_with($route, '/gzip')) {
 
     echo gzencode('This is a gzip compressed string');
 }
+
+if (str_starts_with($route, '/sleep')) {
+    sleep(10);
+
+    return;
+}

--- a/tests/_Integration/Server.php
+++ b/tests/_Integration/Server.php
@@ -100,7 +100,7 @@ if (str_starts_with($route, '/gzip')) {
 }
 
 if (str_starts_with($route, '/sleep')) {
-    sleep(10);
+    usleep(1050000);
 
     return;
 }


### PR DESCRIPTION
The default values are 10 seconds for connect_timeout and 60 seconds for timeout. Also add the option to provide config options for the default guzzle client created inside the `HttpLoader`.

Further, removed the `httpClient()` method in the `HttpCrawler` class. If you want to provide your own HTTP client, implement a custom `loader` method passing your client to the `HttpLoader` instead.