### PR TITLE
Fix getting only certain HTML meta data properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2] - 2023-05-28
+* Using the `only()` method of the `MetaData` (`Html::metaData()`) step class, the `title` property was always contained in the output, even if not listed in the `only` properties. This is fixed now.
+
 ## [1.1.1] - 2023-05-28
 ### Fixed
 * There was an issue when adding multiple associative arrays with the same key to a `Result` object: let's say you're having a step producing array output like: `['bar' => 'something', 'baz' => 'something else']` and it (the whole array) shall be added to the result property `foo`. When the step produced multiple such array outputs, that led to a result like `['bar' => '...', 'baz' => '...', ['bar' => '...', 'baz' => '...'], ['bar' => '...', 'baz' => '...']`. Now it's fixed to result in `[['bar' => '...', 'baz' => '...'], ['bar' => '...', 'baz' => '...'], ['bar' => '...', 'baz' => '...']`.

--- a/src/Steps/Html/MetaData.php
+++ b/src/Steps/Html/MetaData.php
@@ -29,7 +29,7 @@ class MetaData extends Step
      */
     protected function invoke(mixed $input): Generator
     {
-        $data = ['title' => $this->getTitle($input)];
+        $data = $this->addToData([], 'title', $this->getTitle($input));
 
         foreach ($input->filter('meta') as $metaElement) {
             /** @var DOMElement $metaElement */
@@ -40,7 +40,7 @@ class MetaData extends Step
             }
 
             if (!empty($metaName) && (empty($this->onlyKeys) || in_array($metaName, $this->onlyKeys, true))) {
-                $data[$metaName] = $metaElement->getAttribute('content');
+                $data = $this->addToData($data, $metaName, $metaElement->getAttribute('content'));
             }
         }
 
@@ -61,5 +61,18 @@ class MetaData extends Step
         }
 
         return '';
+    }
+
+    /**
+     * @param array<string, string> $data
+     * @return array<string, string>
+     */
+    protected function addToData(array $data, string $key, string $value): array
+    {
+        if (empty($this->onlyKeys) || in_array($key, $this->onlyKeys, true)) {
+            $data[$key] = $value;
+        }
+
+        return $data;
     }
 }

--- a/tests/Steps/Html/MetaDataTest.php
+++ b/tests/Steps/Html/MetaDataTest.php
@@ -69,10 +69,10 @@ it('returns only the meta tags defined via the only() method', function () {
         </html>
         HTML;
 
-    $outputs = helper_invokeStepWithInput(Html::metaData()->only(['title', 'description']), $html);
+    $outputs = helper_invokeStepWithInput(Html::metaData()->only(['description', 'og:title']), $html);
 
     expect($outputs[0]->get())->toBe([
-        'title' => 'Hello World!',
         'description' => 'This is a page saying: Hello World!',
+        'og:title' => 'Hello World!',
     ]);
 });


### PR DESCRIPTION
Using the `only()` method of the `MetaData` (`Html::metaData()`) step class, the `title` property was always contained in the output, even if not listed in the `only` properties. This is fixed now.