### PR TITLE
Improve response cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * New methods `stopOnErrorResponse()` and `yieldErrorResponses()` that can be used with `Http` steps. By calling `stopOnErrorResponse()` the step will throw a `LoadingException` when a response has a 4xx or 5xx status code. By calling the `yieldErrorResponse()` even error responses will be yielded and passed on to the next steps (this was default behaviour until this version. See the breaking change below).
 * The body of HTTP responses with a `Content-Type` header containing `application/x-gzip` are automatically decoded when `Http::getBodyString()` is used. Therefor added `ext-zlib` to suggested in `composer.json`.
 * The `FileCache` class can compress the cache data now to save disk space. Use the `useCompression()` method to do so.
+* New method `retryCachedErrorResponses()` in `HttpLoader`. When called, the loader will only use successful responses (status code < 400) from the cache and therefore retry already cached error responses.
+* New method `writeOnlyCache()` in `HttpLoader` to only write to, but don't read from the response cache. Can be used to renew cached responses.
 
 ### Changed
 * __BREAKING__: Error responses (4xx as well as 5xx), by default, won't produce any step outputs any longer. If you want to receive error responses, use the new `yieldErrorResponses()` method.

--- a/tests/Loader/Http/HttpLoaderTest.php
+++ b/tests/Loader/Http/HttpLoaderTest.php
@@ -2,6 +2,7 @@
 
 namespace tests\Loader\Http;
 
+use Crwlr\Crawler\Loader\Http\Cache\FileCache;
 use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
 use Crwlr\Crawler\Loader\Http\Cache\HttpResponseCacheItem;
 use Crwlr\Crawler\Loader\Http\Exceptions\LoadingException;
@@ -18,33 +19,60 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\SimpleCache\CacheInterface;
 use stdClass;
+use Throwable;
 
 function helper_nonBotUserAgent(): UserAgent
 {
     return new UserAgent('Mozilla/5.0 (compatible; FooBot)');
 }
 
+afterEach(function () {
+    $dir = __DIR__ . '/_cachedir';
+
+    $files = scandir($dir);
+
+    if (is_array($files)) {
+        foreach ($files as $file) {
+            if ($file === '.' || $file === '..' || $file === '.gitkeep') {
+                continue;
+            }
+
+            @unlink($dir . '/' . $file);
+        }
+    }
+});
+
 /** @var TestCase $this */
 
 test('It accepts url string as argument to load', function () {
     $httpClient = Mockery::mock(ClientInterface::class);
+
     $httpClient->shouldReceive('sendRequest')->twice()->andReturn(new Response());
+
     $httpLoader = new HttpLoader(helper_nonBotUserAgent(), $httpClient);
+
     $httpLoader->load('https://www.crwlr.software');
+
     $httpLoader->loadOrFail('https://www.crwlr.software');
 });
 
 test('It accepts RequestInterface as argument to load', function () {
     $httpClient = Mockery::mock(ClientInterface::class);
+
     $httpClient->shouldReceive('sendRequest')->twice()->andReturn(new Response());
+
     $httpLoader = new HttpLoader(helper_nonBotUserAgent(), $httpClient);
+
     $httpLoader->load(new Request('GET', 'https://www.crwlr.software'));
+
     $httpLoader->loadOrFail(new Request('GET', 'https://www.crwlr.software'));
 });
 
 test('It does not accept other argument types for the load method', function ($loadMethod) {
     $httpClient = Mockery::mock(ClientInterface::class);
+
     $httpLoader = new HttpLoader(new BotUserAgent('Foo'), $httpClient);
+
     $httpLoader->{$loadMethod}(new stdClass());
 })->with(['load', 'loadOrFail'])->expectError();
 
@@ -62,56 +90,78 @@ test(
         }
 
         $httpLoader = new HttpLoader(helper_nonBotUserAgent(), $httpClient);
+
         $beforeLoadWasCalled = false;
+
         $httpLoader->beforeLoad(function () use (& $beforeLoadWasCalled) {
             $beforeLoadWasCalled = true;
         });
+
         $afterLoadWasCalled = false;
+
         $httpLoader->beforeLoad(function () use (& $afterLoadWasCalled) {
             $afterLoadWasCalled = true;
         });
 
         $httpLoader->load('https://www.otsch.codes');
+
         expect($beforeLoadWasCalled)->toBeTrue();
