### PR TITLE
Fix losing result data to add later

### DIFF
--- a/src/Steps/BaseStep.php
+++ b/src/Steps/BaseStep.php
@@ -216,7 +216,7 @@ abstract class BaseStep implements StepInterface
                 throw new Exception('Key ' . $this->useInputKey . ' does not exist in input');
             }
 
-            $input = new Input($input->get()[$this->useInputKey], $input->result);
+            $input = new Input($input->get()[$this->useInputKey], $input->result, $input->addLaterToResult);
         }
 
         return $input;

--- a/src/Steps/Group.php
+++ b/src/Steps/Group.php
@@ -160,7 +160,9 @@ final class Group extends BaseStep
     private function addResultToInputIfAnyResultKeysDefined(Input $input): Input
     {
         if ($this->createsResult() && !$input->result) {
-            $input = new Input($input->get(), new Result());
+            $input = new Input($input->get(), new Result(), $input->addLaterToResult);
+        } elseif ($this->addsToOrCreatesResult() && !$input->addLaterToResult) {
+            $input = new Input($input->get(), $input->result, new Result());
         }
 
         return $input;

--- a/src/Steps/Loop.php
+++ b/src/Steps/Loop.php
@@ -274,7 +274,7 @@ final class Loop implements StepInterface
                 }
             }
 
-            return $newInputValue !== null ? new Input($newInputValue, $input->result) : null;
+            return $newInputValue !== null ? new Input($newInputValue, $input->result, $input->addLaterToResult) : null;
         }
 
         return new Input($output);

--- a/src/Steps/Step.php
+++ b/src/Steps/Step.php
@@ -75,7 +75,11 @@ abstract class Step extends BaseStep
     final public function callUpdateInputUsingOutput(Input $input, Output $output): Input
     {
         if ($this->updateInputUsingOutput instanceof Closure) {
-            return new Input($this->updateInputUsingOutput->call($this, $input->get(), $output->get()), $input->result);
+            return new Input(
+                $this->updateInputUsingOutput->call($this, $input->get(), $output->get()),
+                $input->result,
+                $input->addLaterToResult,
+            );
         }
 
         return $input;

--- a/tests/Steps/GroupTest.php
+++ b/tests/Steps/GroupTest.php
@@ -791,6 +791,28 @@ it(
     }
 );
 
+it(
+    'adds a secondary Result object with data to add later to main Result objects when addLaterToResult() is called ' .
+    'on one of the steps in the group',
+    function () {
+        $step1 = helper_getValueReturningStep(['foo' => 'one', 'bar' => 'two'])->addLaterToResult();
+
+        $step2 = helper_getValueReturningStep(['baz' => 'three', 'four' => 'quz']);
+
+        $group = (new Group())
+            ->addStep($step1)
+            ->addStep($step2);
+
+        $outputs = helper_invokeStepWithInput($group);
+
+        expect($outputs[0]->result)->toBeNull();
+
+        expect($outputs[0]->addLaterToResult)->toBeInstanceOf(Result::class);
+
+        expect($outputs[0]->addLaterToResult?->toArray())->toBe(['foo' => 'one', 'bar' => 'two']);
+    }
+);
+
 test(
     'When steps yield multiple outputs it combines the first output from first step with first output from second ' .
         'step and so on.',

--- a/tests/Steps/StepTest.php
+++ b/tests/Steps/StepTest.php
@@ -269,6 +269,17 @@ test('with addLaterToResult() you can also pick some keys from array output', fu
     ]);
 });
 
+it('does not lose previously added result to add later, when it uses the useInputKey() method', function () {
+    $step = helper_getValueReturningStep(['test' => 'test'])
+        ->useInputKey('foo');
+
+    $addLaterToResult = new Result();
+
+    $outputs = helper_invokeStepWithInput($step, new Input(['foo' => 'test'], addLaterToResult: $addLaterToResult));
+
+    expect($outputs[0]->addLaterToResult)->toBe($addLaterToResult);
+});
+
 it(
     'also passes on Result objects through further steps when they don\'t define further result resource properties',
     function () {
@@ -553,6 +564,23 @@ test('You can add and call an updateInputUsingOutput callback', function () {
     expect($updatedInput)->toBeInstanceOf(Input::class);
 
     expect($updatedInput->get())->toBe('Boo Yah!');
+});
+
+it('does not lose previously added result to add later, when updateInputUsingOutput() is called', function () {
+    $step = helper_getValueReturningStep('something');
+
+    $step->updateInputUsingOutput(function (mixed $input, mixed $output) {
+        return $input . ' ' . $output;
+    });
+
+    $addLaterToResult = new Result();
+
+    $updatedInput = $step->callUpdateInputUsingOutput(
+        new Input('Some', addLaterToResult: $addLaterToResult),
+        new Output('thing')
+    );
+
+    expect($updatedInput->addLaterToResult)->toBe($addLaterToResult);
 });
 
 it('does not yield more outputs than defined via maxOutputs() method', function () {


### PR DESCRIPTION
When a new Io object is created it does always keep the addLaterToResult object from its parent.