### PR TITLE
Fixes in Http steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.2] - 2023-09-19
+### Fixed
+* Fix in `HttpCrawl` (`Http::crawl()`) step: when a page contains a broken link, that can't be resolved and throws an `Exception` from the URL library, ignore the link and log a warning message.
+* Minor fix for merging HTTP headers when an `Http` step gets both, statically defined headers and headers to use from array input.
+
 ## [1.2.1] - 2023-08-21
 ### Fixed
 * When a URL redirects, the `trackRequestEndFor()` method of the `HttpLoader`'s `Throttler` instance is called only once at the end and with the original request URL.

--- a/src/Cache/Exceptions/MissingZlibExtensionException.php
+++ b/src/Cache/Exceptions/MissingZlibExtensionException.php
@@ -5,6 +5,4 @@ namespace Crwlr\Crawler\Cache\Exceptions;
 use Exception;
 use Psr\SimpleCache\CacheException;
 
-class MissingZlibExtensionException extends Exception implements CacheException
-{
-}
+class MissingZlibExtensionException extends Exception implements CacheException {}

--- a/src/Cache/Exceptions/ReadingCacheFailedException.php
+++ b/src/Cache/Exceptions/ReadingCacheFailedException.php
@@ -5,6 +5,4 @@ namespace Crwlr\Crawler\Cache\Exceptions;
 use Exception;
 use Psr\SimpleCache\CacheException;
 
