### PR TITLE
Improve Json step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.3] - 2023-06-29
+### Fixed
+* Improved `Json` step: if the target of the "each" (like `Json::each('target', [...])`) does not exist in the input JSON data, the step yields nothing and logs a warning.
+
 ## [1.1.2] - 2023-05-28
+### Fixed
 * Using the `only()` method of the `MetaData` (`Html::metaData()`) step class, the `title` property was always contained in the output, even if not listed in the `only` properties. This is fixed now.
 
 ## [1.1.1] - 2023-05-28

--- a/src/Steps/Json.php
+++ b/src/Steps/Json.php
@@ -54,8 +54,12 @@ class Json extends Step
         } else {
             $each = $this->each === '' ? $dot->get() : $dot->get($this->each);
 
-            foreach ($each as $item) {
-                yield $this->mapProperties(new Dot($item));
+            if (!is_iterable($each)) {
+                $this->logger?->warning('The target of "each" does not exist in the JSON data.');
+            } else {
+                foreach ($each as $item) {
+                    yield $this->mapProperties(new Dot($item));
+                }
             }
         }
     }

--- a/tests/Steps/JsonTest.php
+++ b/tests/Steps/JsonTest.php
@@ -3,12 +3,16 @@
 namespace tests\Steps;
 
 use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Logger\CliLogger;
 use Crwlr\Crawler\Steps\Json;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Utils;
+use PHPUnit\Framework\TestCase;
 
 use function tests\helper_invokeStepWithInput;
+
+/** @var TestCase $this */
 
 it('accepts RespondedRequest as input', function () {
     $json = '{ "data": { "foo": "bar" } }';
@@ -136,6 +140,22 @@ test('When the root element is an array you can use each with empty string as pa
     expect($output[2]->get())->toBe(['nickname' => 'Poppi']);
 
     expect($output[3]->get())->toBe(['nickname' => 'Dominik']);
+});
+
+it('yields no results and logs a warning when the target for "each" does not exist', function () {
+    $jsonString = '{ "foo": { "bar": [{ "number": "one" }, { "number": "two" }] } }';
+
+    $step = Json::each('boo.bar', ['number']);
+
+    $step->addLogger(new CliLogger());
+
+    $output = helper_invokeStepWithInput($step, $jsonString);
+
+    expect($output)->toHaveCount(0);
+
+    $logOutput = $this->getActualOutputForAssertion();
+
+    expect($logOutput)->toContain('The target of "each" does not exist in the JSON data.');
 });
 
 it('also works with JS style JSON objects without quotes around keys', function () {


### PR DESCRIPTION
If the target of the "each" (like `Json::each('target', [...])`) does not exist in the input JSON data, the step yields nothing and logs a warning.