### PR TITLE
Fix issue with array of arrays in result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2023-05-28
+### Fixed
+* There was an issue when adding multiple associative arrays with the same key to a `Result` object: let's say you're having a step producing array output like: `['bar' => 'something', 'baz' => 'something else']` and it (the whole array) shall be added to the result property `foo`. When the step produced multiple such array outputs, that led to a result like `['bar' => '...', 'baz' => '...', ['bar' => '...', 'baz' => '...'], ['bar' => '...', 'baz' => '...']`. Now it's fixed to result in `[['bar' => '...', 'baz' => '...'], ['bar' => '...', 'baz' => '...'], ['bar' => '...', 'baz' => '...']`.
+
 ## [1.1.0] - 2023-05-21
 
 ### Added

--- a/src/Result.php
+++ b/src/Result.php
@@ -23,10 +23,10 @@ final class Result
         }
 
         if (array_key_exists($key, $this->data)) {
-            if (is_array($this->data[$key])) {
-                $this->data[$key][] = $value;
-            } else {
+            if (!is_array($this->data[$key]) || $this->isAssociativeArray($this->data[$key])) {
                 $this->data[$key] = [$this->data[$key], $value];
+            } else {
+                $this->data[$key][] = $value;
             }
         } else {
             $this->data[$key] = $value;
@@ -61,5 +61,17 @@ final class Result
         }
 
         return 'unnamed' . $i;
+    }
+
+    /**
+     * @param mixed[] $array
+     */
+    private function isAssociativeArray(array $array): bool
+    {
+        foreach ($array as $key => $value) {
+            return is_string($key);
+        }
+
+        return false;
     }
 }

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -80,3 +80,18 @@ test('you can create a new instance from another instance', function () {
 
     expect($instance2->get('baz'))->toBe('quz');
 });
+
+test('it makes a proper array of arrays if you repeatedly add (associative) arrays with the same key', function () {
+    $result = new Result();
+
+    $result->set('foo', ['bar' => 'one', 'baz' => 'two']);
+
+    expect($result->get('foo'))->toBe(['bar' => 'one', 'baz' => 'two']);
+
+    $result->set('foo', ['bar' => 'three', 'baz' => 'four']);
+
+    expect($result->get('foo'))->toBe([
+        ['bar' => 'one', 'baz' => 'two'],
+        ['bar' => 'three', 'baz' => 'four'],
+    ]);
+});


### PR DESCRIPTION
When the current value of a result property is an associative array and we add another value, it makes the property value an array with that associative array as first element and add the second value.