### PR TITLE
Links/URLs without fragment part

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `Crawler::runAndDump()` as a simple way to just run a crawler and dump all results, each as an array.
 * `addToResult()` now also works with serializable objects.
 * If you know certain keys that the output of a step will contain, you can now also define aliases for those keys, to be used with `addToResult()`. The output of an `Http` step (`RespondedRequest`) contains the keys `requestUri` and `effectiveUri`. The aliases `url` and `uri` refer to `effectiveUri`, so `addToResult(['url'])` will add the `effectiveUri` as `url` to the result object.
+* The `GetLink` (`Html::getLink()`) and `GetLinks` (`Html::getLinks()`) steps, as well as the abstract `DomQuery` (parent of `CssSelector` (/`Dom::cssSelector`) and `XPathQuery` (/`Dom::xPath`)) now have a method `withoutFragment()` to get links respectively URLs without their fragment part.
 
 ### Fixed
+* The `HttpCrawl` step (`Http::crawl()`) by default now removes the fragment part of URLs to not load the same page multiple times, because in almost any case, servers won't respond with different content based on the fragment. That's why this change is considered non-breaking. For the rare cases when servers respond with different content based on the fragment, you can call the new `keepUrlFragment()` method of the step.
 * A so-called byte order mark at the beginning of a file (/string) can cause issues. So just remove it, when a step's input string starts with a UTF-8 BOM.
 
 ## [1.0.2] - 2023-03-20

--- a/src/Steps/Html/DomQuery.php
+++ b/src/Steps/Html/DomQuery.php
@@ -3,6 +3,7 @@
 namespace Crwlr\Crawler\Steps\Html;
 
 use Crwlr\Url\Url;
+use Exception;
 use InvalidArgumentException;
 use Symfony\Component\DomCrawler\Crawler;
 
@@ -23,6 +24,8 @@ abstract class DomQuery implements DomQueryInterface
     protected bool $onlyOddMatches = false;
 
     protected bool $toAbsoluteUrl = false;
+
+    protected bool $withFragment = true;
 
     protected ?string $baseUrl = null;
 
@@ -173,6 +176,13 @@ abstract class DomQuery implements DomQueryInterface
         return $this;
     }
 
+    public function withoutFragment(): self
+    {
+        $this->withFragment = false;
+
+        return $this;
+    }
+
     /**
      * Call this method and the selected value will be converted to an absolute url when apply() is called.
      *
@@ -259,9 +269,21 @@ abstract class DomQuery implements DomQueryInterface
         );
 
         if ($this->toAbsoluteUrl && $this->baseUrl !== null) {
-            $target = Url::parse($this->baseUrl)->resolve($target);
+            $target = $this->handleUrlFragment(Url::parse($this->baseUrl)->resolve($target));
         }
 
         return $target;
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function handleUrlFragment(Url $url): Url
+    {
+        if (!$this->withFragment) {
+            $url->fragment('');
+        }
+
+        return $url;
     }
 }

--- a/src/Steps/Html/GetLink.php
+++ b/src/Steps/Html/GetLink.php
@@ -29,6 +29,8 @@ class GetLink extends Step
      */
     protected ?array $onHost = null;
 
+    protected bool $withFragment = true;
+
     public function __construct(protected ?string $selector = null)
     {
     }
@@ -62,7 +64,9 @@ class GetLink extends Step
                 continue;
             }
 
-            $linkUrl = $this->baseUri->resolve((new Crawler($link))->attr('href') ?? '');
+            $linkUrl = $this->handleUrlFragment(
+                $this->baseUri->resolve((new Crawler($link))->attr('href') ?? '')
+            );
 
             if ($this->matchesAdditionalCriteria($linkUrl)) {
                 yield $linkUrl->__toString();
@@ -129,6 +133,13 @@ class GetLink extends Step
         $hosts = is_string($hosts) ? [$hosts] : $hosts;
 
         $this->onHost = $this->onHost ? array_merge($this->onHost, $hosts) : $hosts;
+
+        return $this;
+    }
+
+    public function withoutFragment(): static
+    {
+        $this->withFragment = false;
 
         return $this;
     }
@@ -210,5 +221,17 @@ class GetLink extends Step
         }
 
         return true;
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function handleUrlFragment(Url $url): Url
+    {
+        if (!$this->withFragment) {
+            $url->fragment('');
+        }
+
+        return $url;
     }
 }

--- a/src/Steps/Html/GetLinks.php
+++ b/src/Steps/Html/GetLinks.php
@@ -25,7 +25,9 @@ class GetLinks extends GetLink
                 continue;
             }
 
