### PR TITLE
Improve the Sitemap::getUrlsFromSitemap() step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * The `CookieJar` now also works with `localhost` or other hosts without a registered domain name.
+* Improve the `Sitemap::getUrlsFromSitemap()` step to also work when the `<urlset>` tag contains attributes that would cause the symfony DomCrawler to not find any elements.
 
 ## [0.6.0] - 2022-10-03
 

--- a/src/Steps/Sitemap/GetUrlsFromSitemap.php
+++ b/src/Steps/Sitemap/GetUrlsFromSitemap.php
@@ -22,6 +22,12 @@ class GetUrlsFromSitemap extends Step
      */
     protected function invoke(mixed $input): Generator
     {
+        if ($input->filter('urlset url')->count() === 0) {
+            $xml = preg_replace('/<urlset.+>/', '<urlset>', $input->outerHtml());
+
+            $input = new Crawler($xml);
+        }
+
         foreach ($input->filter('urlset url') as $urlNode) {
             $urlNode = new Crawler($urlNode);
 

--- a/tests/Steps/Sitemap/GetUrlsFromSitemapTest.php
+++ b/tests/Steps/Sitemap/GetUrlsFromSitemapTest.php
@@ -75,3 +75,24 @@ it('doesn\'t fail when sitemap is empty', function () {
 
     expect($outputs)->toHaveCount(0);
 });
+
+it(
+    'doesn\'t fail when the urlset tag contains attributes, that would cause the symfony DomCrawler to not find the ' .
+    'elements',
+    function () {
+        $xml = <<<XML
+            <?xml version="1.0" encoding="UTF-8"?>
+            <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+                    xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                <url><loc>https://www.crwlr.software/blog/whats-new-in-crwlr-crawler-v0-5</loc></url>
+                <url><loc>https://www.crwlr.software/blog/dealing-with-http-url-query-strings-in-php</loc></url>
+                <url><loc>https://www.crwlr.software/blog/whats-new-in-crwlr-crawler-v0-4</loc></url>
+            </urlset>
+            XML;
+
+        $outputs = helper_invokeStepWithInput(Sitemap::getUrlsFromSitemap(), $xml);
+
+        expect($outputs)->toHaveCount(3);
+    }
+);


### PR DESCRIPTION
It now also works when the urlset tag contains attributes that would cause the symfony DomCrawler to not find any elements.