### PR TITLE
Fix reading input sitemap in HTTP crawl step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.4] - 2023-07-14
+### Fixed
+* The `Http::crawl()` step now also work with sitemaps as input URL, where the `<urlset>` tag contains attributes that would cause the symfony DomCrawler to not find any elements.
+
 ## [1.1.3] - 2023-06-29
 ### Fixed
 * Improved `Json` step: if the target of the "each" (like `Json::each('target', [...])`) does not exist in the input JSON data, the step yields nothing and logs a warning.

--- a/src/Steps/Loading/HttpCrawl.php
+++ b/src/Steps/Loading/HttpCrawl.php
@@ -5,6 +5,7 @@ namespace Crwlr\Crawler\Steps\Loading;
 use Closure;
 use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
 use Crwlr\Crawler\Steps\Loading\Http\Document;
+use Crwlr\Crawler\Steps\Sitemap\GetUrlsFromSitemap;
 use Crwlr\Url\Url;
 use Exception;
 use Generator;
@@ -249,7 +250,7 @@ class HttpCrawl extends Http
      */
     protected function getUrlsFromSitemap(RespondedRequest $respondedRequest): array
     {
-        $domCrawler = new Crawler(Http::getBodyString($respondedRequest));
+        $domCrawler = GetUrlsFromSitemap::fixUrlSetTag(new Crawler(Http::getBodyString($respondedRequest)));
 
         $urls = [];
 

--- a/src/Steps/Sitemap/GetUrlsFromSitemap.php
+++ b/src/Steps/Sitemap/GetUrlsFromSitemap.php
@@ -15,9 +15,6 @@ class GetUrlsFromSitemap extends Step
      *
      * Symfony's DomCrawler component has problems when a sitemap's <urlset> tag contains certain attributes.
      * So, if the count of urls in the sitemap is zero, try to remove all attributes from the <urlset> tag.
-     *
-     * @param Crawler $dom
-     * @return Crawler
      */
     public static function fixUrlSetTag(Crawler $dom): Crawler
     {

--- a/tests/_Integration/Http/CrawlingTest.php
+++ b/tests/_Integration/Http/CrawlingTest.php
@@ -188,6 +188,19 @@ it('fails to extract URLs if you provide a sitemap as input and don\'t call inpu
     expect($crawler->getLoader()->loadedUrls)->toHaveCount(1);
 });
 
+it(
+    'extracts URLs from a sitemap where the <urlset> tag contains attributes that cause symfony DomCrawler to fail',
+    function () {
+        $crawler = (new Crawler())
+            ->input('http://www.example.com/crawling/sitemap2.xml')
+            ->addStep(Http::crawl()->inputIsSitemap());
+
+        $crawler->runAndTraverse();
+
+        expect($crawler->getLoader()->loadedUrls)->toHaveCount(7);
+    }
+);
+
 it('loads only pages where the path starts with a certain string when method pathStartsWith() is called', function () {
     $crawler = (new Crawler())
         ->input('http://www.example.com/crawling/sitemap.xml')

--- a/tests/_Integration/_Server/Crawling.php
+++ b/tests/_Integration/_Server/Crawling.php
@@ -25,6 +25,20 @@ if ($route === '/crawling/sitemap.xml') {
 XML;
 }
 
+if ($route === '/crawling/sitemap2.xml') {
+    echo <<<XML
+<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="/typo3/sysext/seo/Resources/Public/CSS/Sitemap.xsl"?>
+<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd http://www.google.com/schemas/sitemap-image/1.1 http://www.google.com/schemas/sitemap-image/1.1/sitemap-image.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<url><loc>http://www.example.com/crawling/main</loc></url>
+<url><loc>http://www.example.com/crawling/sub1</loc></url>
+<url><loc>http://www.example.com/crawling/sub1/sub1</loc></url>
+<url><loc>http://www.example.com/crawling/sub2</loc></url>
+<url><loc>http://www.example.com/crawling/sub2/sub1</loc></url>
+<url><loc>http://www.example.com/crawling/sub2/sub1/sub1</loc></url>
+</urlset>
+XML;
+}
+
 if ($route === '/crawling/main') {
     echo <<<HTML
         <!doctype html>


### PR DESCRIPTION
The `Http::crawl()` step now also work with sitemaps as input URL, where the `<urlset>` tag contains attributes that would cause the symfony DomCrawler to not find any elements.