-class ReadingCacheFailedException extends Exception implements CacheException
-{
-}
+class ReadingCacheFailedException extends Exception implements CacheException {}

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -16,8 +16,7 @@ class FileCache implements CacheInterface
 
     public function __construct(
         protected readonly string $basePath,
-    ) {
-    }
+    ) {}
 
     public function useCompression(): static
     {

--- a/src/Exceptions/UnknownLoaderKeyException.php
+++ b/src/Exceptions/UnknownLoaderKeyException.php
@@ -4,6 +4,4 @@ namespace Crwlr\Crawler\Exceptions;
 
 use Exception;
 
-class UnknownLoaderKeyException extends Exception
-{
-}
+class UnknownLoaderKeyException extends Exception {}

--- a/src/HttpCrawler/AnonymousHttpCrawlerBuilder.php
+++ b/src/HttpCrawler/AnonymousHttpCrawlerBuilder.php
@@ -9,9 +9,7 @@ use Crwlr\Crawler\UserAgents\UserAgentInterface;
 
 class AnonymousHttpCrawlerBuilder
 {
-    public function __construct()
-    {
-    }
+    public function __construct() {}
 
     public function withBotUserAgent(string $productToken): HttpCrawler
     {

--- a/src/Input.php
+++ b/src/Input.php
@@ -2,6 +2,4 @@
 
 namespace Crwlr\Crawler;
 
-class Input extends Io
-{
-}
+class Input extends Io {}

--- a/src/Loader/AddLoadersToStepAction.php
+++ b/src/Loader/AddLoadersToStepAction.php
@@ -11,9 +11,7 @@ class AddLoadersToStepAction
      * @param LoaderInterface|array<string, LoaderInterface> $loaders
      * @param StepInterface $step
      */
-    public function __construct(protected LoaderInterface|array $loaders, protected StepInterface $step)
-    {
-    }
+    public function __construct(protected LoaderInterface|array $loaders, protected StepInterface $step) {}
 
     /**
      * @return void

--- a/src/Loader/Http/Cookies/Date.php
+++ b/src/Loader/Http/Cookies/Date.php
@@ -10,9 +10,7 @@ class Date
 {
     protected ?DateTime $dateTime = null;
 
-    public function __construct(protected readonly string $httpDateString)
-    {
-    }
+    public function __construct(protected readonly string $httpDateString) {}
 
     /**
      * @throws InvalidArgumentException

--- a/src/Loader/Http/Cookies/Exceptions/InvalidCookieException.php
+++ b/src/Loader/Http/Cookies/Exceptions/InvalidCookieException.php
@@ -4,6 +4,4 @@ namespace Crwlr\Crawler\Loader\Http\Cookies\Exceptions;
 
 use Exception;
 
-class InvalidCookieException extends Exception
-{
-}
+class InvalidCookieException extends Exception {}

--- a/src/Loader/Http/Exceptions/LoadingException.php
+++ b/src/Loader/Http/Exceptions/LoadingException.php
@@ -4,6 +4,4 @@ namespace Crwlr\Crawler\Loader\Http\Exceptions;
 
 use Exception;
 
-class LoadingException extends Exception
-{
-}
+class LoadingException extends Exception {}

--- a/src/Loader/Http/Politeness/RetryErrorResponseHandler.php
+++ b/src/Loader/Http/Politeness/RetryErrorResponseHandler.php
@@ -27,8 +27,7 @@ class RetryErrorResponseHandler
         protected int $retries = 2,
         protected array $wait = [10, 60],
         protected int $maxWait = 60,
-    ) {
-    }
+    ) {}
 
     public function shouldWait(RespondedRequest $respondedRequest): bool
     {

--- a/src/Loader/Http/Politeness/TimingUnits/Microseconds.php
+++ b/src/Loader/Http/Politeness/TimingUnits/Microseconds.php
@@ -5,6 +5,4 @@ namespace Crwlr\Crawler\Loader\Http\Politeness\TimingUnits;
 /**
  * @deprecated Will be removed in v2.0.0. Use the Microseconds class from the crwlr/utils package directly instead.
  */
-final class Microseconds extends \Crwlr\Utils\Microseconds
-{
-}
+final class Microseconds extends \Crwlr\Utils\Microseconds {}

--- a/src/Loader/Http/Politeness/TimingUnits/MultipleOf.php
+++ b/src/Loader/Http/Politeness/TimingUnits/MultipleOf.php
@@ -6,9 +6,7 @@ use Crwlr\Utils\Microseconds;
 
 class MultipleOf
 {
-    public function __construct(public readonly float $factor)
-    {
-    }
+    public function __construct(public readonly float $factor) {}
 
     public function calc(Microseconds $microseconds): Microseconds
     {

--- a/src/Loader/Loader.php
+++ b/src/Loader/Loader.php
@@ -81,16 +81,12 @@ abstract class Loader implements LoaderInterface
     /**
      * Can be implemented in a child class to track how long a request waited for its response.
      */
-    protected function trackRequestStart(?float $microtime = null): void
-    {
-    }
+    protected function trackRequestStart(?float $microtime = null): void {}
 
     /**
      * Can be implemented in a child class to track how long a request waited for its response.
      */
-    protected function trackRequestEnd(?float $microtime = null): void
-    {
-    }
+    protected function trackRequestEnd(?float $microtime = null): void {}
 
     protected function callHook(string $hook, mixed ...$arguments): void
     {

--- a/src/Output.php
+++ b/src/Output.php
@@ -2,6 +2,4 @@
 
 namespace Crwlr\Crawler;
 
-class Output extends Io
-{
-}
+class Output extends Io {}

--- a/src/Steps/Csv.php
+++ b/src/Steps/Csv.php
@@ -19,9 +19,7 @@ class Csv extends Step
     /**
      * @param array<string|null> $columnMapping
      */
-    public function __construct(protected array $columnMapping = [], protected bool $skipFirstLine = false)
-    {
-    }
+    public function __construct(protected array $columnMapping = [], protected bool $skipFirstLine = false) {}
 
     /**
      * @param array<string|null> $columnMapping

--- a/src/Steps/Filters/ClosureFilter.php
+++ b/src/Steps/Filters/ClosureFilter.php
@@ -9,8 +9,7 @@ class ClosureFilter extends Filter
 {
     public function __construct(
         protected readonly Closure $closure,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws Exception

--- a/src/Steps/Filters/ComparisonFilter.php
+++ b/src/Steps/Filters/ComparisonFilter.php
@@ -10,8 +10,7 @@ class ComparisonFilter extends Filter
     public function __construct(
         protected readonly ComparisonFilterRule $filterRule,
         protected readonly mixed $compareTo,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws Exception

--- a/src/Steps/Filters/NegatedFilter.php
+++ b/src/Steps/Filters/NegatedFilter.php
@@ -4,9 +4,7 @@ namespace Crwlr\Crawler\Steps\Filters;
 
 final class NegatedFilter implements FilterInterface
 {
-    public function __construct(private readonly FilterInterface $filter)
-    {
-    }
+    public function __construct(private readonly FilterInterface $filter) {}
 
     public function useKey(string $key): static
     {

--- a/src/Steps/Filters/StringFilter.php
+++ b/src/Steps/Filters/StringFilter.php
@@ -10,8 +10,7 @@ class StringFilter extends Filter
     public function __construct(
         protected readonly StringFilterRule $filterRule,
         protected readonly string $filterString,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws Exception

--- a/src/Steps/Filters/StringLengthFilter.php
+++ b/src/Steps/Filters/StringLengthFilter.php
@@ -10,8 +10,7 @@ class StringLengthFilter extends Filter
     public function __construct(
         protected readonly StringLengthFilterRule $filterRule,
         protected readonly int $compareToLength,
-    ) {
-    }
+    ) {}
 
     /**
      * @throws Exception

--- a/src/Steps/Filters/UrlFilter.php
+++ b/src/Steps/Filters/UrlFilter.php
@@ -7,9 +7,7 @@ use Exception;
 
 class UrlFilter extends Filter
 {
-    public function __construct(protected readonly UrlFilterRule $filterRule, protected readonly string $filterString)
-    {
-    }
+    public function __construct(protected readonly UrlFilterRule $filterRule, protected readonly string $filterString) {}
 
     /**
      * @throws Exception

--- a/src/Steps/Html/DomQuery.php
+++ b/src/Steps/Html/DomQuery.php
@@ -31,8 +31,7 @@ abstract class DomQuery implements DomQueryInterface
 
     public function __construct(
         public readonly string $query
-    ) {
-    }
+    ) {}
 
     /**
      * When there is a <base> tag with a href attribute in an HTML document all links in the document must be resolved

--- a/src/Steps/Html/GetLink.php
+++ b/src/Steps/Html/GetLink.php
@@ -32,9 +32,7 @@ class GetLink extends Step
 
     protected bool $withFragment = true;
 
-    public function __construct(protected ?string $selector = null)
-    {
-    }
+    public function __construct(protected ?string $selector = null) {}
 
     public static function isSpecialNonHttpLink(Crawler $linkElement): bool
     {

--- a/src/Steps/Json.php
+++ b/src/Steps/Json.php
@@ -12,9 +12,7 @@ class Json extends Step
     /**
      * @param mixed[] $propertyMapping
      */
-    final public function __construct(protected array $propertyMapping = [], protected ?string $each = null)
-    {
-    }
+    final public function __construct(protected array $propertyMapping = [], protected ?string $each = null) {}
 
     /**
      * @param mixed[] $propertyMapping

--- a/src/Steps/Loading/Http/Paginators/AbstractPaginator.php
+++ b/src/Steps/Loading/Http/Paginators/AbstractPaginator.php
@@ -9,9 +9,7 @@ use Psr\Http\Message\RequestInterface;
 
 abstract class AbstractPaginator implements PaginatorInterface
 {
-    public function __construct(protected int $maxPages = Paginator::MAX_PAGES_DEFAULT)
-    {
-    }
+    public function __construct(protected int $maxPages = Paginator::MAX_PAGES_DEFAULT) {}
 
     public function prepareRequest(
         RequestInterface $request,

--- a/src/Steps/Loading/HttpCrawl.php
+++ b/src/Steps/Loading/HttpCrawl.php
@@ -12,6 +12,7 @@ use Exception;
 use Generator;
 use Psr\Http\Message\UriInterface;
 use Symfony\Component\DomCrawler\Crawler;
+use Throwable;
 
 class HttpCrawl extends Http
 {
@@ -295,7 +296,13 @@ class HttpCrawl extends Http
                 continue;
             }
 
-            $url = $this->handleUrlFragment($document->baseUrl()->resolve($linkElement->attr('href') ?? ''));
+            try {
+                $url = $this->handleUrlFragment($document->baseUrl()->resolve($linkElement->attr('href') ?? ''));
+            } catch (Throwable) {
+                $this->logger?->warning('Failed to resolve a link with href: ' . $linkElement->attr('href'));
+
+                continue;
+            }
 
             if (!$this->isOnSameHostOrDomain($url)) {
                 continue;

--- a/src/Steps/Refiners/String/StrAfterFirst.php
+++ b/src/Steps/Refiners/String/StrAfterFirst.php
@@ -6,9 +6,7 @@ use Crwlr\Crawler\Steps\Refiners\AbstractRefiner;
 
 class StrAfterFirst extends AbstractRefiner
 {
-    public function __construct(protected readonly string $first)
-    {
-    }
+    public function __construct(protected readonly string $first) {}
 
     public function refine(mixed $value): mixed
     {

--- a/src/Steps/Refiners/String/StrAfterLast.php
+++ b/src/Steps/Refiners/String/StrAfterLast.php
@@ -6,9 +6,7 @@ use Crwlr\Crawler\Steps\Refiners\AbstractRefiner;
 
 class StrAfterLast extends AbstractRefiner
 {
-    public function __construct(protected readonly string $last)
-    {
-    }
+    public function __construct(protected readonly string $last) {}
 
     public function refine(mixed $value): mixed
     {

--- a/src/Steps/Refiners/String/StrBeforeFirst.php
+++ b/src/Steps/Refiners/String/StrBeforeFirst.php
@@ -6,9 +6,7 @@ use Crwlr\Crawler\Steps\Refiners\AbstractRefiner;
 
 class StrBeforeFirst extends AbstractRefiner
 {
-    public function __construct(protected readonly string $first)
-    {
-    }
+    public function __construct(protected readonly string $first) {}
 
     public function refine(mixed $value): mixed
     {

--- a/src/Steps/Refiners/String/StrBeforeLast.php
+++ b/src/Steps/Refiners/String/StrBeforeLast.php
@@ -6,9 +6,7 @@ use Crwlr\Crawler\Steps\Refiners\AbstractRefiner;
 
 class StrBeforeLast extends AbstractRefiner
 {
-    public function __construct(protected readonly string $last)
-    {
-    }
+    public function __construct(protected readonly string $last) {}
 
     public function refine(mixed $value): mixed
     {

--- a/src/Steps/Refiners/String/StrBetweenFirst.php
+++ b/src/Steps/Refiners/String/StrBetweenFirst.php
@@ -6,9 +6,7 @@ use Crwlr\Crawler\Steps\Refiners\AbstractRefiner;
 
 class StrBetweenFirst extends AbstractRefiner
 {
-    public function __construct(protected readonly string $start, protected readonly string $end)
-    {
-    }
+    public function __construct(protected readonly string $start, protected readonly string $end) {}
 
     public function refine(mixed $value): mixed
     {

--- a/src/Steps/Refiners/String/StrBetweenLast.php
+++ b/src/Steps/Refiners/String/StrBetweenLast.php
@@ -6,9 +6,7 @@ use Crwlr\Crawler\Steps\Refiners\AbstractRefiner;
 
 class StrBetweenLast extends AbstractRefiner
 {
-    public function __construct(protected readonly string $start, protected readonly string $end)
-    {
-    }
+    public function __construct(protected readonly string $start, protected readonly string $end) {}
 
     public function refine(mixed $value): mixed
     {

--- a/src/Steps/Refiners/String/StrReplace.php
+++ b/src/Steps/Refiners/String/StrReplace.php
@@ -13,8 +13,7 @@ class StrReplace extends AbstractRefiner
     public function __construct(
         protected readonly string|array $search,
         protected readonly string|array $replace,
-    ) {
-    }
+    ) {}
 
     public function refine(mixed $value): mixed
     {

--- a/src/UserAgents/BotUserAgent.php
+++ b/src/UserAgents/BotUserAgent.php
@@ -13,8 +13,7 @@ class BotUserAgent implements BotUserAgentInterface
         protected string $productToken,
         protected ?string $infoUri = null,
         protected ?string $version = null
-    ) {
-    }
+    ) {}
 
     public static function make(string $productToken, ?string $crawlerInfoUri = null, ?string $version = null): self
     {

--- a/src/UserAgents/UserAgent.php
+++ b/src/UserAgents/UserAgent.php
@@ -4,9 +4,7 @@ namespace Crwlr\Crawler\UserAgents;
 
 class UserAgent implements UserAgentInterface
 {
-    public function __construct(protected readonly string $userAgent)
-    {
-    }
+    public function __construct(protected readonly string $userAgent) {}
 
     public function __toString(): string
     {

--- a/src/Utils/HttpHeaders.php
+++ b/src/Utils/HttpHeaders.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Crwlr\Crawler\Utils;
+
+final class HttpHeaders
+{
+    /**
+     * @param array<string, string|string[]> $headers
+     * @return array<string, string[]>
+     */
+    public static function normalize(array $headers): array
+    {
+        $normalized = [];
+
+        foreach ($headers as $headerName => $value) {
+            $normalized[$headerName] = is_array($value) ? $value : [$value];
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param array<string, array<int, string>> $headers
+     * @param array<string, array<int, string>> $mergeHeaders
+     * @return array<string, array<int, string>>
+     */
+    public static function merge(array $headers, array $mergeHeaders): array
+    {
+        foreach ($mergeHeaders as $headerName => $value) {
+            if (!array_key_exists($headerName, $headers)) {
+                $headers[$headerName] = $value;
+            } else {
+                $headers = self::addTo($headers, $headerName, $value);
+            }
+        }
+
+        return $headers;
+    }
+
+    /**
+     * @param array<string, array<int, string>> $headers
+     * @param string $headerName
+     * @param string|string[] $value
+     * @return array<string, array<int, string>>
+     */
+    public static function addTo(array $headers, string $headerName, string|array $value): array
+    {
+        if (!array_key_exists($headerName, $headers)) {
+            $headers[$headerName] = is_array($value) ? $value : [$value];
+        } elseif (is_array($value)) {
+            foreach ($value as $valueItem) {
+                if (!in_array($valueItem, $headers[$headerName], true)) {
+                    $headers[$headerName][] = $valueItem;
+                }
+            }
+        } elseif (!in_array($value, $headers[$headerName], true)) {
+            $headers[$headerName][] = $value;
+        }
+
+        return $headers;
+    }
+}

--- a/tests/IoTest.php
+++ b/tests/IoTest.php
@@ -7,8 +7,7 @@ use Crwlr\Crawler\Result;
 
 function helper_getIoInstance(mixed $value, ?Result $result = null, ?Result $addLaterToResult = null): Io
 {
-    return new class ($value, $result, $addLaterToResult) extends Io {
-    };
+    return new class ($value, $result, $addLaterToResult) extends Io {};
 }
 
 it('can be created with only a value.', function () {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -47,9 +47,7 @@ uses()
 function helper_getValueReturningStep(mixed $value): Step
 {
     return new class ($value) extends Step {
-        public function __construct(private mixed $value)
-        {
-        }
+        public function __construct(private mixed $value) {}
 
         protected function invoke(mixed $input): Generator
         {
@@ -93,9 +91,7 @@ function helper_getStepYieldingMultipleNumbers(): Step
 function helper_getStepYieldingArrayWithNumber(int $number): Step
 {
     return new class ($number) extends Step {
-        public function __construct(private int $number)
-        {
-        }
+        public function __construct(private int $number) {}
 
         protected function invoke(mixed $input): Generator
         {
@@ -119,9 +115,7 @@ function helper_getStepYieldingMultipleArraysWithNumber(): Step
 function helper_getStepYieldingObjectWithNumber(int $number): Step
 {
     return new class ($number) extends Step {
-        public function __construct(private int $number)
-        {
-        }
+        public function __construct(private int $number) {}
 
         protected function invoke(mixed $input): Generator
         {

--- a/tests/Utils/HttpHeadersTest.php
+++ b/tests/Utils/HttpHeadersTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace tests\Utils;
+
+use Crwlr\Crawler\Utils\HttpHeaders;
+
+it('normalizes a headers array', function () {
+    expect(HttpHeaders::normalize([
+        'Accept-Language' => 'de',
+        'Accept-Encoding' => ['gzip', 'deflate', 'br'],
+    ]))->toBe([
+        'Accept-Language' => ['de'],
+        'Accept-Encoding' => ['gzip', 'deflate', 'br'],
+    ]);
+});
+
+it('merges two header arrays', function () {
+    $headers = [
+        'Accept-Language' => ['de'],
+        'Accept-Encoding' => ['gzip', 'deflate', 'br'],
+    ];
+
+    $merge = [
+        'Accept' => ['text/html', 'application/xhtml+xml', 'application/xml'],
+        'Accept-Language' => ['de', 'en'],
+    ];
+
+    expect(HttpHeaders::merge($headers, $merge))->toBe([
+        'Accept-Language' => ['de', 'en'],
+        'Accept-Encoding' => ['gzip', 'deflate', 'br'],
+        'Accept' => ['text/html', 'application/xhtml+xml', 'application/xml'],
+    ]);
+});
+
+it('adds a single value to a certain header in a headers array', function () {
+    $headers = ['Accept-Language' => ['de']];
+
+    expect(HttpHeaders::addTo($headers, 'Accept-Language', 'en'))->toBe(['Accept-Language' => ['de', 'en']]);
+});
+
+it('adds an array of values to a certain header in a headers array', function () {
+    $headers = ['Accept-Language' => ['de']];
+
+    expect(
+        HttpHeaders::addTo($headers, 'Accept-Language', ['en-US', 'en'])
+    )->toBe(['Accept-Language' => ['de', 'en-US', 'en']]);
+});
+
+it('adds the header when calling addTo() with a header name that the array does not contain yet', function () {
+    $headers = ['Accept-Encoding' => ['gzip', 'deflate', 'br']];
+
+    expect(
+        HttpHeaders::addTo($headers, 'Accept-Language', ['de', 'en'])
+    )->toBe([
+        'Accept-Encoding' => ['gzip', 'deflate', 'br'],
+        'Accept-Language' => ['de', 'en'],
+    ]);
+});

--- a/tests/_Integration/_Server/Crawling.php
+++ b/tests/_Integration/_Server/Crawling.php
@@ -54,6 +54,8 @@ if ($route === '/crawling/main') {
             <a href="mailto:somebody@example.com">mailto link</a>
             <a href="javascript:alert('hello');">javascript link</a>
             <a href="tel:+499123456789">phone link</a>
+
+            <a href="//">broken link</a>
         </body>
         </html>
         HTML;


### PR DESCRIPTION
* Fix in `HttpCrawl` (`Http::crawl()`) step: when a page contains a broken link, that can't be resolved and throws an `Exception` from the URL library, ignore the link and log a warning message.
* Minor fix for merging HTTP headers when an `Http` step gets both, statically defined headers and headers to use from array input.
* Also CS Fixer changed a lot of empty classes and constructors.