### PR TITLE
Html/Xml data extraction multiple layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * New method `retryCachedErrorResponses()` in `HttpLoader`. When called, the loader will only use successful responses (status code < 400) from the cache and therefore retry already cached error responses.
 * New method `writeOnlyCache()` in `HttpLoader` to only write to, but don't read from the response cache. Can be used to renew cached responses.
 * `Filter::urlPathMatches()` to filter URL paths using a regex.
+* With the `Html` and `Xml` data extraction steps you can now add layers to the data that is being extracted, by just adding further `Html`/`Xml` data extraction steps as values in the mapping array that you pass as argument to the `extract()` method.
 
 ### Changed
 * __BREAKING__: Group steps can now only produce combined outputs, as previously done when `combineToSingleOutput()` method was called. The method is removed. 

--- a/tests/Steps/_Files/Html/event.html
+++ b/tests/Steps/_Files/Html/event.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Bookstore Example in HTML :)</title>
+</head>
+<body>
+<div id="event">
+    <h1>Some Meetup</h1>
+    <div class="location">Somewhere</div>
+    <div class="date">2023-01-14 21:00</div>
+
+    <div class="talks">
+        <div class="talk">
+            <h2 class="title">Sophisticated talk title</h2>
+            <div class="speaker">Super Mario</div>
+            <a href="slides/talk1.pdf" class="slidesLink">Slides</a>
+        </div>
+        <div class="talk">
+            <h2 class="title">Simple beginner talk</h2>
+            <div class="speaker">Luigi</div>
+            <a href="slides/talk2.pdf" class="slidesLink">Slides</a>
+        </div>
+        <div class="talk">
+            <h2 class="title">Fun talk</h2>
+            <div class="speaker">Princess Peach</div>
+            <a href="slides/talk3.pdf" class="slidesLink">Slides</a>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/tests/Steps/_Files/Xml/events.xml
+++ b/tests/Steps/_Files/Xml/events.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<events>
+
+    <event>
+        <name>Some Meetup</name>
+        <location>Somewhere</location>
+        <date>2023-01-14 20:00</date>
+        <talks>
+            <talk>
+                <title>Sophisticated talk title</title>
+                <speaker>Super Mario</speaker>
+            </talk>
+            <talk>
+                <title>Fun talk</title>
+                <speaker>Princess Peach</speaker>
+            </talk>
+        </talks>
+    </event>
+
+    <event>
+        <name>Another Meetup</name>
+        <location>Somewhere else</location>
+        <date>2023-01-21 19:00</date>
+        <talks>
+            <talk>
+                <title>Join the dark side</title>
+                <speaker>Wario</speaker>
+            </talk>
+            <talk>
+                <title>Let's go</title>
+                <speaker>Yoshi</speaker>
+            </talk>
+        </talks>
+    </event>
+
+</events>


### PR DESCRIPTION
With the `Html` and `Xml` data extraction steps you can now add layers to the data that is being extracted, by just adding further `Html`/`Xml` data extraction steps as values in the mapping array that you pass as argument to the `extract()` method.