### PR TITLE
Use new crwlr/utils Json class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "ext-dom": "*",
         "php": "^8.1",
         "crwlr/robots-txt": "^1.1",
-        "crwlr/schema-org": "^0.1.0",
+        "crwlr/schema-org": "^0.2.0",
         "crwlr/url": "^2.0",
         "psr/log": "^2.0|^3.0",
         "symfony/dom-crawler": "^6.0",
@@ -39,7 +39,8 @@
         "psr/simple-cache": "^1.0|^2.0|^3.0",
         "guzzlehttp/guzzle": "^7.4",
         "adbario/php-dot-notation": "^3.1",
-        "chrome-php/chrome": "^1.7"
+        "chrome-php/chrome": "^1.7",
+        "crwlr/utils": "^1.0"
     },
     "require-dev": {
         "pestphp/pest": "^2.3",

--- a/src/Steps/Html/SchemaOrg.php
+++ b/src/Steps/Html/SchemaOrg.php
@@ -43,7 +43,7 @@ class SchemaOrg extends Step
 
     protected function invoke(mixed $input): Generator
     {
-        $data = \Crwlr\SchemaOrg\SchemaOrg::fromHtml($input);
+        $data = \Crwlr\SchemaOrg\SchemaOrg::fromHtml($input, $this->logger);
 
         foreach ($data as $schemaOrgObject) {
             if ($this->onlyType && $schemaOrgObject->getType() !== $this->onlyType) {


### PR DESCRIPTION
Extracted the fixJsonString() method to a separate utils package, because it's also needed in the schema-org package. This new package shall be a place for all the functionality that will be needed in multiple crwlr packages.