### PR TITLE
Http::crawl() step respect maxOutputs limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * The `HttpCrawl` step (`Http::crawl()`) by default now removes the fragment part of URLs to not load the same page multiple times, because in almost any case, servers won't respond with different content based on the fragment. That's why this change is considered non-breaking. For the rare cases when servers respond with different content based on the fragment, you can call the new `keepUrlFragment()` method of the step.
+* Although the `HttpCrawl` step (`Http::crawl()`) already respected the limit of outputs defined via the `maxOutputs()` method, it actually didn't stop loading pages. The limit had no effect on loading, only on passing on outputs (responses) to the next step. This is fixed in this version.
 * A so-called byte order mark at the beginning of a file (/string) can cause issues. So just remove it, when a step's input string starts with a UTF-8 BOM.
 
 ## [1.0.2] - 2023-03-20

--- a/tests/_Integration/Http/CrawlingTest.php
+++ b/tests/_Integration/Http/CrawlingTest.php
@@ -371,3 +371,19 @@ it(
         expect($urls)->toContain('http://www.example.com/crawling/sub2#fragment2');
     }
 );
+
+it('stops crawling when maxOutputs is reached', function () {
+    $crawler = (new Crawler())
+        ->input('http://www.example.com/crawling/main')
+        ->addStep(
+            Http::crawl()
+                ->keepUrlFragment()
+                ->maxOutputs(4)
+        );
+
+    $results = helper_generatorToArray($crawler->run());
+
+    expect($results)->toHaveCount(4);
+
+    expect($crawler->getLoader()->loadedUrls)->toHaveCount(4);
+});


### PR DESCRIPTION
Although the `HttpCrawl` step (`Http::crawl()`) already respected the limit of outputs defined via the `maxOutputs()` method, it actually didn't stop loading pages. The limit had no effect on loading, only on passing on outputs (responses) to the next step. Fixed it.