+
         expect($afterLoadWasCalled)->toBeTrue();
     }
 )->with([100, 200, 300, 400, 500]);
 
 test('It calls the onSuccess hook on a successful response', function ($responseStatusCode) {
     $httpClient = Mockery::mock(ClientInterface::class);
+
     $httpClient->shouldReceive('sendRequest')->twice()->andReturn(new Response($responseStatusCode));
+
     $httpLoader = new HttpLoader(helper_nonBotUserAgent(), $httpClient);
+
     $onSuccessWasCalled = false;
+
     $httpLoader->onSuccess(function () use (& $onSuccessWasCalled) {
         $onSuccessWasCalled = true;
     });
 
     $httpLoader->load('https://www.otsch.codes');
+
     expect($onSuccessWasCalled)->toBeTrue();
 
     $onSuccessWasCalled = false;
+
     $httpLoader->loadOrFail('https://www.otsch.codes');
+
     expect($onSuccessWasCalled)->toBeTrue();
 })->with([200, 201, 202]);
 
 test('It calls the onError hook on a failed request', function ($responseStatusCode) {
     $httpClient = Mockery::mock(ClientInterface::class);
+
     $httpClient->shouldReceive('sendRequest')->once()->andReturn(new Response($responseStatusCode));
+
     $httpLoader = new HttpLoader(helper_nonBotUserAgent(), $httpClient);
+
     $onErrorWasCalled = false;
+
     $httpLoader->onError(function () use (& $onErrorWasCalled) {
         $onErrorWasCalled = true;
     });
 
     $httpLoader->load('https://www.otsch.codes');
+
     expect($onErrorWasCalled)->toBeTrue();
 })->with([400, 404, 422, 500]);
 
 test('It throws an Exception when request fails in loadOrFail method', function () {
     $httpClient = Mockery::mock(ClientInterface::class);
+
     $httpClient->shouldReceive('sendRequest')->once()->andReturn(new Response(400));
+
     $httpLoader = new HttpLoader(helper_nonBotUserAgent(), $httpClient);
+
     $onErrorWasCalled = false;
+
     $httpLoader->onError(function () use (& $onErrorWasCalled) {
         $onErrorWasCalled = true;
     });
@@ -127,7 +177,9 @@ test('It throws an Exception when request fails in loadOrFail method', function 
 
 test('You can implement logic to disallow certain request', function () {
     $httpClient = Mockery::mock(ClientInterface::class);
+
     $httpClient->shouldReceive('sendRequest')->once()->andReturn(new Response());
+
     $httpLoader = new class (new BotUserAgent('Foo'), $httpClient) extends HttpLoader {
         public function isAllowedToBeLoaded(UriInterface $uri, bool $throwsException = false): bool
         {
@@ -136,9 +188,11 @@ test('You can implement logic to disallow certain request', function () {
     };
 
     $response = $httpLoader->load('/foo');
+
     expect($response)->toBeInstanceOf(RespondedRequest::class);
 
     $response = $httpLoader->load('/bar');
+
     expect($response)->toBeNull();
 });
 
@@ -146,7 +200,9 @@ test(
     'The isAllowedToBeLoaded method is called with argument throwsException true when called from loadOrFail',
     function () {
         $httpClient = Mockery::mock(ClientInterface::class);
+
         $httpClient->shouldReceive('sendRequest')->once()->andReturn(new Response());
+
         $httpLoader = new class (new BotUserAgent('Foo'), $httpClient) extends HttpLoader {
             public function isAllowedToBeLoaded(UriInterface $uri, bool $throwsException = false): bool
             {
@@ -168,24 +224,29 @@ test(
     }
 );
 
-test('It automatically handles redirects', function (string $loadingMethod) {
+it('automatically handles redirects', function (string $loadingMethod) {
     $httpClient = Mockery::mock(ClientInterface::class);
+
     $httpClient->shouldReceive('sendRequest')
         ->twice()
         ->andReturn(
             new Response(301, ['Location' => 'https://www.redirect.com']),
             new Response(200, [], 'YES')
         );
+
     $httpLoader = new HttpLoader(helper_nonBotUserAgent(), $httpClient);
+
     $requestResponseAggregate = $httpLoader->{$loadingMethod}('https://www.crwlr.software/packages');
 
     /** @var RespondedRequest $requestResponseAggregate */
     expect($requestResponseAggregate->requestedUri())->toBe('https://www.crwlr.software/packages');
+
     expect($requestResponseAggregate->effectiveUri())->toBe('https://www.redirect.com');
+
     expect($requestResponseAggregate->response->getBody()->getContents())->toBe('YES');
 })->with(['load', 'loadOrFail']);
 
-test('It calls request start and end tracking methods', function (string $loadingMethod) {
+it('calls request start and end tracking methods', function (string $loadingMethod) {
     $httpClient = Mockery::mock(ClientInterface::class);
 
     $httpClient->shouldReceive('sendRequest')->once()->andReturn(new Response(200));
@@ -217,98 +278,192 @@ test('It calls request start and end tracking methods', function (string $loadin
     expect($output)->toContain('Track request end https://www.twitter.com');
 })->with(['load', 'loadOrFail']);
 
-test('It automatically logs loading success message', function ($loadingMethod) {
+it('automatically logs loading success message', function ($loadingMethod) {
     $httpClient = Mockery::mock(ClientInterface::class);
+
     $httpClient->shouldReceive('sendRequest')->once()->andReturn(new Response());
+
     $httpLoader = new HttpLoader(helper_nonBotUserAgent(), $httpClient);
+
     $httpLoader->{$loadingMethod}(new Request('GET', 'https://phpstan.org/'));
 
     $output = $this->getActualOutput();
+
     expect($output)->toContain('Loaded https://phpstan.org/');
 })->with(['load', 'loadOrFail']);
 
-test('It automatically logs loading error message in normal load method', function () {
+it('automatically logs loading error message in normal load method', function () {
     $httpClient = Mockery::mock(ClientInterface::class);
+
     $httpClient->shouldReceive('sendRequest')->once()->andReturn(new Response(500));
+
     $httpLoader = new HttpLoader(helper_nonBotUserAgent(), $httpClient);
+
     $httpLoader->load(new Request('GET', 'https://phpstan.org/'));
 
     $output = $this->getActualOutput();
+
     expect($output)->toContain('Failed to load https://phpstan.org/');
 });
 
-test('It automatically adds the User-Agent header before sending', function () {
+it('automatically adds the User-Agent header before sending', function () {
     $httpClient = Mockery::mock(ClientInterface::class);
+
     $httpClient->shouldReceive('sendRequest')
         ->once()
         ->withArgs(function ($request) {
             return str_contains($request->getHeaderLine('User-Agent'), 'FooBot');
         })
         ->andReturn(new Response());
+
     $httpLoader = new HttpLoader(helper_nonBotUserAgent(), $httpClient);
+
     $httpLoader->load('https://www.facebook.com');
 });
 
-test('It tries to get responses from cache', function () {
+it('tries to get responses from cache', function () {
     $httpClient = Mockery::mock(ClientInterface::class);
+
     $httpClient->shouldNotReceive('sendRequest');
+
     $cache = Mockery::mock(CacheInterface::class);
+
     $cache->shouldReceive('has')->once()->andReturn(true);
+
     $cache->shouldReceive('get')
         ->once()
         ->andReturn(HttpResponseCacheItem::fromAggregate(
             new RespondedRequest(new Request('GET', '/'), new Response())
         ));
+
     $httpLoader = new HttpLoader(helper_nonBotUserAgent(), $httpClient);
+
     $httpLoader->setCache($cache);
+
     $httpLoader->load('https://www.facebook.com');
 });
 
-test('It fails when it gets a failed response from cache', function () {
+it('fails when it gets a failed response from cache', function () {
     $httpClient = Mockery::mock(ClientInterface::class);
+
     $cache = Mockery::mock(CacheInterface::class);
+
     $cache->shouldReceive('has')->once()->andReturn(true);
+
     $cache->shouldReceive('get')
         ->once()
         ->andReturn(HttpResponseCacheItem::fromAggregate(
             new RespondedRequest(new Request('GET', '/'), new Response(404))
         ));
+
     $httpLoader = new HttpLoader(helper_nonBotUserAgent(), $httpClient);
+
     $httpLoader->setCache($cache);
 
     $onErrorWasCalled = false;
+
     $httpLoader->onError(function () use (& $onErrorWasCalled) {
         $onErrorWasCalled = true;
     });
 
     $httpLoader->load('https://www.facebook.com');
+
     expect($onErrorWasCalled)->toBeTrue();
 });
 
-test('It fails when it gets a failed response from cache in loadOrFail', function () {
+it('fails when it gets a failed response from cache in loadOrFail', function () {
     $httpClient = Mockery::mock(ClientInterface::class);
+
     $cache = Mockery::mock(CacheInterface::class);
+
     $cache->shouldReceive('has')->once()->andReturn(true);
+
     $cache->shouldReceive('get')
         ->once()
         ->andReturn(HttpResponseCacheItem::fromAggregate(
             new RespondedRequest(new Request('GET', 'facebook'), new Response(404))
         ));
+
     $httpLoader = new HttpLoader(helper_nonBotUserAgent(), $httpClient);
+
     $httpLoader->setCache($cache);
+
     $httpLoader->loadOrFail('https://www.facebook.com');
 })->throws(LoadingException::class);
 
-test('It adds loaded responses to the cache when it has a cache', function ($loadingMethod) {
+it('adds loaded responses to the cache when it has a cache', function ($loadingMethod) {
     $httpClient = Mockery::mock(ClientInterface::class);
+
     $httpClient->shouldReceive('sendRequest')->once()->andReturn(new Response());
+
     $cache = Mockery::mock(CacheInterface::class);
+
     $cache->shouldReceive('has')->once()->andReturn(false);
+
     $cache->shouldReceive('set')->once();
+
     $httpLoader = new HttpLoader(helper_nonBotUserAgent(), $httpClient);
+
     $httpLoader->setCache($cache);
+
     $httpLoader->{$loadingMethod}('https://laravel.com/');
 })->with(['load', 'loadOrFail']);
+
+test(
+    'when a cached response was an error response it retries to load it when retryCachedErrorResponses() was called',
+    function (string $loadingMethod) {
+        $httpClient = Mockery::mock(ClientInterface::class);
+
+        $httpClient->shouldReceive('sendRequest')
+            ->twice()
+            ->andReturn(new Response(404), new Response(200));
+
+        $cache = new FileCache(__DIR__ . '/_cachedir');
+
+        $httpLoader = new HttpLoader(helper_nonBotUserAgent(), $httpClient);
+
+        $httpLoader->setCache($cache);
+
+        $httpLoader->retryCachedErrorResponses();
+
+        try {
+            $httpLoader->{$loadingMethod}('https://www.example.com/articles/123');
+        } catch (Throwable $exception) {
+        }
+
+        try {
+            $httpLoader->{$loadingMethod}('https://www.example.com/articles/123');
+        } catch (Throwable $exception) {
+        }
+    }
+)->with(['load', 'loadOrFail']);
+
+it(
+    'adds responses to the cache but doesn\'t try to get them from the cache, when writeOnlyCache() was called',
+    function ($loadingMethod) {
+        $httpClient = Mockery::mock(ClientInterface::class);
+
+        $httpClient->shouldReceive('sendRequest')->twice()->andReturn(new Response());
+
+        $cache = new FileCache(__DIR__ . '/_cachedir');
+
+        $httpLoader = new HttpLoader(helper_nonBotUserAgent(), $httpClient);
+
+        $httpLoader->setCache($cache);
+
+        $httpLoader->writeOnlyCache();
+
+        try {
+            $httpLoader->{$loadingMethod}('https://www.example.com/articles/123');
+        } catch (Throwable $exception) {
+        }
+
+        try {
+            $httpLoader->{$loadingMethod}('https://www.example.com/articles/123');
+        } catch (Throwable $exception) {
+        }
+    }
+)->with(['load', 'loadOrFail']);
 
 test('By default it uses the cookie jar and passes on cookies', function () {
     $httpClient = Mockery::mock(ClientInterface::class);
@@ -339,9 +494,13 @@ test('By default it uses the cookie jar and passes on cookies', function () {
     })->andReturn(new Response());
 
     $httpLoader = new HttpLoader(helper_nonBotUserAgent(), $httpClient);
+
     $httpLoader->load('https://www.crwlr.software/');
+
     $httpLoader->load('https://www.crwlr.software/blog');
+
     $httpLoader->loadOrFail('https://www.crwlr.software/contact');
+
     $httpLoader->loadOrFail('https://www.crwlr.software/packages');
 
     expect(true)->toBeTrue(); // Just here so pest doesn't complain that there is no assertion.
@@ -373,10 +532,15 @@ test('You can turn off using the cookie jar', function () {
     })->andReturn(new Response());
 
     $httpLoader = new HttpLoader(helper_nonBotUserAgent(), $httpClient);
+
     $httpLoader->dontUseCookies();
+
     $httpLoader->load('https://www.crwlr.software/');
+
     $httpLoader->load('https://www.crwlr.software/blog');
+
     $httpLoader->loadOrFail('https://www.crwlr.software/contact');
+
     $httpLoader->loadOrFail('https://www.crwlr.software/packages');
 
     expect(true)->toBeTrue(); // Just here so pest doesn't complain that there is no assertion.


### PR DESCRIPTION
* New method `retryCachedErrorResponses()` in `HttpLoader`. When called, the loader will only use successful responses (status code < 400) from the cache and therefore retry already cached error responses.
* New method `writeOnlyCache()` in `HttpLoader` to only write to, but don't read from the response cache. Can be used to renew cached responses.