### PR TITLE
Filter by output key aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Although the `HttpCrawl` step (`Http::crawl()`) already respected the limit of outputs defined via the `maxOutputs()` method, it actually didn't stop loading pages. The limit had no effect on loading, only on passing on outputs (responses) to the next step. This is fixed in this version.
 * A so-called byte order mark at the beginning of a file (/string) can cause issues. So just remove it, when a step's input string starts with a UTF-8 BOM.
 * There seems to be an issue in guzzle when it gets a PSR-7 request object with a header with multiple string values (as array, like: `['accept-encoding' => ['gzip', 'deflate', 'br']]`). When testing it happened that it only sent the last part (in this case `br`). Therefor the `HttpLoader` now prepares headers before sending (in this case to: `['accept-encoding' => ['gzip, deflate, br']]`).
+* You can now also use the output key aliases when filtering step outputs. You can even use keys that are only present in the serialized version of an output object.
 
 ## [1.0.2] - 2023-03-20
 ### Fixed

--- a/src/Steps/BaseStep.php
+++ b/src/Steps/BaseStep.php
@@ -142,6 +142,10 @@ abstract class BaseStep implements StepInterface
         if (is_string($keyOrFilter) && $filter === null) {
             throw new InvalidArgumentException('You have to provide a Filter (instance of FilterInterface)');
         } elseif (is_string($keyOrFilter)) {
+            if ($this->isOutputKeyAlias($keyOrFilter)) {
+                $keyOrFilter = $this->getOutputKeyAliasRealKey($keyOrFilter);
+            }
+
             $filter->useKey($keyOrFilter);
 
             $this->filters[] = $filter;
@@ -465,6 +469,18 @@ abstract class BaseStep implements StepInterface
         }
 
         return $aliases;
+    }
+
+    protected function isOutputKeyAlias(string $key): bool
+    {
+        return array_key_exists($key, $this->outputKeyAliases());
+    }
+
+    protected function getOutputKeyAliasRealKey(string $key): string
+    {
+        $mapping = $this->outputKeyAliases();
+
+        return $mapping[$key];
     }
 
     /**

--- a/src/Steps/Filters/Filter.php
+++ b/src/Steps/Filters/Filter.php
@@ -178,6 +178,14 @@ abstract class Filter implements FilterInterface
             throw new InvalidArgumentException('Can only filter by key with array or object output.');
         }
 
+        if (is_object($value) && !property_exists($value, $this->useKey) && method_exists($value, '__serialize')) {
+            $serialized = $value->__serialize();
+
+            if (array_key_exists($this->useKey, $serialized)) {
+                $value = $serialized;
+            }
+        }
+
         if (
             (is_array($value) && !array_key_exists($this->useKey, $value)) ||
             (is_object($value) && !property_exists($value, $this->useKey))


### PR DESCRIPTION
You can now also use the output key aliases when filtering step outputs. You can even use keys that are only present in the serialized version of an output object.