### PR TITLE
Get HTTP request parameters from input data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+* `Http` steps can now receive body and headers from input data (instead of statically defining them via argument like `Http::method(headers: ...)`) using the new methods `useInputKeyAsBody(<key>)` and `useInputKeyAsHeader(<key>, <asHeader>)` or `useInputKeyAsHeaders(<key>)`. Further, when invoked with associative array input data, the step will by default use the value from `url` or `uri` for the request URL. If the input array contains the URL in a key with a different name, you can use the new `useInputKeyAsUrl(<key>)` method. That was basically already possible with the existing `useInputKey(<key>)` method, because the URL is the main input argument for the step. But if you want to use it in combination with the other new `useInputKeyAsXyz()` methods, you have to use `useInputKeyAsUrl()`, because using `useInputKey(<key>)` would invoke the whole step with that key only.
 * `Crawler::runAndDump()` as a simple way to just run a crawler and dump all results, each as an array.
 * `addToResult()` now also works with serializable objects.
 * If you know certain keys that the output of a step will contain, you can now also define aliases for those keys, to be used with `addToResult()`. The output of an `Http` step (`RespondedRequest`) contains the keys `requestUri` and `effectiveUri`. The aliases `url` and `uri` refer to `effectiveUri`, so `addToResult(['url'])` will add the `effectiveUri` as `url` to the result object.
@@ -16,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The `HttpCrawl` step (`Http::crawl()`) by default now removes the fragment part of URLs to not load the same page multiple times, because in almost any case, servers won't respond with different content based on the fragment. That's why this change is considered non-breaking. For the rare cases when servers respond with different content based on the fragment, you can call the new `keepUrlFragment()` method of the step.
 * Although the `HttpCrawl` step (`Http::crawl()`) already respected the limit of outputs defined via the `maxOutputs()` method, it actually didn't stop loading pages. The limit had no effect on loading, only on passing on outputs (responses) to the next step. This is fixed in this version.
 * A so-called byte order mark at the beginning of a file (/string) can cause issues. So just remove it, when a step's input string starts with a UTF-8 BOM.
+* There seems to be an issue in guzzle when it gets a PSR-7 request object with a header with multiple string values (as array, like: `['accept-encoding' => ['gzip', 'deflate', 'br']]`). When testing it happened that it only sent the last part (in this case `br`). Therefor the `HttpLoader` now prepares headers before sending (in this case to: `['accept-encoding' => ['gzip, deflate, br']]`).
 
 ## [1.0.2] - 2023-03-20
 ### Fixed

--- a/src/Loader/Http/HttpLoader.php
+++ b/src/Loader/Http/HttpLoader.php
@@ -392,6 +392,14 @@ class HttpLoader extends Loader
     {
         $request = $request->withHeader('User-Agent', $this->userAgent->__toString());
 
+        // When writing tests I found that guzzle somehow messed up headers with multiple strings as value in the PSR-7
+        // request object. It sent only the last part of the array, instead of concatenating the array of strings to a
+        // comma separated string. Don't know if that happens with all handlers (curl, stream), will investigate
+        // further. But until this is fixed, we just prepare the headers ourselves.
+        foreach ($request->getHeaders() as $headerName => $headerValues) {
+            $request = $request->withHeader($headerName, $request->getHeaderLine($headerName));
+        }
+
         return $this->addCookiesToRequest($request);
     }
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,13 +2,16 @@
 
 namespace tests;
 
+use Crwlr\Crawler\HttpCrawler;
 use Crwlr\Crawler\Input;
 use Crwlr\Crawler\Loader\Http\HttpLoader;
 use Crwlr\Crawler\Loader\Http\Politeness\TimingUnits\Microseconds;
 use Crwlr\Crawler\Loader\Http\Politeness\TimingUnits\MultipleOf;
+use Crwlr\Crawler\Loader\LoaderInterface;
 use Crwlr\Crawler\Output;
 use Crwlr\Crawler\Steps\Step;
 use Crwlr\Crawler\Steps\StepInterface;
+use Crwlr\Crawler\UserAgents\UserAgent;
 use Crwlr\Crawler\UserAgents\UserAgentInterface;
 use Generator;
 use GuzzleHttp\Psr7\Response;
@@ -244,4 +247,19 @@ function helper_getFastLoader(UserAgentInterface $userAgent, ?LoggerInterface $l
         ->waitAtLeast(Microseconds::fromSeconds(0.0001));
 
     return $loader;
+}
+
+function helper_getFastCrawler(): HttpCrawler
+{
+    return new class () extends HttpCrawler {
+        protected function userAgent(): UserAgentInterface
+        {
+            return new UserAgent('TestBot');
+        }
+
+        protected function loader(UserAgentInterface $userAgent, LoggerInterface $logger): LoaderInterface|array
+        {
+            return helper_getFastLoader($userAgent, $logger);
+        }
+    };
 }

--- a/tests/_Integration/Http/RequestParamsFromInputTest.php
+++ b/tests/_Integration/Http/RequestParamsFromInputTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace tests\_Integration\Http;
+
+use Crwlr\Crawler\Steps\Loading\Http;
+use Crwlr\Crawler\Steps\Step;
+use Generator;
+
+use function tests\helper_generatorToArray;
+use function tests\helper_getFastCrawler;
+
+test('Http steps can receive url, body and headers from an input array', function () {
+    $paramsStep = new class () extends Step {
+        protected function invoke(mixed $input): Generator
+        {
+            yield [
+                'url' => 'http://localhost:8000/print-headers',
+                'body' => 'test',
+                'headers' => [
+                    'header-x' => 'foo',
+                    'header-y' => ['bar'],
+                ],
+                'header-y' => 'baz',
+                'header-z' => ['quz'],
+            ];
+        }
+    };
+
+    $getJsonDataStep = new class () extends Step {
+        protected function invoke(mixed $input): Generator
+        {
+            yield json_decode(Http::getBodyString($input->response), true);
+        }
+    };
+
+    $crawler = helper_getFastCrawler();
+
+    $crawler
+        ->input('anything')
+        ->addStep($paramsStep)
+        ->addStep(
+            Http::get()
+                ->useInputKeyAsBody('body')
+                ->useInputKeyAsHeaders('headers')
+                ->useInputKeyAsHeader('header-y', 'header-y')
+                ->useInputKeyAsHeader('header-z', 'header-z')
+        )
+        ->addStep($getJsonDataStep);
+
+    $results = helper_generatorToArray($crawler->run());
+
+    expect($results)->toHaveCount(1);
+
+    $result = $results[0]->toArray();
+
+    expect($result['Content-Length'])->toBe('4');
+
+    expect($result['header-x'])->toBe('foo');
+
+    expect($result['header-y'])->toBe('bar, baz');
+
+    expect($result['header-z'])->toBe('quz');
+});


### PR DESCRIPTION
Add new methods `useInputKeyAsUrl()`, `useInputKeyAsBody()`, `useInputKeyAsHeader()` and `useInputKeyAsHeaders()` to the Http steps, so you can have dynamic body or headers coming from outputs from previous steps.

Also fix a minor issue with sending headers with multiple values, that seems to happen somewhere in guzzle.