-            $linkUrl = $this->baseUri->resolve((new Crawler($link))->attr('href') ?? '');
+            $linkUrl = $this->handleUrlFragment(
+                $this->baseUri->resolve((new Crawler($link))->attr('href') ?? '')
+            );
 
             if ($this->matchesAdditionalCriteria($linkUrl)) {
                 yield $linkUrl->__toString();

--- a/tests/Steps/Html/GetLinkTest.php
+++ b/tests/Steps/Html/GetLinkTest.php
@@ -12,7 +12,7 @@ use InvalidArgumentException;
 use function tests\helper_invokeStepWithInput;
 use function tests\helper_traverseIterable;
 
-test('It works with a RespondedRequest as input', function () {
+it('works with a RespondedRequest as input', function () {
     $step = (new GetLink());
 
     $link = helper_invokeStepWithInput($step, new RespondedRequest(
@@ -25,7 +25,7 @@ test('It works with a RespondedRequest as input', function () {
     expect($link[0]->get())->toBe('https://www.crwl.io/blog');
 });
 
-test('It does not work with something else as input', function () {
+it('does not work with something else as input', function () {
     $step = (new GetLink());
 
     helper_traverseIterable($step->invokeStep(new Input(new Response())));
@@ -364,4 +364,31 @@ it('works correctly when HTML contains a base tag', function () {
     ));
 
     expect($links[0]->get())->toBe('https://www.example.com/c/e');
+});
+
+it('throws away the URL fragment part when withoutFragment() was called', function () {
+    $html = <<<HTML
+        <!DOCTYPE html>
+        <html>
+        <head></head>
+        <body><a href="/foo/bar#fragment">link</a></body>
+        </html>
+        HTML;
+
+    $step = (new GetLink());
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.example.com/foo/baz'),
+        new Response(200, [], $html)
+    );
+
+    $links = helper_invokeStepWithInput($step, $respondedRequest);
+
+    expect($links[0]->get())->toBe('https://www.example.com/foo/bar#fragment');
+
+    $step->withoutFragment();
+
+    $links = helper_invokeStepWithInput($step, $respondedRequest);
+
+    expect($links[0]->get())->toBe('https://www.example.com/foo/bar');
 });

--- a/tests/_Integration/Http/CrawlingTest.php
+++ b/tests/_Integration/Http/CrawlingTest.php
@@ -342,3 +342,32 @@ it(
         expect($results)->toHaveCount(3);
     }
 );
+
+it(
+    'keeps the fragment parts in URLs and treats the same URL with a different fragment part as separate URLs when ' .
+    'keepUrlFragment() was called',
+    function () {
+        // Explanation: in almost all cases URLs with a fragment part at the end (#something) will respond with the
+        // same content. So, to avoid loading the same page multiple times, the step throws away the fragment part of
+        // discovered URLs by default.
+        $crawler = (new Crawler())
+            ->input('http://www.example.com/crawling/main')
+            ->addStep(Http::crawl()->keepUrlFragment()->addToResult(['url']));
+
+        $results = helper_generatorToArray($crawler->run());
+
+        expect($results)->toHaveCount(8);
+
+        $urls = [];
+
+        foreach ($results as $result) {
+            $urls[] = $result->get('url');
+        }
+
+        expect($urls)->toContain('http://www.example.com/crawling/sub2');
+
+        expect($urls)->toContain('http://www.example.com/crawling/sub2#fragment1');
+
+        expect($urls)->toContain('http://www.example.com/crawling/sub2#fragment2');
+    }
+);

--- a/tests/_Integration/_Server/Crawling.php
+++ b/tests/_Integration/_Server/Crawling.php
@@ -32,7 +32,9 @@ if ($route === '/crawling/main') {
         <body>
             <a href="/crawling/sub1">Subpage 1</a> <br>
             <a href="/crawling/sub2">Subpage 2</a> <br>
-            
+            <a href="/crawling/sub2#fragment1">Subpage 2 - Fragment 1</a> <br>
+            <a href="/crawling/sub2#fragment2">Subpage 2 - Fragment 2</a> <br>
+
             <a href="https://www.crwlr.software/packages/crawler">External link</a>
         </body>
         </html>
@@ -45,9 +47,9 @@ if ($route === '/crawling/sub1') {
         <html lang="en">
         <body>
             <a href="/crawling/sub1/sub1">Subpage 1 of Subpage 1</a> <br>
-            
+
             <a href="https://www.foo.com">External link</a>
-            
+
             <a href="http://foo.example.com/crawling/main-on-subdomain">Link to subdomain</a>
         </body>
         </html>


### PR DESCRIPTION
The `HttpCrawl` step (`Http::crawl()`) by default now removes the fragment part of URLs to not load the same page multiple times, because in almost any case, servers won't respond with different content based on the fragment. That's why this change is considered non-breaking. For the rare cases when servers respond with different content based on the fragment, you can call the new `keepUrlFragment()` method of the step.

The `GetLink` (`Html::getLink()`) and `GetLinks` (`Html::getLinks()`) steps, as well as the abstract `DomQuery` (parent of `CssSelector` (/`Dom::cssSelector`) and `XPathQuery` (/`Dom::xPath`)) now have a method `withoutFragment()` to get links respectively URLs without their fragment part.