### PR TITLE
New onCacheHit Loader hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2023-08-18
+### Added
+* New `onCacheHit` hook in the `Loader` class (in addition to `beforeLoad`, `onSuccess`, `onError` and `afterLoad`) that is called in the `HttpLoader` class when a response for a request was found in the cache.
+
 ### Deprecated
 * Moved the `Microseconds` value object class to the crwlr/utils package, as it is a very useful and universal tool. The class in this package still exists, but just extends the class from the utils package and will be removed in v2. So, if you're using this class, please change to use the version from the utils package.
 

--- a/src/Loader/Http/HttpLoader.php
+++ b/src/Loader/Http/HttpLoader.php
@@ -143,6 +143,10 @@ class HttpLoader extends Loader
 
             $isFromCache = $respondedRequest !== null;
 
+            if ($isFromCache) {
+                $this->callHook('onCacheHit', $request, $respondedRequest->response);
+            }
+
             if (!$respondedRequest) {
                 $respondedRequest = $this->waitForGoAndLoadViaClientOrHeadlessBrowser($request);
             }
@@ -196,6 +200,10 @@ class HttpLoader extends Loader
         $respondedRequest = $this->getFromCache($request);
 
         $isFromCache = $respondedRequest !== null;
+
+        if ($isFromCache) {
+            $this->callHook('onCacheHit', $request, $respondedRequest->response);
+        }
 
         if (!$respondedRequest) {
             $respondedRequest = $this->waitForGoAndLoadViaClientOrHeadlessBrowser($request);

--- a/src/Loader/Loader.php
+++ b/src/Loader/Loader.php
@@ -19,6 +19,7 @@ abstract class Loader implements LoaderInterface
      */
     protected array $hooks = [
         'beforeLoad' => [],
+        'onCacheHit' => [],
         'onSuccess' => [],
         'onError' => [],
         'afterLoad' => [],
@@ -34,6 +35,11 @@ abstract class Loader implements LoaderInterface
     public function beforeLoad(callable $callback): void
     {
         $this->addHookCallback('beforeLoad', $callback);
+    }
+
+    public function onCacheHit(callable $callback): void
+    {
+        $this->addHookCallback('onCacheHit', $callback);
     }
 
     public function onSuccess(callable $callback): void

--- a/tests/Loader/LoaderTest.php
+++ b/tests/Loader/LoaderTest.php
@@ -9,7 +9,7 @@ use Psr\SimpleCache\CacheInterface;
 
 test('You can set multiple hook callbacks for one type and they are executed when called', function (string $hookName) {
     $loader = new class (new BotUserAgent('FooBot'), $hookName) extends Loader {
-        public function __construct(BotUserAgent $userAgent, private string $hookName)
+        public function __construct(BotUserAgent $userAgent, private readonly string $hookName)
         {
             parent::__construct($userAgent);
         }
@@ -45,6 +45,7 @@ test('You can set multiple hook callbacks for one type and they are executed whe
     expect($callback3Called)->toBeTrue();
 })->with([
     'beforeLoad',
+    'onCacheHit',
     'onSuccess',
     'onError',
     'afterLoad',
@@ -65,7 +66,10 @@ test('You can set a cache and use it in the load function', function () {
     };
 
     $cache = Mockery::mock(CacheInterface::class);
+
     $cache->shouldReceive('get')->with('foo')->once();
+
     $loader->setCache($cache);
+
     $loader->load('something');
 });

--- a/tests/Steps/GroupTest.php
+++ b/tests/Steps/GroupTest.php
@@ -416,7 +416,7 @@ it('returns only unique outputs when outputs are objects and uniqueOutput was ca
     expect(helper_invokeStepWithInput($group))->toHaveCount(0);
 
     $incrementNumberCallback = function (mixed $input) {
-        return $input+1;
+        return $input + 1;
     };
 
     helper_addUpdateInputUsingOutputCallbackToSteps($incrementNumberCallback, $step1, $step2);
@@ -447,7 +447,7 @@ it(
         $group->resetAfterRun();
 
         $incrementNumberCallback = function (mixed $input) {
-            return $input+1;
+            return $input + 1;
         };
 
         helper_addUpdateInputUsingOutputCallbackToSteps($incrementNumberCallback, $step1, $step2);


### PR DESCRIPTION
New `onCacheHit` hook in the `Loader` class (in addition to `beforeLoad`, `onSuccess`, `onError` and `afterLoad`) that is called in the `HttpLoader` class when a response for a request was found in the cache.