### PR TITLE
Deprecate the loop feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * __BREAKING__: `getResultKey()` is also removed with `setResultKey()`. It's removed without replacement, as it doesn't really make sense any longer.
 * __BREAKING__: Error responses (4xx as well as 5xx), by default, won't produce any step outputs any longer. If you want to receive error responses, use the new `yieldErrorResponses()` method.
 * __BREAKING__: Removed the `httpClient()` method in the `HttpCrawler` class. If you want to provide your own HTTP client, implement a custom `loader` method passing your client to the `HttpLoader` instead.
+* __Deprecated__ the loop feature (class `Loop` and `Crawler::loop()` method). Probably the only use case is iterating over paginated list pages, which can be done using the new Paginator functionality. It will be removed in v1.0.
 * In case of a 429 (Too Many Requests) response, the `HttpLoader` now automatically waits and retries. By default, it retries twice and waits 10 seconds for the first retry and a minute for the second one. In case the response also contains a `Retry-After` header with a value in seconds, it complies to that. Exception: by default it waits at max `60` seconds (you can set your own limit if you want), if the `Retry-After` value is higher, it will stop crawling. If all the retries also receive a `429` it also throws an Exception.
 * Removed logger from `Throttler` as it doesn't log anything.
 * Fail silently when `robots.txt` can't be parsed.

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -47,6 +47,14 @@ abstract class Crawler
 
     abstract protected function loader(UserAgentInterface $userAgent, LoggerInterface $logger): LoaderInterface;
 
+    /**
+     * The loop feature is deprecated
+     *
+     * This method and the Loop class will be removed in v1.0. Probably the only use case is iterating over
+     * paginated list pages, which can be done using the new Paginator functionality.
+     *
+     * @deprecated since v0.7.0
+     */
     public static function loop(StepInterface $step): Loop
     {
         return new Loop($step);

--- a/src/Steps/Loop.php
+++ b/src/Steps/Loop.php
@@ -10,6 +10,15 @@ use Crwlr\Crawler\Steps\Filters\FilterInterface;
 use Generator;
 use Psr\Log\LoggerInterface;
 
+/**
+ * The loop feature is deprecated
+ *
+ * The Loop class will be removed in v1.0. Probably the only use case is iterating over paginated list pages,
+ * which can be done using the new Paginator functionality.
+ *
+ * @deprecated since v0.7.0
+ */
+
 final class Loop implements StepInterface
 {
     private int $maxIterations = 1000;


### PR DESCRIPTION
Probably the only use case is iterating over paginated list pages, which can be done using the new Paginator functionality. It will be removed in v1.0.