### PR TITLE
Enable the use of Proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Added
+* New methods `HttpLoader::useProxy()` and `HttpLoader::useRotatingProxies([...])` to define proxies that the loader shall use. They can be used with a guzzle HTTP client instance (default) and when the loader uses the headless chrome browser. Using them when providing some other PSR-18 implementation will throw an exception.
+
+### Fixed
+* The `HttpLoader::load()` implementation won't throw any exception, because it shouldn't kill a crawler run. When you want any loading error to end the whole crawler execution `HttpLoader::loadOrFail()` should be used. Also adapted the phpdoc in the `LoaderInterface`.
 
 ## [1.2.2] - 2023-09-19
 ### Fixed

--- a/src/Loader/Http/Exceptions/LoadingException.php
+++ b/src/Loader/Http/Exceptions/LoadingException.php
@@ -3,5 +3,16 @@
 namespace Crwlr\Crawler\Loader\Http\Exceptions;
 
 use Exception;
+use Throwable;
 
-class LoadingException extends Exception {}
+class LoadingException extends Exception
+{
+    public static function from(Throwable $previousException): self
+    {
+        return new self(
+            'Loading failed. Exception of type ' . get_class($previousException) . ' was thrown. Exception message: ' .
+            $previousException->getMessage(),
+            previous: $previousException,
+        );
+    }
+}

--- a/src/Loader/Http/ProxyManager.php
+++ b/src/Loader/Http/ProxyManager.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Crwlr\Crawler\Loader\Http;
+
+class ProxyManager
+{
+    protected ?int $lastUsedProxy = null;
+
+    /**
+     * @param string[] $proxies
+     */
+    public function __construct(protected array $proxies)
+    {
+        $this->proxies = array_values($this->proxies);
+    }
+
+    public function singleProxy(): bool
+    {
+        return count($this->proxies) === 1;
+    }
+
+    public function hasOnlySingleProxy(): bool
+    {
+        return count($this->proxies) === 1;
+    }
+
+    public function hasMultipleProxies(): bool
+    {
+        return count($this->proxies) > 1;
+    }
+
+    public function getProxy(): string
+    {
+        if ($this->hasOnlySingleProxy()) {
+            return $this->proxies[0];
+        }
+
+        if ($this->lastUsedProxy === null || !isset($this->proxies[$this->lastUsedProxy + 1])) {
+            $this->lastUsedProxy = 0;
+        } else {
+            $this->lastUsedProxy += 1;
+        }
+
+        return $this->proxies[$this->lastUsedProxy];
+    }
+}

--- a/src/Loader/LoaderInterface.php
+++ b/src/Loader/LoaderInterface.php
@@ -11,8 +11,6 @@ interface LoaderInterface
     /**
      * @param mixed $subject  The subject to load, whatever the Loader implementation needs to load something.
      * @return mixed
-     * @throws InvalidArgumentException  Throw an InvalidArgumentException when the type of $subject argument isn't
-     *                                   valid for the Loader implementation.
      */
     public function load(mixed $subject): mixed;
 

--- a/tests/Loader/Http/ProxyManagerTest.php
+++ b/tests/Loader/Http/ProxyManagerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace tests\Loader\Http;
+
+use Crwlr\Crawler\Loader\Http\ProxyManager;
+
+it('knows if it manages only one or multiple proxy server', function () {
+    $manager = new ProxyManager(['http://127.0.0.1:8001']);
+
+    expect($manager->hasOnlySingleProxy())
+        ->toBeTrue()
+        ->and($manager->hasMultipleProxies())
+        ->toBeFalse();
+
+    $manager = new ProxyManager(['http://127.0.0.1:8001', 'http://127.0.0.1:8002']);
+
+    expect($manager->hasOnlySingleProxy())
+        ->toBeFalse()
+        ->and($manager->hasMultipleProxies())
+        ->toBeTrue();
+});
+
+it('returns the proxy when only one is defined', function () {
+    $manager = new ProxyManager(['http://127.0.0.1:8003']);
+
+    expect($manager->getProxy())
+        ->toBe('http://127.0.0.1:8003')
+        ->and($manager->getProxy())
+        ->toBe('http://127.0.0.1:8003');
+});
+
+it('rotates the proxies when multiple are defined', function () {
+    $manager = new ProxyManager(['http://127.0.0.1:8001', 'http://127.0.0.1:8002', 'http://127.0.0.1:8003']);
+
+    expect($manager->getProxy())
+        ->toBe('http://127.0.0.1:8001')
+        ->and($manager->getProxy())
+        ->toBe('http://127.0.0.1:8002')
+        ->and($manager->getProxy())
+        ->toBe('http://127.0.0.1:8003')
+        ->and($manager->getProxy())
+        ->toBe('http://127.0.0.1:8001');
+});

