### PR TITLE
Output key aliases for addToResult()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+* `addToResult()` now also works with serializable objects.
+* If you know certain keys that the output of a step will contain, you can now also define aliases for those keys, to be used with `addToResult()`. The output of an `Http` step (`RespondedRequest`) contains the keys `requestUri` and `effectiveUri`. The aliases `url` and `uri` refer to `effectiveUri`, so `addToResult(['url'])` will add the `effectiveUri` as `url` to the result object.
+
 ## [1.0.2] - 2023-03-20
 ### Fixed
 * JSON step: another fix for JSON strings having keys without quotes with empty string value.

--- a/src/Steps/Loading/Http.php
+++ b/src/Steps/Loading/Http.php
@@ -178,6 +178,17 @@ class Http extends LoadingStep
         }
     }
 
+    protected function outputKeyAliases(): array
+    {
+        return [
+            'url' => 'effectiveUri',
+            'uri' => 'effectiveUri',
+            'status' => 'responseStatusCode',
+            'headers' => 'responseHeaders',
+            'body' => 'responseBody',
+        ];
+    }
+
     protected function getResponseFromInputUri(UriInterface $input): ?RespondedRequest
     {
         $request = $this->getRequestFromInputUri($input);

--- a/tests/Steps/StepTest.php
+++ b/tests/Steps/StepTest.php
@@ -815,3 +815,37 @@ it(
         expect($outputs[0]->get())->toBe(['foo' => 'one', 'bar' => 'two']);
     }
 );
+
+test('you can define aliases for output keys for addToResult()', function () {
+    $step = new class () extends Step {
+        protected function invoke(mixed $input): Generator
+        {
+            yield [
+                'foo' => 'one',
+                'bar' => 'two',
+                'baz' => 'three',
+            ];
+        }
+
+        protected function outputKeyAliases(): array
+        {
+            return [
+                'woo' => 'foo',
+                'war' => 'bar',
+                'waz' => 'baz',
+            ];
+        }
+    };
+
+    $step->addToResult(['woo', 'far' => 'war', 'waz']);
+
+    $outputs = helper_invokeStepWithInput($step);
+
+    expect($outputs[0]->result)->toBeInstanceOf(Result::class);
+
+    expect($outputs[0]->result?->toArray())->toBe([
+        'woo' => 'one',
+        'far' => 'two',
+        'waz' => 'three',
+    ]);
+});


### PR DESCRIPTION
* `addToResult()` now also works with serializable objects.
* If you know certain keys that the output of a step will contain, you can now also define aliases for those keys, to be used with `addToResult()`. The output of an `Http` step (`RespondedRequest`) contains the keys `requestUri` and `effectiveUri`. The aliases `url` and `uri` refer to `effectiveUri`, so `addToResult(['url'])` will add the `effectiveUri` as `url` to the result object.