### PR TITLE
Ignore special non HTTP links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.5] - 2023-07-14
+### Fixed
+* The `Http::crawl()` step, as well as the `Html::getLink()` and `Html::getLinks()` steps now ignore links, when the `href` attribute starts with `mailto:`, `tel:` or `javascript:`. For the crawl step it obviously makes no sense, but it's also considered a bugfix for the getLink(s) steps, because they are meant to deliver absolute HTTP URLs. If you want to get the values of such links, use the HTML data extraction step.
+
 ## [1.1.4] - 2023-07-14
 ### Fixed
 * The `Http::crawl()` step now also work with sitemaps as input URL, where the `<urlset>` tag contains attributes that would cause the symfony DomCrawler to not find any elements.

--- a/src/Steps/Html/GetLinks.php
+++ b/src/Steps/Html/GetLinks.php
@@ -20,17 +20,10 @@ class GetLinks extends GetLink
         $selector = $this->selector ?? 'a';
 
         foreach ($input->filter($selector) as $link) {
-            if ($link->nodeName !== 'a') {
-                $this->logger?->warning('Selector matched <' . $link->nodeName . '> html element. Ignored it.');
-                continue;
-            }
+            $linkUrl = $this->getLinkUrl($link);
 
-            $linkUrl = $this->handleUrlFragment(
-                $this->baseUri->resolve((new Crawler($link))->attr('href') ?? '')
-            );
-
-            if ($this->matchesAdditionalCriteria($linkUrl)) {
-                yield $linkUrl->__toString();
+            if ($linkUrl) {
+                yield (string) $linkUrl;
             }
         }
     }

--- a/src/Steps/Loading/HttpCrawl.php
+++ b/src/Steps/Loading/HttpCrawl.php
@@ -4,6 +4,7 @@ namespace Crwlr\Crawler\Steps\Loading;
 
 use Closure;
 use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Html\GetLink;
 use Crwlr\Crawler\Steps\Loading\Http\Document;
 use Crwlr\Crawler\Steps\Sitemap\GetUrlsFromSitemap;
 use Crwlr\Url\Url;
@@ -289,6 +290,10 @@ class HttpCrawl extends Http
 
         foreach ($document->dom()->filter('a') as $link) {
             $linkElement = new Crawler($link);
+
+            if (GetLink::isSpecialNonHttpLink($linkElement)) {
+                continue;
+            }
 
             $url = $this->handleUrlFragment($document->baseUrl()->resolve($linkElement->attr('href') ?? ''));
 

--- a/tests/Steps/Html/GetLinkTest.php
+++ b/tests/Steps/Html/GetLinkTest.php
@@ -392,3 +392,29 @@ it('throws away the URL fragment part when withoutFragment() was called', functi
 
     expect($links[0]->get())->toBe('https://www.example.com/foo/bar');
 });
+
+it('ignores special non HTTP links', function () {
+    $html = <<<HTML
+        <!DOCTYPE html>
+        <html>
+        <head></head>
+        <body>
+        <a href="mailto:somebody@example.com">mailto link</a>
+        <a href="javascript:alert('hello');">javascript link</a>
+        <a href="tel:+499123456789">phone link</a>
+        <a href="/foo/bar">link</a>
+        </body>
+        </html>
+        HTML;
+
+    $step = (new GetLink());
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.example.com/home'),
+        new Response(200, [], $html)
+    );
+
+    $links = helper_invokeStepWithInput($step, $respondedRequest);
+
+    expect($links[0]->get())->toBe('https://www.example.com/foo/bar');
+});

--- a/tests/Steps/Html/GetLinksTest.php
+++ b/tests/Steps/Html/GetLinksTest.php
@@ -416,3 +416,37 @@ it('throws away the URL fragment part when withoutFragment() was called', functi
 
     expect($links[1]->get())->toBe('https://www.example.com/baz');
 });
+
+it('ignores special non HTTP links', function () {
+    $html = <<<HTML
+        <!DOCTYPE html>
+        <html>
+        <head></head>
+        <body>
+        <a href="mailto:somebody@example.com">mailto link</a>
+        <a href="/one">link one</a>
+        <a href="javascript:alert('hello');">javascript link</a>
+        <a href="/two">link two</a>
+        <a href="tel:+499123456789">phone link</a>
+        <a href="/three">link three</a>
+        </body>
+        </html>
+        HTML;
+
+    $step = (new GetLinks());
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.example.com/home'),
+        new Response(200, [], $html)
+    );
+
+    $links = helper_invokeStepWithInput($step, $respondedRequest);
+
+    expect($links)->toHaveCount(3);
+
+    expect($links[0]->get())->toBe('https://www.example.com/one');
+
+    expect($links[1]->get())->toBe('https://www.example.com/two');
+
+    expect($links[2]->get())->toBe('https://www.example.com/three');
+});

--- a/tests/_Integration/_Server/Crawling.php
+++ b/tests/_Integration/_Server/Crawling.php
@@ -50,6 +50,10 @@ if ($route === '/crawling/main') {
             <a href="/crawling/sub2#fragment2">Subpage 2 - Fragment 2</a> <br>
 
             <a href="https://www.crwlr.software/packages/crawler">External link</a>
+
+            <a href="mailto:somebody@example.com">mailto link</a>
+            <a href="javascript:alert('hello');">javascript link</a>
+            <a href="tel:+499123456789">phone link</a>
         </body>
         </html>
         HTML;


### PR DESCRIPTION
The `Http::crawl()` step, as well as the `Html::getLink()` and `Html::getLinks()` steps now ignore links, when the `href` attribute starts with `mailto:`, `tel:` or `javascript:`.