--- a/tests/Steps/Loading/Http/Paginators/SimpleWebsitePaginatorTest.php
+++ b/tests/Steps/Loading/Http/Paginators/SimpleWebsitePaginatorTest.php
@@ -27,7 +27,7 @@ function helper_createResponseBodyWithPaginationLinks(array $links): string
     $body = '<div class="pagination">';
 
     foreach ($links as $url => $text) {
-        $body .= '<a href="' . $url .'">' . $text . '</a> ' . PHP_EOL;
+        $body .= '<a href="' . $url . '">' . $text . '</a> ' . PHP_EOL;
     }
 
     return $body . '</div>';

--- a/tests/_Integration/Http/ProxyingTest.php
+++ b/tests/_Integration/Http/ProxyingTest.php
@@ -1,0 +1,202 @@
+<?php
+
+use Crwlr\Crawler\Loader\Http\HttpLoader;
+use Crwlr\Crawler\Result;
+use Crwlr\Crawler\Steps\Loading\Http;
+use Symfony\Component\Process\Process;
+
+use function tests\helper_getFastCrawler;
+
+class ProxyServerProcesses
+{
+    public const PORTS = [8001, 8002, 8003];
+
+    /**
+     * @var array<int, ?Process>
+     */
+    public static array $processes = [8001 => null, 8002 => null, 8003 => null];
+}
+
+beforeEach(function () {
+    $startedProcesses = false;
+
+    foreach (ProxyServerProcesses::PORTS as $port) {
+        if (!ProxyServerProcesses::$processes[$port]) {
+            ProxyServerProcesses::$processes[$port] = Process::fromShellCommandline(
+                'php -S localhost:' . $port . ' ' . __DIR__ . '/../ProxyServer.php'
+            );
+
+            ProxyServerProcesses::$processes[$port]->start();
+
+            $startedProcesses = true;
+        }
+    }
+
+    if ($startedProcesses) {
+        usleep(100_000);
+    }
+});
+
+afterAll(function () {
+    foreach (ProxyServerProcesses::PORTS as $port) {
+        ProxyServerProcesses::$processes[$port]?->stop(3, SIGINT);
+
+        ProxyServerProcesses::$processes[$port] = null;
+    }
+});
+
+it('uses a proxy when the useProxy() method of the loader was called', function () {
+    $crawler = helper_getFastCrawler();
+
+    $loader = $crawler->getLoader();
+
+    /** @var HttpLoader $loader */
+
+    $loader->useProxy('http://localhost:8001');
+
+    $crawler
+        ->input('http://www.crwlr.software/packages')
+        ->addStep(Http::get()->addToResult(['body']));
+
+    $results = iterator_to_array($crawler->run());
+
+    expect($results[0])
+        ->toBeInstanceOf(Result::class)
+        ->and($results[0]->get('body'))
+        ->toContain('Proxy Server Response for http://www.crwlr.software/packages');
+});
+
+it('uses correct method, headers and HTTP version in the proxied request', function () {
+    $crawler = helper_getFastCrawler();
+
+    $loader = $crawler->getLoader();
+
+    /** @var HttpLoader $loader */
+
+    $loader->useProxy('http://localhost:8001');
+
+    $crawler
+        ->input('http://www.crwlr.software/packages')
+        ->addStep(
+            Http::put(['Accept-Encoding' => 'gzip, deflate, br'], 'Hello World', '1.0')
+                ->addToResult(['body'])
+        );
+
+    $results = iterator_to_array($crawler->run());
+
+    expect($results[0])
+        ->toBeInstanceOf(Result::class)
+        ->and($results[0]->get('body'))
+        ->toContain('Protocol Version: HTTP/1.0')
+        ->toContain('Request Method: PUT')
+        ->toContain('Request Body: Hello World')
+        ->toContain('["Accept-Encoding"]=>' . PHP_EOL . '  string(17) "gzip, deflate, br"');
+});
+
+it('uses rotating proxies when the useRotatingProxies() method of the loader was called', function () {
+    $crawler = helper_getFastCrawler();
+
+    $loader = $crawler->getLoader();
+
+    /** @var HttpLoader $loader */
+
+    $loader->useRotatingProxies([
+        'http://localhost:8001',
+        'http://localhost:8002',
+        'http://localhost:8003',
+    ]);
+
+    $crawler
+        ->input([
+            'http://www.crwlr.software/packages/crawler/v1.1/getting-started',
+            'http://www.crwlr.software/packages/url/v2.0/getting-started',
+            'http://www.crwlr.software/packages/query-string/v1.0/getting-started',
+            'http://www.crwlr.software/packages/robots-txt/v1.1/getting-started',
+        ])
+        ->addStep(Http::get()->addToResult(['body']));
+
+    $results = iterator_to_array($crawler->run());
+
+    expect($results)->toHaveCount(4)
+        ->and($results[0])
+        ->toBeInstanceOf(Result::class)
+        ->and($results[0]->get('body'))
+        ->toContain('Port: 8001')           // First request with first proxy
+        ->and($results[1])
+        ->toBeInstanceOf(Result::class)
+        ->and($results[1]->get('body'))
+        ->toContain('Port: 8002')           // Second request with second proxy
+        ->and($results[2])
+        ->toBeInstanceOf(Result::class)
+        ->and($results[2]->get('body'))
+        ->toContain('Port: 8003')           // Third request with third proxy
+        ->and($results[3])
+        ->toBeInstanceOf(Result::class)
+        ->and($results[3]->get('body'))
+        ->toContain('Port: 8001');          // And finally the fourth request with the first proxy again.
+});
+
+it('can also use a proxy when using the headless browser', function () {
+    $crawler = helper_getFastCrawler();
+
+    $loader = $crawler->getLoader();
+
+    /** @var HttpLoader $loader */
+
+    $loader
+        ->useHeadlessBrowser()
+        ->useProxy('http://localhost:8001');
+
+    $crawler
+        ->input('http://www.crwlr.software/blog')
+        ->addStep(
+            Http::get(['Accept-Language' => 'de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7'])
+                ->addToResult(['body'])
+        );
+
+    $results = iterator_to_array($crawler->run());
+
+    expect($results[0])
+        ->toBeInstanceOf(Result::class)
+        ->and($results[0]->get('body'))
+        ->toContain('["Accept-Language"]=&gt;' . PHP_EOL . '  string(35) "de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7"');
+});
+
+it('can also use rotating proxies when using the headless browser', function () {
+    $crawler = helper_getFastCrawler();
+
+    $loader = $crawler->getLoader();
+
+    /** @var HttpLoader $loader */
+
+    $loader
+        ->useHeadlessBrowser()
+        ->useRotatingProxies([
+            'http://localhost:8001',
+            'http://localhost:8002',
+        ]);
+
+    $crawler
+        ->input([
+            'http://www.crwlr.software/packages/crawler/v1.1',
+            'http://www.crwlr.software/packages/url/v2.0',
+            'http://www.crwlr.software/packages/query-string/v1.0',
+        ])
+        ->addStep(Http::get()->addToResult(['body']));
+
+    $results = iterator_to_array($crawler->run());
+
+    expect($results)->toHaveCount(3)
+        ->and($results[0])
+        ->toBeInstanceOf(Result::class)
+        ->and($results[0]->get('body'))
+        ->toContain('Port: 8001')           // First request with first proxy
+        ->and($results[1])
+        ->toBeInstanceOf(Result::class)
+        ->and($results[1]->get('body'))
+        ->toContain('Port: 8002')           // Second request with second proxy
+        ->and($results[2])
+        ->toBeInstanceOf(Result::class)
+        ->and($results[2]->get('body'))
+        ->toContain('Port: 8001');          // And finally the third request with the first proxy again.
+});

