### PR TITLE
Change urlPathMatches filter rule

### DIFF
--- a/src/Steps/Filters/Enums/UrlFilterRule.php
+++ b/src/Steps/Filters/Enums/UrlFilterRule.php
@@ -29,10 +29,15 @@ enum UrlFilterRule
                 self::Domain => Url::parse($url)->domain() === $needle,
                 self::Path => Url::parse($url)->path() === $needle,
                 self::PathStartsWith => str_starts_with(Url::parse($url)->path() ?? '', $needle),
-                self::PathMatches => preg_match($needle, Url::parse($url)->path() ?? '') === 1,
+                self::PathMatches => preg_match($this->prepareRegex($needle), Url::parse($url)->path() ?? '') === 1,
             };
         } catch (InvalidUrlException|Exception $exception) {
             return false;
         }
+    }
+
+    protected function prepareRegex(string $regex): string
+    {
+        return '~' . $regex . '~';
     }
 }

--- a/tests/Steps/Filters/Enums/UrlFilterRuleTest.php
+++ b/tests/Steps/Filters/Enums/UrlFilterRuleTest.php
@@ -62,7 +62,7 @@ it('checks if a URL path matches a regex pattern', function (bool $expectedResul
 
     expect($urlFilterRule->evaluate($haystack, $needle))->toBe($expectedResult);
 })->with([
-    [true, 'https://www.example.com/foo/bar', '/^\/foo/'],
-    [true, 'https://www.example.com/56/something/foo', '/^\/\d{1,5}\/[a-z]{1,20}/'],
-    [false, 'https://www.example.com/56/some-thing/foo', '/^\/\d{1,5}\/[a-z]{1,20}\//'],
+    [true, 'https://www.example.com/foo/bar', '^/foo/'],
+    [true, 'https://www.example.com/56/something/foo', '^/\d{1,5}/[a-z]{1,20}'],
+    [false, 'https://www.example.com/56/some-thing/foo', '^/\d{1,5}/[a-z]{1,20}/'],
 ]);


### PR DESCRIPTION
Don't require delimiters in the argument for the regex pattern and also use tilde as delimiter which will be pretty rare in url paths compared to other common delimiters like /, %, #, +.