### PR TITLE
Keeping input data uses original input

### DIFF
--- a/src/Steps/Step.php
+++ b/src/Steps/Step.php
@@ -40,9 +40,7 @@ abstract class Step extends BaseStep
             return;
         }
 
-        $input = $this->getInputKeyToUse($input);
-
-        $validInputValue = $this->validateAndSanitizeInput($input->get());
+        $validInputValue = $this->validateAndSanitizeInput($this->getInputKeyToUse($input)->get());
 
         if ($this->uniqueInput === false || $this->inputOrOutputIsUnique(new Input($validInputValue))) {
             yield from $this->invokeAndYield($validInputValue, $input);
@@ -97,7 +95,7 @@ abstract class Step extends BaseStep
      *
      * In child classes you can add this method to validate and sanitize the incoming input. The method is called
      * automatically when the step is invoked within the Crawler and the invoke method receives the validated and
-     * sanitized input. Also you can just return any value from this method and in the invoke method it's again
+     * sanitized input. Also, you can just return any value from this method and in the invoke method it's again
      * incoming as an Input object.
      *
      * @throws InvalidArgumentException  Throw this if the input value is invalid for this step.
@@ -193,7 +191,7 @@ abstract class Step extends BaseStep
             }
 
             if ($this->keepInputData === true) {
-                $outputData = $this->addInputDataToOutputData($validInputValue, $outputData);
+                $outputData = $this->addInputDataToOutputData($input->get(), $outputData);
             }
 
             $output = $this->makeOutput($outputData, $input);

--- a/tests/Steps/GroupTest.php
+++ b/tests/Steps/GroupTest.php
@@ -1059,3 +1059,31 @@ it('throws an exception when input should be kept, is non array and no key is de
 
     helper_invokeStepWithInput($group, new Input('three'));
 })->throws(Exception::class);
+
+it('keeps the original input data when useInputKey() is used', function () {
+    $step1 = new class () extends Step {
+        protected function invoke(mixed $input): Generator
+        {
+            yield ['foo' => 'one'];
+        }
+    };
+
+    $step2 = new class () extends Step {
+        protected function invoke(mixed $input): Generator
+        {
+            yield ['bar' => 'two'];
+        }
+    };
+
+    $group = (new Group())
+        ->addStep($step1)
+        ->addStep($step2)
+        ->useInputKey('baz')
+        ->keepInputData();
+
+    $output = helper_invokeStepWithInput($group, new Input(['baz' => 'three', 'quz' => 'four']));
+
+    expect($output)->toHaveCount(1);
+
+    expect($output[0]->get())->toBe(['foo' => 'one', 'bar' => 'two', 'baz' => 'three', 'quz' => 'four']);
+});

--- a/tests/Steps/StepTest.php
+++ b/tests/Steps/StepTest.php
@@ -729,3 +729,13 @@ it(
         expect($outputs[0]->get())->toBe(['baz' => 'three', 'foo' => 'one', 'bar' => 'two']);
     }
 );
+
+it('keeps the original input data when useInputKey() is used', function () {
+    $step = helper_getValueReturningStep(['baz' => 'three'])
+        ->keepInputData()
+        ->useInputKey('bar');
+
+    $outputs = helper_invokeStepWithInput($step, ['foo' => 'one', 'bar' => 'two']);
+
+    expect($outputs[0]->get())->toBe(['baz' => 'three', 'foo' => 'one', 'bar' => 'two']);
+});


### PR DESCRIPTION
When using the new keepInputData() method in combination with useInputKey(), it still uses the full original input and not only the one key defined in useInputKey(), to add to the output.