### PR TITLE
Minor validation methods improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Removed logger from `Throttler` as it doesn't log anything.
 * Fail silently when `robots.txt` can't be parsed.
 * Default timeout configuration for the default guzzle HTTP client: `connect_timeout` is `10` seconds and `timeout` is `60` seconds.
+* The `validateAndSanitize...()` methods in the abstract `Step` class, when called with an array with one single element, automatically try to use that array element as input value.
 
 ### Fixed
 * The `CookieJar` now also works with `localhost` or other hosts without a registered domain name.

--- a/src/Steps/Step.php
+++ b/src/Steps/Step.php
@@ -110,6 +110,8 @@ abstract class Step extends BaseStep
         mixed $inputValue,
         string $exceptionMessage = 'Input must be string or stringable'
     ): string {
+        $inputValue = $this->getSingleElementFromArray($inputValue);
+
         if (is_object($inputValue) && method_exists($inputValue, '__toString')) {
             return $inputValue->__toString();
         }
@@ -129,6 +131,8 @@ abstract class Step extends BaseStep
         string $exceptionMessage = 'Input must be string, stringable or HTTP response (RespondedRequest)',
         bool $allowOnlyRespondedRequest = false
     ): string {
+        $inputValue = $this->getSingleElementFromArray($inputValue);
+
         if (
             $inputValue instanceof RespondedRequest ||
             ($inputValue instanceof ResponseInterface && !$allowOnlyRespondedRequest)
@@ -146,6 +150,8 @@ abstract class Step extends BaseStep
         mixed $inputValue,
         string $exceptionMessage = 'Input must be string, stringable or an instance of UriInterface or Crwlr\\Url',
     ): UriInterface {
+        $inputValue = $this->getSingleElementFromArray($inputValue);
+
         if ($inputValue instanceof UriInterface) {
             return $inputValue;
         }
@@ -203,5 +209,14 @@ abstract class Step extends BaseStep
     private function maxOutputsExceeded(): bool
     {
         return $this->maxOutputs !== null && $this->currentOutputCount >= $this->maxOutputs;
+    }
+
+    private function getSingleElementFromArray(mixed $inputValue): mixed
+    {
+        if (is_array($inputValue) && count($inputValue) === 1) {
+            return reset($inputValue);
+        }
+
+        return $inputValue;
     }
 }

--- a/tests/Steps/StepTest.php
+++ b/tests/Steps/StepTest.php
@@ -9,6 +9,7 @@ use Crwlr\Crawler\Result;
 use Crwlr\Crawler\Steps\Step;
 use Exception;
 use Generator;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 use function tests\helper_getInputReturningStep;
@@ -450,6 +451,48 @@ it('calls the validateAndSanitizeInput method', function () {
 
     expect($output[0]->get())->toBe('inputValue validated and sanitized');
 });
+
+test(
+    'when calling validateAndSanitizeStringOrStringable() and the input is array with a single element it tries to ' .
+    'use that element as input value',
+    function () {
+        $step = new class () extends Step {
+            protected function validateAndSanitizeInput(mixed $input): string
+            {
+                return $this->validateAndSanitizeStringOrStringable($input);
+            }
+
+            protected function invoke(mixed $input): Generator
+            {
+                yield $input;
+            }
+        };
+
+        $output = helper_invokeStepWithInput($step, ['inputValue']);
+
+        expect($output[0]->get())->toBe('inputValue');
+    }
+);
+
+test(
+    'when calling validateAndSanitizeStringOrStringable() and the input is array with multiple elements it throws ' .
+    'an InvalidArgumentException',
+    function () {
+        $step = new class () extends Step {
+            protected function validateAndSanitizeInput(mixed $input): string
+            {
+                return $this->validateAndSanitizeStringOrStringable($input);
+            }
+
+            protected function invoke(mixed $input): Generator
+            {
+                yield $input;
+            }
+        };
+
+        helper_invokeStepWithInput($step, ['inputValue', 'foo' => 'bar']);
+    }
+)->throws(InvalidArgumentException::class);
 
 it('is possible that a step does not produce any output at all', function () {
     $step = new class () extends Step {


### PR DESCRIPTION
The `validateAndSanitize...()` methods in the abstract `Step` class, when called with an array with one single element, automatically try to use that array element as input value.