### PR TITLE
Fix throttling when using the headless browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.6] - 2023-07-20
+### Fixed
+* Throttling now also works when using the headless browser.
+
 ## [1.1.5] - 2023-07-14
 ### Fixed
 * The `Http::crawl()` step, as well as the `Html::getLink()` and `Html::getLinks()` steps now ignore links, when the `href` attribute starts with `mailto:`, `tel:` or `javascript:`. For the crawl step it obviously makes no sense, but it's also considered a bugfix for the getLink(s) steps, because they are meant to deliver absolute HTTP URLs. If you want to get the values of such links, use the HTML data extraction step.

--- a/src/Loader/Http/HttpLoader.php
+++ b/src/Loader/Http/HttpLoader.php
@@ -560,7 +560,7 @@ class HttpLoader extends Loader
 
         $page = $browser->createPage();
 
-        $statusCode = 500;
+        $statusCode = 200;
 
         $responseHeaders = [];
 
@@ -573,8 +573,13 @@ class HttpLoader extends Loader
             }
         );
 
-        $page->navigate($request->getUri()->__toString())
+        $this->throttler->trackRequestStartFor($request->getUri());
+
+        $page
+            ->navigate($request->getUri()->__toString())
             ->waitForNavigation();
+
+        $this->throttler->trackRequestEndFor($request->getUri());
 
         $html = $page->getHtml();
 

--- a/src/Loader/Http/Politeness/Throttler.php
+++ b/src/Loader/Http/Politeness/Throttler.php
@@ -105,7 +105,7 @@ class Throttler
             return;
         }
 
-        $waitUntil = $this->calcWaitUntil($domain);
+        $waitUntil = $this->calcWaitUntil($this->latestDurations[$domain], $this->latestResponseTimes[$domain]);
 
         $now = $this->time();
 
@@ -138,10 +138,10 @@ class Throttler
         return $domain;
     }
 
-    protected function calcWaitUntil(string $domain): Microseconds
-    {
-        $latestResponseDuration = $this->latestDurations[$domain];
-
+    protected function calcWaitUntil(
+        Microseconds $latestResponseDuration,
+        Microseconds $latestResponseTime
+    ): Microseconds {
         $from = $this->from instanceof MultipleOf ? $this->from->calc($latestResponseDuration) : $this->from;
 
         $to = $this->to instanceof MultipleOf ? $this->to->calc($latestResponseDuration) : $this->to;
@@ -156,7 +156,7 @@ class Throttler
             $waitValue = $this->max;
         }
 
-        return $this->latestResponseTimes[$domain]->add($waitValue);
+        return $latestResponseTime->add($waitValue);
     }
 
     protected function getRandBetween(Microseconds $from, Microseconds $to): Microseconds


### PR DESCRIPTION
Add missing calls to track request start and end times, so the call to `waitForGo()` actually works as expected.