### PR TITLE
Fix tracking request end for redirected requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2023-08-21
+### Fixed
+* When a URL redirects, the `trackRequestEndFor()` method of the `HttpLoader`'s `Throttler` instance is called only once at the end and with the original request URL.
+
 ## [1.2.0] - 2023-08-18
 ### Added
 * New `onCacheHit` hook in the `Loader` class (in addition to `beforeLoad`, `onSuccess`, `onError` and `afterLoad`) that is called in the `HttpLoader` class when a response for a request was found in the cache.

--- a/src/Loader/Http/HttpLoader.php
+++ b/src/Loader/Http/HttpLoader.php
@@ -527,8 +527,6 @@ class HttpLoader extends Loader
 
         $response = $this->httpClient->sendRequest($request);
 
-        $this->throttler->trackRequestEndFor($request->getUri());
-
         if (!$respondedRequest) {
             $respondedRequest = new RespondedRequest($request, $response);
         } else {
@@ -545,6 +543,8 @@ class HttpLoader extends Loader
             $redirectNumber++;
 
             return $this->handleRedirects($newRequest, $respondedRequest, $redirectNumber);
+        } else {
+            $this->throttler->trackRequestEndFor($respondedRequest->request->getUri());
         }
 
         return $respondedRequest;


### PR DESCRIPTION
When a URL redirects, the `trackRequestEndFor()` method of the `HttpLoader`'s `Throttler` instance is called only once at the end and with the original request URL.