--- a/tests/_Integration/ProxyServer.php
+++ b/tests/_Integration/ProxyServer.php
@@ -1,0 +1,13 @@
+<?php
+
+echo "Proxy Server Response for " . ($_SERVER['REQUEST_URI'] ?? '?') . PHP_EOL . PHP_EOL;
+
+echo "Port: " . $_SERVER['SERVER_PORT'] . PHP_EOL;
+
+echo "Protocol Version: " . $_SERVER['SERVER_PROTOCOL'] . PHP_EOL;
+
+echo "Request Method: " . $_SERVER['REQUEST_METHOD'] . PHP_EOL;
+
+echo "Request Body: " . file_get_contents('php://input') . PHP_EOL;
+
+var_dump(getallheaders());


### PR DESCRIPTION
Add new methods `HttpLoader::useProxy()` and
`HttpLoader::useRotatingProxies([...])` to define proxies that the loader shall use. They can be used with a guzzle HTTP client instance (default) and when the loader uses the headless chrome browser. Using them when providing some other PSR-18 implementation will throw an exception.
(see https://github.com/crwlrsoft/crawler/issues/99)

Also, fix the `HttpLoader::load()` implementation won't throw any exception, because it shouldn't kill a crawler run. When you want any loading error to end the whole crawler execution
`HttpLoader::loadOrFail()` should be used. Also adapted the phpdoc in the `LoaderInterface`.