### PR TITLE
Query params paginator and paginator improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## Added
-* New methods `HttpLoader::useProxy()` and `HttpLoader::useRotatingProxies([...])` to define proxies that the loader shall use. They can be used with a guzzle HTTP client instance (default) and when the loader uses the headless chrome browser. Using them when providing some other PSR-18 implementation will throw an exception.
+
+## [1.3.0] - 2023-10-28
+### Added
+* New methods `HttpLoader::useProxy()` and `HttpLoader::useRotatingProxies([...])` to define proxies that the loader shall use. They can be used with a guzzle HTTP client instance (default) and when the loader uses the headless Chrome browser. Using them when providing some other PSR-18 implementation will throw an exception.
+* New `QueryParamsPaginator` to paginate by increasing and/or decreasing one or multiple query params, either in the URL or in the body of requests. Can be created via static method `Crwlr\Crawler\Steps\Loading\Http\Paginator::queryParams()`.
+* New method `stopWhen` in the new `Crwlr\Crawler\Steps\Loading\Http\AbstractPaginator` class (for more info see the deprecation below). You can pass implementations of the new `StopRule` interface or custom closures to that method and then, every time the Paginator receives a loaded response to process, those stop rules are called with the response. If any of the conditions of the stop rules is met, the Paginator stops paginating. Of course also added a few stop rules to use with that new method: `IsEmptyInHtml`, `IsEmptyInJson`, `IsEmptyInXml` and `IsEmptyResponse`, also available via static methods: `PaginatorStopRules::isEmptyInHtml()`, `PaginatorStopRules::isEmptyInJson()`, `PaginatorStopRules::isEmptyInXml()` and `PaginatorStopRules::isEmptyResponse()`.
+
+### Deprecated
+* Deprecated the `Crwlr\Crawler\Steps\Loading\Http\PaginatorInterface` and the `Crwlr\Crawler\Steps\Loading\Http\Paginators\AbstractPaginator`. Instead, added a new version of the `AbstractPaginator` as `Crwlr\Crawler\Steps\Loading\Http\AbstractPaginator` that can be used. Usually there shouldn't be a problem switching from the old to the new version. If you want to make your custom paginator implementation ready for v2 of the library, extend the new `AbstractPaginator` class, implement your own `getNextRequest` method (new requirement, with a default implementation in the abstract class, which will be removed in v2) and check if properties and methods of your existing class don't collide with the new properties and methods in the abstract class.
 
 ### Fixed
 * The `HttpLoader::load()` implementation won't throw any exception, because it shouldn't kill a crawler run. When you want any loading error to end the whole crawler execution `HttpLoader::loadOrFail()` should be used. Also adapted the phpdoc in the `LoaderInterface`.

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "guzzlehttp/guzzle": "^7.4",
         "adbario/php-dot-notation": "^3.1",
         "chrome-php/chrome": "^1.7",
-        "crwlr/utils": "^1.0"
+        "crwlr/utils": "^1.1"
     },
     "require-dev": {
         "pestphp/pest": "^2.3",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "php": "^8.1",
         "crwlr/robots-txt": "^1.1",
         "crwlr/schema-org": "^0.2.0",
-        "crwlr/url": "^2.0",
+        "crwlr/url": "^2.1",
         "psr/log": "^2.0|^3.0",
         "symfony/dom-crawler": "^6.0",
         "symfony/css-selector": "^6.0",

--- a/src/Loader/Http/HttpLoader.php
+++ b/src/Loader/Http/HttpLoader.php
@@ -11,6 +11,7 @@ use Crwlr\Crawler\Loader\Http\Politeness\Throttler;
 use Crwlr\Crawler\Loader\Loader;
 use Crwlr\Crawler\Steps\Filters\FilterInterface;
 use Crwlr\Crawler\UserAgents\UserAgentInterface;
+use Crwlr\Crawler\Utils\RequestKey;
 use Crwlr\Url\Exceptions\InvalidUrlException;
 use Crwlr\Url\Url;
 use Error;
@@ -406,7 +407,7 @@ class HttpLoader extends Loader
             return null;
         }
 
-        $key = RespondedRequest::cacheKeyFromRequest($request);
+        $key = RequestKey::from($request);
 
         if ($this->cache->has($key)) {
             $this->logger->info('Found ' . $request->getUri()->__toString() . ' in cache.');

--- a/src/Loader/Http/HttpLoader.php
+++ b/src/Loader/Http/HttpLoader.php
@@ -631,7 +631,7 @@ class HttpLoader extends Loader
 
         $page->getSession()->once(
             "method:Network.responseReceived",
-            function ($params) use (& $statusCode, & $responseHeaders) {
+            function ($params) use (&$statusCode, &$responseHeaders) {
                 $statusCode = $params['response']['status'];
 
                 $responseHeaders = $this->sanitizeResponseHeaders($params['response']['headers']);

--- a/src/Loader/Http/Messages/RespondedRequest.php
+++ b/src/Loader/Http/Messages/RespondedRequest.php
@@ -3,6 +3,7 @@
 namespace Crwlr\Crawler\Loader\Http\Messages;
 
 use Crwlr\Crawler\Steps\Loading\Http;
+use Crwlr\Crawler\Utils\RequestKey;
 use Crwlr\Url\Url;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -41,9 +42,12 @@ class RespondedRequest
         return $respondedRequest;
     }
 
+    /**
+     * @deprecated You can use RequestKey::from() directly instead.
+     */
     public static function cacheKeyFromRequest(RequestInterface $request): string
     {
-        return self::cacheKeyFromRequestData(self::requestDataFromRequest($request));
+        return RequestKey::from($request);
     }
 
     /**
@@ -137,39 +141,7 @@ class RespondedRequest
 
     public function cacheKey(): string
     {
-        return self::cacheKeyFromRequestData(self::requestDataFromRequest($this->request));
-    }
-
-    /**
-     * @return mixed[]
-     */
-    protected static function requestDataFromRequest(RequestInterface $request): array
-    {
-        return [
-            'requestMethod' => $request->getMethod(),
-            'requestUri' => $request->getUri()->__toString(),
-            'requestHeaders' => $request->getHeaders(),
-            'requestBody' => Http::getBodyString($request),
-        ];
-    }
-
-    /**
-     * @param mixed[] $requestData
-     */
-    protected static function cacheKeyFromRequestData(array $requestData): string
-    {
-        // Remove cookies when building the key, so cache doesn't depend on sessions
-        if (isset($requestData['requestHeaders']['Cookie'])) {
-            unset($requestData['requestHeaders']['Cookie']);
-        }
-
-        if (isset($requestData['requestHeaders']['cookie'])) {
-            unset($requestData['requestHeaders']['cookie']);
-        }
-
-        $serialized = serialize($requestData);
-
-        return md5($serialized);
+        return RequestKey::from($this->request);
     }
 
     /**

--- a/src/Steps/Loading/Http.php
+++ b/src/Steps/Loading/Http.php
@@ -4,6 +4,7 @@ namespace Crwlr\Crawler\Steps\Loading;
 
 use Crwlr\Crawler\Loader\Http\Exceptions\LoadingException;
 use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Loading\Http\AbstractPaginator;
 use Crwlr\Crawler\Steps\Loading\Http\Paginate;
 use Crwlr\Crawler\Steps\Loading\Http\Paginator;
 use Crwlr\Crawler\Steps\Loading\Http\PaginatorInterface;
@@ -138,7 +139,7 @@ class Http extends LoadingStep
     }
 
     public function paginate(
-        PaginatorInterface|string $paginator,
+        PaginatorInterface|AbstractPaginator|string $paginator,
         int $defaultPaginatorMaxPages = Paginator::MAX_PAGES_DEFAULT
     ): Paginate {
         if (is_string($paginator)) {

--- a/src/Steps/Loading/Http/AbstractPaginator.php
+++ b/src/Steps/Loading/Http/AbstractPaginator.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading\Http;
+
+use Closure;
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Loading\Http\Paginators\StopRules\StopRule;
+use Crwlr\Crawler\Utils\RequestKey;
+use Crwlr\Url\Url;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
+use Psr\Log\LoggerInterface;
+
+abstract class AbstractPaginator
+{
+    /**
+     * @var array<string, true>
+     */
+    protected array $loaded = [];
+
+    protected int $loadedCount = 0;
+
+    protected ?RequestInterface $latestRequest;
+
+    /**
+     * @var array<int, Closure|StopRule>
+     */
+    protected array $stopRules = [];
+
+    protected bool $hasFinished = false;
+
+    public function __construct(protected int $maxPages = Paginator::MAX_PAGES_DEFAULT) {}
+
+    public function processLoaded(
+        UriInterface $url,
+        RequestInterface $request,
+        ?RespondedRequest $respondedRequest,
+    ): void {
+        $this->registerLoadedRequest($respondedRequest ?? $request);
+    }
+
+    public function hasFinished(): bool
+    {
+        return $this->hasFinished || $this->maxPagesReached();
+    }
+
+    public function stopWhen(Closure|StopRule $callback): self
+    {
+        $this->stopRules[] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Default implementation of getNextRequest() that will be remove in v2.
+     * Initially it was required that an implementation has a getNextUrl() method.
+     * As paginating is not always only done via the URL, it's better to have a getNextRequest() method
+     * to be more flexible. Until v2 of this library this method makes the next request, using the
+     * getNextUrl() method. In v2 it will then be required, that Paginator implementations, implement
+     * their own getNextRequest() method and getNextUrl() won't be required anymore.
+     */
+    public function getNextRequest(): ?RequestInterface
+    {
+        if (!$this->latestRequest || !method_exists($this, 'getNextUrl')) {
+            return null;
+        }
+
+        $nextUrl = $this->getNextUrl();
+
+        if (!$nextUrl) {
+            return null;
+        }
+
+        return $this->latestRequest->withUri(Url::parsePsr7($nextUrl));
+    }
+
+    public function logWhenFinished(LoggerInterface $logger): void
+    {
+        if ($this->maxPagesReached()) {
+            $logger->notice('Max pages limit reached.');
+        } else {
+            $logger->info('Finished paginating.');
+        }
+    }
+
+    /**
+     * For v2. See above.
+     */
+    //abstract public function getNextRequest(): ?RequestInterface;
+
+    protected function registerLoadedRequest(RequestInterface|RespondedRequest $request): void
+    {
+        $key = $request instanceof RespondedRequest ? RequestKey::from($request->request) : RequestKey::from($request);
+
+        if (array_key_exists($key, $this->loaded)) {
+            return;
+        }
+
+        $this->loaded[$key] = true;
+
+        $this->loadedCount++;
+
+        if ($request instanceof RespondedRequest) {
+            foreach ($request->redirects() as $redirectUrl) {
+                $this->loaded[RequestKey::from($request->request->withUri(Url::parsePsr7($redirectUrl)))] = true;
+            }
+        }
+
+        $this->latestRequest = $request instanceof RespondedRequest ? $request->request : $request;
+
+        $respondedRequest = $request instanceof RespondedRequest ? $request : null;
+
+        $request = $request instanceof RequestInterface ? $request : $request->request;
+
+        if ($this->shouldStop($request, $respondedRequest)) {
+            $this->setFinished();
+        }
+    }
+
+    protected function shouldStop(RequestInterface $request, ?RespondedRequest $respondedRequest): bool
+    {
+        if ($this->maxPagesReached()) {
+            return true;
+        }
+
+        foreach ($this->stopRules as $stopRule) {
+            if ($stopRule instanceof StopRule && $stopRule->shouldStop($request, $respondedRequest)) {
+                return true;
+            } elseif ($stopRule instanceof Closure && $stopRule->call($this, $request, $respondedRequest)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function maxPagesReached(): bool
+    {
+        return $this->loadedCount >= $this->maxPages;
+    }
+
+    protected function setFinished(): self
+    {
+        $this->hasFinished = true;
+
+        return $this;
+    }
+}

--- a/src/Steps/Loading/Http/Paginator.php
+++ b/src/Steps/Loading/Http/Paginator.php
@@ -3,6 +3,7 @@
 namespace Crwlr\Crawler\Steps\Loading\Http;
 
 use Crwlr\Crawler\Steps\Html\DomQueryInterface;
+use Crwlr\Crawler\Steps\Loading\Http\Paginators\QueryParamsPaginator;
 use Crwlr\Crawler\Steps\Loading\Http\Paginators\SimpleWebsitePaginator;
 
 class Paginator
@@ -14,5 +15,10 @@ class Paginator
         int $maxPages = self::MAX_PAGES_DEFAULT,
     ): SimpleWebsitePaginator {
         return new SimpleWebsitePaginator($paginationLinksSelector, $maxPages);
+    }
+
+    public static function queryParams(int $maxPages = Paginator::MAX_PAGES_DEFAULT): QueryParamsPaginator
+    {
+        return new QueryParamsPaginator($maxPages);
     }
 }

--- a/src/Steps/Loading/Http/PaginatorInterface.php
+++ b/src/Steps/Loading/Http/PaginatorInterface.php
@@ -7,6 +7,12 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerInterface;
 
+/**
+ * @deprecated For better extensibility, this interface will be removed in v2.
+ *             Just extend the abstract AbstractPaginator class, which was already recommended since
+ *             Paginators where introduced.
+ */
+
 interface PaginatorInterface
 {
     public function hasFinished(): bool;

--- a/src/Steps/Loading/Http/Paginators/AbstractPaginator.php
+++ b/src/Steps/Loading/Http/Paginators/AbstractPaginator.php
@@ -7,6 +7,13 @@ use Crwlr\Crawler\Steps\Loading\Http\Paginator;
 use Crwlr\Crawler\Steps\Loading\Http\PaginatorInterface;
 use Psr\Http\Message\RequestInterface;
 
+/**
+ * @deprecated There's a new improved version of this class: Crwlr\Crawler\Steps\Loading\Http\AbstractPaginator
+ *             In order to prevent potentially breaking backwards compatibility, by adding methods and properties
+ *             to this class, that could already exist in user's custom implementations, this class is deprecated
+ *             and the improved version is available with a different namespace (see above).
+ */
+
 abstract class AbstractPaginator implements PaginatorInterface
 {
     public function __construct(protected int $maxPages = Paginator::MAX_PAGES_DEFAULT) {}

--- a/src/Steps/Loading/Http/Paginators/QueryParams/AbstractQueryParamManipulator.php
+++ b/src/Steps/Loading/Http/Paginators/QueryParams/AbstractQueryParamManipulator.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading\Http\Paginators\QueryParams;
+
+use Crwlr\QueryString\Query;
+use Exception;
+
+abstract class AbstractQueryParamManipulator implements QueryParamManipulator
+{
+    public function __construct(protected string $queryParamName) {}
+
+    /**
+     * @throws Exception
+     */
+    protected function getCurrentValue(Query $query, mixed $fallbackValue = null): mixed
+    {
+        if ($query->has($this->queryParamName)) {
+            return $query->get($this->queryParamName);
+        }
+
+        return $fallbackValue;
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function getCurrentValueAsInt(Query $query): int
+    {
+        $currentValue = $this->getCurrentValue($query);
+
+        return $currentValue === null ? 0 : (int) $currentValue;
+    }
+}

--- a/src/Steps/Loading/Http/Paginators/QueryParams/Decrementor.php
+++ b/src/Steps/Loading/Http/Paginators/QueryParams/Decrementor.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading\Http\Paginators\QueryParams;
+
+use Crwlr\QueryString\Query;
+use Exception;
+
+class Decrementor extends AbstractQueryParamManipulator
+{
+    public function __construct(
+        string $queryParamName,
+        protected int $decrement = 1
+    ) {
+        parent::__construct($queryParamName);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function execute(Query $query): Query
+    {
+        return $query->set(
+            $this->queryParamName,
+            (string) ($this->getCurrentValueAsInt($query) - $this->decrement),
+        );
+    }
+}

--- a/src/Steps/Loading/Http/Paginators/QueryParams/Incrementor.php
+++ b/src/Steps/Loading/Http/Paginators/QueryParams/Incrementor.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading\Http\Paginators\QueryParams;
+
+use Crwlr\QueryString\Query;
+use Exception;
+
+class Incrementor extends AbstractQueryParamManipulator
+{
+    public function __construct(
+        string $queryParamName,
+        protected int $increment = 1
+    ) {
+        parent::__construct($queryParamName);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function execute(Query $query): Query
+    {
+        return $query->set(
+            $this->queryParamName,
+            (string) ($this->getCurrentValueAsInt($query) + $this->increment),
+        );
+    }
+}

--- a/src/Steps/Loading/Http/Paginators/QueryParams/QueryParamManipulator.php
+++ b/src/Steps/Loading/Http/Paginators/QueryParams/QueryParamManipulator.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading\Http\Paginators\QueryParams;
+
+use Crwlr\QueryString\Query;
+
+interface QueryParamManipulator
+{
+    public function execute(Query $query): Query;
+}

--- a/src/Steps/Loading/Http/Paginators/QueryParamsPaginator.php
+++ b/src/Steps/Loading/Http/Paginators/QueryParamsPaginator.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading\Http\Paginators;
+
+use Crwlr\Crawler\Steps\Loading\Http;
+use Crwlr\Crawler\Steps\Loading\Http\Paginator;
+use Crwlr\Crawler\Steps\Loading\Http\Paginators\QueryParams\Decrementor;
+use Crwlr\Crawler\Steps\Loading\Http\Paginators\QueryParams\Incrementor;
+use Crwlr\Crawler\Steps\Loading\Http\Paginators\QueryParams\QueryParamManipulator;
+use Crwlr\QueryString\Query;
+use Crwlr\Url\Url;
+use Exception;
+use GuzzleHttp\Psr7\Utils;
+use Psr\Http\Message\RequestInterface;
+
+class QueryParamsPaginator extends Http\AbstractPaginator
+{
+    /**
+     * @var QueryParamManipulator[]
+     */
+    protected array $manipulators = [];
+
+    /**
+     * @var bool True means the class handles URL query params, false means it's about params sent as request body.
+     */
+    protected bool $paramsInUrl = true;
+
+    public static function paramsInUrl(int $maxPages = Paginator::MAX_PAGES_DEFAULT): self
+    {
+        return new self($maxPages);
+    }
+
+    public function inUrl(): self
+    {
+        $this->paramsInUrl = true;
+
+        return $this;
+    }
+
+    public static function paramsInBody(int $maxPages = Paginator::MAX_PAGES_DEFAULT): self
+    {
+        $instance = new self($maxPages);
+
+        $instance->paramsInUrl = false;
+
+        return $instance;
+    }
+
+    public function inBody(): self
+    {
+        $this->paramsInUrl = false;
+
+        return $this;
+    }
+
+    public function increase(string $queryParamName, int $by = 1): self
+    {
+        $this->manipulators[] = new Incrementor($queryParamName, $by);
+
+        return $this;
+    }
+
+    public function decrease(string $queryParamName, int $by = 1): self
+    {
+        $this->manipulators[] = new Decrementor($queryParamName, $by);
+
+        return $this;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function getNextRequest(): ?RequestInterface
+    {
+        if (!$this->latestRequest) {
+            return null;
+        }
+
+        if ($this->paramsInUrl) {
+            $url = Url::parse($this->latestRequest->getUri());
+
+            $query = $url->queryString();
+        } else {
+            $query = Query::fromString(Http::getBodyString($this->latestRequest));
+        }
+
+        foreach ($this->manipulators as $manipulator) {
+            $query = $manipulator->execute($query);
+        }
+
+        if ($this->paramsInUrl) {
+            $request = $this->latestRequest->withUri($url->toPsr7());
+        } else {
+            $request = $this->latestRequest->withBody(Utils::streamFor($query->toString()));
+        }
+
+        return $request;
+    }
+}

--- a/src/Steps/Loading/Http/Paginators/SimpleWebsitePaginator.php
+++ b/src/Steps/Loading/Http/Paginators/SimpleWebsitePaginator.php
@@ -7,6 +7,7 @@ use Crwlr\Crawler\Steps\Dom;
 use Crwlr\Crawler\Steps\Html\DomQuery;
 use Crwlr\Crawler\Steps\Html\DomQueryInterface;
 use Crwlr\Crawler\Steps\Loading\Http;
+use Crwlr\Crawler\Utils\RequestKey;
 use Crwlr\Url\Url;
 use Exception;
 use Psr\Http\Message\RequestInterface;
@@ -14,21 +15,26 @@ use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DomCrawler\Crawler;
 
-class SimpleWebsitePaginator extends AbstractPaginator
+class SimpleWebsitePaginator extends Http\AbstractPaginator
 {
     /**
-     * @var array<string, string>
+     * @var array<string, array{ url: string, foundOn: string }>
      */
     protected array $found = [];
 
     /**
      * @var array<string, true>
      */
-    protected array $loaded = [];
-
-    protected int $loadedPagesCount = 0;
+    protected array $loadedUrls = [];
 
     protected DomQueryInterface $paginationLinksSelector;
+
+    protected string $latestRequestKey = '';
+
+    /**
+     * @var array<string, RequestInterface>
+     */
+    protected array $parentRequests = [];
 
     public function __construct(string|DomQueryInterface $paginationLinksSelector, int $maxPages = 1000)
     {
@@ -43,12 +49,40 @@ class SimpleWebsitePaginator extends AbstractPaginator
 
     public function hasFinished(): bool
     {
-        return $this->loadedPagesCount >= $this->maxPages || empty($this->found);
+        return $this->maxPagesReached() || empty($this->found) || $this->hasFinished;
     }
 
+    /**
+     * Remove in v2.
+     */
     public function getNextUrl(): ?string
     {
-        return array_shift($this->found);
+        $found = array_shift($this->found);
+
+        if (is_array($found)) {
+            return $found['url'];
+        }
+
+        return null;
+    }
+
+    public function getNextRequest(): ?RequestInterface
+    {
+        if (!$this->latestRequest) {
+            return null;
+        }
+
+        $nextUrl = array_shift($this->found);
+
+        if (!$nextUrl) {
+            return null;
+        }
+
+        $request = $this->parentRequests[$nextUrl['foundOn']];
+
+        $this->cleanUpParentRequests();
+
+        return $request->withUri(Url::parsePsr7($nextUrl['url']));
     }
 
     /**
@@ -59,13 +93,17 @@ class SimpleWebsitePaginator extends AbstractPaginator
         RequestInterface $request,
         ?RespondedRequest $respondedRequest,
     ): void {
-        $this->loaded[$url->__toString()] = true;
+        $this->registerLoadedRequest($request);
 
-        $this->loadedPagesCount++;
+        if ($this->latestRequest) {
+            $this->latestRequestKey = RequestKey::from($this->latestRequest);
+        }
+
+        $this->loadedUrls[$request->getUri()->__toString()] = true;
 
         if ($respondedRequest) {
             foreach ($respondedRequest->redirects() as $redirectUrl) {
-                $this->loaded[$redirectUrl] = true;
+                $this->loadedUrls[$redirectUrl] = true;
             }
 
             $this->getPaginationLinksFromResponse($respondedRequest);
@@ -74,8 +112,8 @@ class SimpleWebsitePaginator extends AbstractPaginator
 
     public function logWhenFinished(LoggerInterface $logger): void
     {
-        if ($this->loadedPagesCount >= $this->maxPages && !empty($this->found)) {
-            $logger->warning('Max pages limit reached');
+        if ($this->maxPagesReached() && !empty($this->found)) {
+            $logger->notice('Max pages limit reached');
         } else {
             $logger->info('All found pagination links loaded');
         }
@@ -162,8 +200,31 @@ class SimpleWebsitePaginator extends AbstractPaginator
 
     protected function addFoundUrl(string $url): void
     {
-        if (!isset($this->found[$url]) && !isset($this->loaded[$url])) {
-            $this->found[$url] = $url;
+        if (!isset($this->found[$url]) && !isset($this->loadedUrls[$url])) {
+            if ($this->latestRequest && !array_key_exists($this->latestRequestKey, $this->parentRequests)) {
+                $this->parentRequests[$this->latestRequestKey] = $this->latestRequest;
+            }
+
+            $this->found[$url] = ['url' => $url, 'foundOn' => $this->latestRequestKey];
+        }
+    }
+
+    /**
+     * The parent requests for found links are stored, so the new requests are always created from the actual parent,
+     * not the latest registered response. After getting the next request to load, always check for all parent
+     * requests, if there are still children in the found URLs. If not, the parent request can be forgotten, so we
+     * keep memory usage as low as possible.
+     */
+    protected function cleanUpParentRequests(): void
+    {
+        foreach ($this->parentRequests as $requestKey => $request) {
+            foreach ($this->found as $found) {
+                if ($found['foundOn'] === $requestKey) {
+                    continue 2;
+                }
+            }
+
+            unset($this->parentRequests[$requestKey]);
         }
     }
 }

--- a/src/Steps/Loading/Http/Paginators/StopRules/IsEmptyInDom.php
+++ b/src/Steps/Loading/Http/Paginators/StopRules/IsEmptyInDom.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading\Http\Paginators\StopRules;
+
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Html\CssSelector;
+use Crwlr\Crawler\Steps\Html\DomQueryInterface;
+use Crwlr\Crawler\Steps\Loading\Http;
+use Psr\Http\Message\RequestInterface;
+use Symfony\Component\DomCrawler\Crawler;
+
+abstract class IsEmptyInDom implements StopRule
+{
+    public function __construct(protected string|DomQueryInterface $selector) {}
+
+    public function shouldStop(RequestInterface $request, ?RespondedRequest $respondedRequest): bool
+    {
+        if (!$respondedRequest) {
+            return true;
+        }
+
+        $content = trim(Http::getBodyString($respondedRequest->response));
+
+        $dom = new Crawler($content);
+
+        $domQuery = $this->selector instanceof DomQueryInterface ? $this->selector : new CssSelector($this->selector);
+
+        $filtered = $domQuery->filter($dom);
+
+        if ($filtered->count() === 0) {
+            return true;
+        }
+
+        foreach ($filtered as $element) {
+            if (trim((new Crawler($element))->html()) !== '') {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Steps/Loading/Http/Paginators/StopRules/IsEmptyInHtml.php
+++ b/src/Steps/Loading/Http/Paginators/StopRules/IsEmptyInHtml.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading\Http\Paginators\StopRules;
+
+class IsEmptyInHtml extends IsEmptyInDom {}

--- a/src/Steps/Loading/Http/Paginators/StopRules/IsEmptyInJson.php
+++ b/src/Steps/Loading/Http/Paginators/StopRules/IsEmptyInJson.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading\Http\Paginators\StopRules;
+
+use Adbar\Dot;
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Loading\Http;
+use Crwlr\Utils\Exceptions\InvalidJsonException;
+use Crwlr\Utils\Json;
+use Psr\Http\Message\RequestInterface;
+
+class IsEmptyInJson implements StopRule
+{
+    public function __construct(protected string $dotNotationKey) {}
+
+    /**
+     * @throws InvalidJsonException
+     */
+    public function shouldStop(RequestInterface $request, ?RespondedRequest $respondedRequest): bool
+    {
+        if (!$respondedRequest) {
+            return true;
+        }
+
+        $content = trim(Http::getBodyString($respondedRequest->response));
+
+        $json = Json::stringToArray($content);
+
+        $dot = new Dot($json);
+
+        return empty($dot->get($this->dotNotationKey));
+    }
+}

--- a/src/Steps/Loading/Http/Paginators/StopRules/IsEmptyInXml.php
+++ b/src/Steps/Loading/Http/Paginators/StopRules/IsEmptyInXml.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading\Http\Paginators\StopRules;
+
+class IsEmptyInXml extends IsEmptyInDom {}

--- a/src/Steps/Loading/Http/Paginators/StopRules/IsEmptyResponse.php
+++ b/src/Steps/Loading/Http/Paginators/StopRules/IsEmptyResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading\Http\Paginators\StopRules;
+
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Loading\Http;
+use Psr\Http\Message\RequestInterface;
+
+class IsEmptyResponse implements StopRule
+{
+    public function shouldStop(RequestInterface $request, ?RespondedRequest $respondedRequest): bool
+    {
+        if (!$respondedRequest) {
+            return true;
+        }
+
+        $content = trim(Http::getBodyString($respondedRequest->response));
+
+        return $content === '' || $content === '[]' || $content === '{}';
+    }
+}

--- a/src/Steps/Loading/Http/Paginators/StopRules/PaginatorStopRules.php
+++ b/src/Steps/Loading/Http/Paginators/StopRules/PaginatorStopRules.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading\Http\Paginators\StopRules;
+
+use Crwlr\Crawler\Steps\Html\DomQueryInterface;
+
+class PaginatorStopRules
+{
+    public static function isEmptyResponse(): IsEmptyResponse
+    {
+        return new IsEmptyResponse();
+    }
+
+    public static function isEmptyInJson(string $dotNotationKey): IsEmptyInJson
+    {
+        return new IsEmptyInJson($dotNotationKey);
+    }
+
+    public static function isEmptyInHtml(string|DomQueryInterface $selector): IsEmptyInHtml
+    {
+        return new IsEmptyInHtml($selector);
+    }
+
+    public static function isEmptyInXml(string|DomQueryInterface $selector): IsEmptyInXml
+    {
+        return new IsEmptyInXml($selector);
+    }
+}

--- a/src/Steps/Loading/Http/Paginators/StopRules/StopRule.php
+++ b/src/Steps/Loading/Http/Paginators/StopRules/StopRule.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading\Http\Paginators\StopRules;
+
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Psr\Http\Message\RequestInterface;
+
+interface StopRule
+{
+    public function shouldStop(RequestInterface $request, ?RespondedRequest $respondedRequest): bool;
+}

--- a/src/Utils/RequestKey.php
+++ b/src/Utils/RequestKey.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Crwlr\Crawler\Utils;
+
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Loading\Http;
+use Psr\Http\Message\RequestInterface;
+
+class RequestKey
+{
+    /**
+     * Creates a unique key for an HTTP request
+     *
+     * The key will be based on all its properties: method, URI, headers, body.
+     * So, for example, if requests send different bodies, but the rest is identical, the keys will be different.
+     *
+     * By default, Cookie headers are removed before building the key, so the key is independent of sessions.
+     * You can also pass other headers (or none if you want cookies to be included) to be ignored as second argument.
+     *
+     * @param RequestInterface|RespondedRequest $request
+     * @param string[] $ignoreHeaders
+     * @return string
+     */
+    public static function from(RequestInterface|RespondedRequest $request, array $ignoreHeaders = ['Cookie']): string
+    {
+        $request = $request instanceof RespondedRequest ? $request->request : $request;
+
+        $data = [
+            'requestMethod' => $request->getMethod(),
+            'requestUri' => $request->getUri()->__toString(),
+            'requestHeaders' => $request->getHeaders(),
+            'requestBody' => Http::getBodyString($request),
+        ];
+
+        $data = self::removeIgnoreHeaders($data, $ignoreHeaders);
+
+        $serialized = serialize($data);
+
+        return md5($serialized);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @param string[] $ignoreHeaders
+     * @return array<string, mixed>
+     */
+    private static function removeIgnoreHeaders(array $data, array $ignoreHeaders): array
+    {
+        foreach ($ignoreHeaders as $ignoreHeader) {
+            if (isset($data['requestHeaders'][$ignoreHeader])) {
+                unset($data['requestHeaders'][$ignoreHeader]);
+            }
+
+            $otherCase = strtolower($ignoreHeader);
+
+            if ($otherCase === $ignoreHeader) {
+                $otherCase = ucwords($ignoreHeader, '-');
+            }
+
+            $ignoreHeader = $otherCase;
+
+            if (isset($data['requestHeaders'][$ignoreHeader])) {
+                unset($data['requestHeaders'][$ignoreHeader]);
+            }
+        }
+
+        return $data;
+    }
+}

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -724,7 +724,7 @@ it('sends all outputs to the outputHook when defined', function () {
         ->input(1)
         ->addStep(helper_getNumberIncrementingStep())
         ->addStep(helper_getNumberIncrementingStep())
-        ->outputHook(function (Output $output, int $stepIndex, StepInterface $step) use (& $outputs) {
+        ->outputHook(function (Output $output, int $stepIndex, StepInterface $step) use (&$outputs) {
             $outputs[$stepIndex][] = $output->get();
         });
 

--- a/tests/Loader/Http/HttpLoaderTest.php
+++ b/tests/Loader/Http/HttpLoaderTest.php
@@ -75,13 +75,13 @@ it(
 
         $beforeLoadWasCalled = false;
 
-        $httpLoader->beforeLoad(function () use (& $beforeLoadWasCalled) {
+        $httpLoader->beforeLoad(function () use (&$beforeLoadWasCalled) {
             $beforeLoadWasCalled = true;
         });
 
         $afterLoadWasCalled = false;
 
-        $httpLoader->beforeLoad(function () use (& $afterLoadWasCalled) {
+        $httpLoader->beforeLoad(function () use (&$afterLoadWasCalled) {
             $afterLoadWasCalled = true;
         });
 
@@ -108,7 +108,7 @@ it('calls the onSuccess hook on a successful response', function ($responseStatu
 
     $onSuccessWasCalled = false;
 
-    $httpLoader->onSuccess(function () use (& $onSuccessWasCalled) {
+    $httpLoader->onSuccess(function () use (&$onSuccessWasCalled) {
         $onSuccessWasCalled = true;
     });
 
@@ -136,7 +136,7 @@ it('calls the onError hook on a failed request', function ($responseStatusCode) 
 
     $onErrorWasCalled = false;
 
-    $httpLoader->onError(function () use (& $onErrorWasCalled) {
+    $httpLoader->onError(function () use (&$onErrorWasCalled) {
         $onErrorWasCalled = true;
     });
 
@@ -172,7 +172,7 @@ it('calls the onCacheHit hook when a response for the request was found in the c
 
     $onCacheHitWasCalled = false;
 
-    $httpLoader->onCacheHit(function () use (& $onCacheHitWasCalled) {
+    $httpLoader->onCacheHit(function () use (&$onCacheHitWasCalled) {
         $onCacheHitWasCalled = true;
     });
 
@@ -190,7 +190,7 @@ it('throws an Exception when request fails in loadOrFail method', function () {
 
     $onErrorWasCalled = false;
 
-    $httpLoader->onError(function () use (& $onErrorWasCalled) {
+    $httpLoader->onError(function () use (&$onErrorWasCalled) {
         $onErrorWasCalled = true;
     });
 
@@ -475,7 +475,7 @@ it('fails when it gets a failed response from cache', function () {
 
     $onErrorWasCalled = false;
 
-    $httpLoader->onError(function () use (& $onErrorWasCalled) {
+    $httpLoader->onError(function () use (&$onErrorWasCalled) {
         $onErrorWasCalled = true;
     });
 

--- a/tests/Loader/Http/Messages/RespondedRequestTest.php
+++ b/tests/Loader/Http/Messages/RespondedRequestTest.php
@@ -195,36 +195,6 @@ it('can be created from a serialized array', function () {
     expect($respondedRequest->effectiveUri())->toBe('/bar');
 });
 
-it('makes a cache key from a Request object', function () {
-    $request = new Request('GET', 'https://www.crwlr.software/packages', ['accept-encoding' => 'gzip, deflate, br']);
-
-    expect(RespondedRequest::cacheKeyFromRequest($request))->toBe('fc2a9e78c97e68674201853cea4a3d74');
-
-    $request = $request->withAddedHeader('accept-language', 'de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7');
-
-    expect(RespondedRequest::cacheKeyFromRequest($request))->not()->toBe('fc2a9e78c97e68674201853cea4a3d74');
-});
-
-test('when creating the key it ignores cookies in the sent headers', function () {
-    $request = new Request('GET', 'https://www.crwlr.software/packages', ['accept-encoding' => 'gzip, deflate, br']);
-
-    $keyWithoutCookie = RespondedRequest::cacheKeyFromRequest($request);
-
-    $request = new Request('GET', 'https://www.crwlr.software/packages', [
-        'accept-encoding' => 'gzip, deflate, br',
-        'Cookie' => 'cookieName=v4lu3',
-    ]);
-
-    expect(RespondedRequest::cacheKeyFromRequest($request))->toBe($keyWithoutCookie);
-
-    $request = new Request('GET', 'https://www.crwlr.software/packages', [
-        'accept-encoding' => 'gzip, deflate, br',
-        'cookie' => 'cookieName=v4lu3',
-    ]);
-
-    expect(RespondedRequest::cacheKeyFromRequest($request))->toBe($keyWithoutCookie);
-});
-
 it('generates a cache key for an instance', function () {
     $respondedRequest = new RespondedRequest(new Request('GET', '/foo/bar'), new Response());
 

--- a/tests/Loader/LoaderTest.php
+++ b/tests/Loader/LoaderTest.php
@@ -26,15 +26,15 @@ test('You can set multiple hook callbacks for one type and they are executed whe
         }
     };
     $callback1Called = false;
-    $loader->{$hookName}(function () use (& $callback1Called) {
+    $loader->{$hookName}(function () use (&$callback1Called) {
         $callback1Called = true;
     });
     $callback2Called = false;
-    $loader->{$hookName}(function () use (& $callback2Called) {
+    $loader->{$hookName}(function () use (&$callback2Called) {
         $callback2Called = true;
     });
     $callback3Called = false;
-    $loader->{$hookName}(function () use (& $callback3Called) {
+    $loader->{$hookName}(function () use (&$callback3Called) {
         $callback3Called = true;
     });
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -5,6 +5,7 @@ namespace tests;
 use Crwlr\Crawler\HttpCrawler;
 use Crwlr\Crawler\Input;
 use Crwlr\Crawler\Loader\Http\HttpLoader;
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
 use Crwlr\Crawler\Loader\Http\Politeness\TimingUnits\MultipleOf;
 use Crwlr\Crawler\Loader\LoaderInterface;
 use Crwlr\Crawler\Output;
@@ -14,7 +15,9 @@ use Crwlr\Crawler\UserAgents\UserAgent;
 use Crwlr\Crawler\UserAgents\UserAgentInterface;
 use Crwlr\Utils\Microseconds;
 use Generator;
+use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Log\LoggerInterface;
 use stdClass;
 use Symfony\Component\Process\Process;
@@ -256,6 +259,34 @@ function helper_getFastCrawler(): HttpCrawler
             return helper_getFastLoader($userAgent, $logger);
         }
     };
+}
+
+/**
+ * @param array<string, string|string[]> $requestHeaders
+ * @param array<string, string|string[]> $responseHeaders
+ */
+function helper_getRespondedRequest(
+    string $method = 'GET',
+    string $url = 'https://www.example.com/foo',
+    array $requestHeaders = [],
+    ?string $requestBody = null,
+    int $statusCode = 200,
+    array $responseHeaders = [],
+    ?string $responseBody = null,
+): RespondedRequest {
+    if ($requestBody !== null) {
+        $request = new Request($method, $url, $requestHeaders, Utils::streamFor($requestBody));
+    } else {
+        $request = new Request($method, $url, $requestHeaders);
+    }
+
+    if ($responseBody !== null) {
+        $response = new Response($statusCode, $responseHeaders, body: Utils::streamFor($responseBody));
+    } else {
+        $response = new Response($statusCode, $responseHeaders);
+    }
+
+    return new RespondedRequest($request, $response);
 }
 
 function helper_cachedir(): string

--- a/tests/Steps/GroupTest.php
+++ b/tests/Steps/GroupTest.php
@@ -1056,7 +1056,7 @@ it('applies multiple refiners to the steps output in the order they\'re added', 
         ->addStep($step1)
         ->addStep($step2)
         ->refineOutput('foo', StringRefiner::betweenFirst('lorem', 'dolor'))
-        ->refineOutput('bar', fn (mixed $outputValue) => $outputValue . ' refined');
+        ->refineOutput('bar', fn(mixed $outputValue) => $outputValue . ' refined');
 
     $outputs = helper_invokeStepWithInput($group);
 
@@ -1072,7 +1072,7 @@ test('you can apply multiple refiners to the same output array key', function ()
         ->addStep($step1)
         ->addStep($step2)
         ->refineOutput('foo', StringRefiner::betweenFirst('lorem', 'dolor'))
-        ->refineOutput('foo', fn (mixed $outputValue) => $outputValue . ' refined');
+        ->refineOutput('foo', fn(mixed $outputValue) => $outputValue . ' refined');
 
     $outputs = helper_invokeStepWithInput($group);
 
@@ -1090,7 +1090,7 @@ it(
         $group = (new Group())
             ->addStep($step1)
             ->addStep($step2)
-            ->refineOutput(fn (mixed $outputValue, mixed $originalInputValue) => $originalInputValue);
+            ->refineOutput(fn(mixed $outputValue, mixed $originalInputValue) => $originalInputValue);
 
         $outputs = helper_invokeStepWithInput($group, ['yo' => 'lo']);
 

--- a/tests/Steps/Loading/Http/Paginators/AbstractPaginatorTest.php
+++ b/tests/Steps/Loading/Http/Paginators/AbstractPaginatorTest.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace tests\Steps\Loading\Http\Paginators;
+
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Loading\Http\Paginators\StopRules\PaginatorStopRules;
+use Crwlr\Url\Url;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use tests\_Stubs\AbstractTestPaginator;
+use tests\_Stubs\DummyLogger;
+
+use function tests\helper_getRespondedRequest;
+
+test(
+    'the temporary default implementation of the getNextRequest() method, uses the getNextUrl() method and the latest' .
+    'request, to create the next request',
+    function () {
+        $paginator = new AbstractTestPaginator(nextUrl: 'https://www.example.com/bar');
+
+        $respondedRequest = helper_getRespondedRequest(
+            'POST',
+            'https://www.example.com/foo',
+            ['foo' => 'lorem ipsum'],
+            'Helloooo'
+        );
+
+        $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+        $nextRequest = $paginator->getNextRequest();
+
+        expect($nextRequest?->getUri()->__toString())
+            ->toBe('https://www.example.com/bar')
+            ->and($nextRequest?->getMethod())
+            ->toBe('POST')
+            ->and($nextRequest?->getHeaders())
+            ->toHaveKey('foo')
+            ->and($nextRequest?->getHeaders()['foo'])
+            ->toBe(['lorem ipsum'])
+            ->and($nextRequest?->getBody()->getContents())
+            ->toBe('Helloooo');
+    }
+);
+
+it('registers loaded requests from PSR-7 RequestInterface instances', function () {
+    $paginator = new AbstractTestPaginator(nextUrl: 'https://www.example.com/bar');
+
+    $respondedRequest1 = helper_getRespondedRequest('GET', 'https://www.example.com/foo', [], 'Hi');
+
+    $paginator->processLoaded($respondedRequest1->request->getUri(), $respondedRequest1->request, $respondedRequest1);
+
+    expect($paginator->getLoaded())
+        ->toBe(['f2be1fcc5667a8f4ee2fd7f48c69c909' => true])
+        ->and($paginator->getLoadedCount())
+        ->toBe(1)
+        ->and($paginator->getLatestRequest())
+        ->toBe($respondedRequest1->request);
+
+    $respondedRequest2 = helper_getRespondedRequest('GET', 'https://www.example.com/bar', [], 'Yo');
+
+    $paginator->processLoaded($respondedRequest2->request->getUri(), $respondedRequest2->request, $respondedRequest2);
+
+    expect($paginator->getLoaded())->toBe([
+        'f2be1fcc5667a8f4ee2fd7f48c69c909' => true,
+        'd9e0c3987944f190782f5af9506eb478' => true,
+    ])
+        ->and($paginator->getLoadedCount())
+        ->toBe(2)
+        ->and($paginator->getLatestRequest())
+        ->toBe($respondedRequest2->request);
+});
+
+it('registers loaded requests from RespondedRequest objects', function () {
+    $paginator = new AbstractTestPaginator(nextUrl: 'https://www.example.com/bar');
+
+    $requestOne = new Request('GET', Url::parsePsr7('https://www.example.com/foo'), [], 'Hi');
+
+    $requestTwo = new Request('GET', Url::parsePsr7('https://www.example.com/bar'), [], 'Yo');
+
+    $paginator->processLoaded($requestOne->getUri(), $requestOne, new RespondedRequest($requestTwo, new Response()));
+
+    expect($paginator->getLoaded())
+        ->toBe(['d9e0c3987944f190782f5af9506eb478' => true])
+        ->and($paginator->getLoadedCount())
+        ->toBe(1)
+        ->and($paginator->getLatestRequest())
+        ->toBe($requestTwo);
+});
+
+it('knows when the max pages to load limit is reached', function () {
+    $paginator = new AbstractTestPaginator(3);
+
+    $respondedRequest = helper_getRespondedRequest(url: 'https://www.example.com/foo');
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    expect($paginator->limitReached())->toBeFalse();
+
+    $respondedRequest = helper_getRespondedRequest(url: 'https://www.example.com/bar');
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    expect($paginator->limitReached())->toBeFalse();
+
+    $respondedRequest = helper_getRespondedRequest(url: 'https://www.example.com/baz');
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    expect($paginator->limitReached())->toBeTrue();
+
+    expect($paginator->hasFinished())->toBeTrue();
+});
+
+test('the same request is not registered twice', function () {
+    $paginator = new AbstractTestPaginator();
+
+    $respondedRequest = helper_getRespondedRequest();
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    expect($paginator->getLoadedCount())->toBe(1);
+
+    $respondedRequest = helper_getRespondedRequest();
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    expect($paginator->getLoadedCount())->toBe(1);
+});
+
+it('logs a message when the max pages limit was reached', function () {
+    $paginator = new AbstractTestPaginator(2);
+
+    $respondedRequest = helper_getRespondedRequest(url: 'https://www.example.com/foo');
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    $logger = new DummyLogger();
+
+    $paginator->logWhenFinished($logger);
+
+    expect($logger->messages[0])->toBe([
+        'level' => 'info',
+        'message' => 'Finished paginating.',
+    ]);
+
+    $respondedRequest = helper_getRespondedRequest(url: 'https://www.example.com/bar');
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    $paginator->logWhenFinished($logger);
+
+    expect($logger->messages[1])->toBe([
+        'level' => 'notice',
+        'message' => 'Max pages limit reached.',
+    ]);
+});
+
+it('logs a message when it finished paginating', function () {
+    $paginator = new AbstractTestPaginator();
+
+    $paginator->stopWhen(PaginatorStopRules::isEmptyResponse());
+
+    $respondedRequest = helper_getRespondedRequest();
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    $logger = new DummyLogger();
+
+    $paginator->logWhenFinished($logger);
+
+    expect($logger->messages[0])->toBe([
+        'level' => 'info',
+        'message' => 'Finished paginating.',
+    ]);
+});
+
+it('stops paginating when a stop condition is met', function () {
+    $paginator = new AbstractTestPaginator();
+
+    $paginator
+        ->stopWhen(PaginatorStopRules::isEmptyResponse())
+        ->stopWhen(PaginatorStopRules::isEmptyInJson('items'));
+
+    $respondedRequest = helper_getRespondedRequest(
+        url: 'https://www.example.com/list?page=1',
+        responseBody: '{ "items": ["foo"] }',
+    );
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    expect($paginator->hasFinished())->toBeFalse();
+
+    $respondedRequest = helper_getRespondedRequest(url: 'https://www.example.com/list?page=2', responseBody: '{}');
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    expect($paginator->hasFinished())->toBeTrue();
+
+    $paginator = new AbstractTestPaginator();
+
+    $paginator
+        ->stopWhen(PaginatorStopRules::isEmptyResponse())
+        ->stopWhen(PaginatorStopRules::isEmptyInJson('items'));
+
+    $respondedRequest = helper_getRespondedRequest(
+        url: 'https://www.example.com/list?page=1',
+        responseBody: '{ "items": [] }',
+    );
+
+    $paginator->processLoaded($respondedRequest->request->getUri(), $respondedRequest->request, $respondedRequest);
+
+    expect($paginator->hasFinished())->toBeTrue();
+});
+
+test('after calling the setFinished() method, the hasFinished() method returns true', function () {
+    $paginator = new AbstractTestPaginator();
+
+    expect($paginator->hasFinished())->toBeFalse();
+
+    $paginator->setFinished();
+
+    expect($paginator->hasFinished())->toBeTrue();
+});

--- a/tests/Steps/Loading/Http/Paginators/QueryParams/AbstractQueryParamManipulatorTest.php
+++ b/tests/Steps/Loading/Http/Paginators/QueryParams/AbstractQueryParamManipulatorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace tests\Steps\Loading\Http\Paginators\QueryParams;
+
+use Crwlr\Crawler\Steps\Loading\Http\Paginators\QueryParams\AbstractQueryParamManipulator;
+use Crwlr\QueryString\Query;
+
+it('gets the current value of a query param', function () {
+    $manipulator = new class ('foo') extends AbstractQueryParamManipulator {
+        public string $currentParamValue = '';
+
+        public function execute(Query $query): Query
+        {
+            $this->currentParamValue = $this->getCurrentValue($query);
+
+            return $query;
+        }
+    };
+
+    $manipulator->execute(Query::fromString('foo=bar'));
+
+    expect($manipulator->currentParamValue)->toBe('bar');
+});
+
+it('gets the current value of a query param as integer', function () {
+    $manipulator = new class ('foo') extends AbstractQueryParamManipulator {
+        public int $currentParamValue = 0;
+
+        public function execute(Query $query): Query
+        {
+            $this->currentParamValue = $this->getCurrentValueAsInt($query);
+
+            return $query;
+        }
+    };
+
+    $manipulator->execute(Query::fromString('foo=123'));
+
+    expect($manipulator->currentParamValue)->toBe(123);
+});

--- a/tests/Steps/Loading/Http/Paginators/QueryParams/DecrementorTest.php
+++ b/tests/Steps/Loading/Http/Paginators/QueryParams/DecrementorTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace tests\Steps\Loading\Http\Paginators\QueryParams;
+
+use Crwlr\Crawler\Steps\Loading\Http\Paginators\QueryParams\Decrementor;
+use Crwlr\QueryString\Query;
+
+it('reduces a query param value by a certain number', function () {
+    $decrementor = new Decrementor('foo', 10);
+
+    $query = Query::fromString('foo=20');
+
+    expect($query->get('foo'))->toBe('20');
+
+    $decrementor->execute($query);
+
+    expect($query->get('foo'))->toBe('10');
+
+    $decrementor->execute($query);
+
+    expect($query->get('foo'))->toBe('0');
+
+    $decrementor->execute($query);
+
+    expect($query->get('foo'))->toBe('-10');
+});

--- a/tests/Steps/Loading/Http/Paginators/QueryParams/IncrementorTest.php
+++ b/tests/Steps/Loading/Http/Paginators/QueryParams/IncrementorTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace tests\Steps\Loading\Http\Paginators\QueryParams;
+
+use Crwlr\Crawler\Steps\Loading\Http\Paginators\QueryParams\Incrementor;
+use Crwlr\QueryString\Query;
+
+it('increments a query param value by a certain number', function () {
+    $incrementor = new Incrementor('foo', 10);
+
+    $query = Query::fromString('foo=-10');
+
+    expect($query->get('foo'))->toBe('-10');
+
+    $incrementor->execute($query);
+
+    expect($query->get('foo'))->toBe('0');
+
+    $incrementor->execute($query);
+
+    expect($query->get('foo'))->toBe('10');
+
+    $incrementor->execute($query);
+
+    expect($query->get('foo'))->toBe('20');
+});

--- a/tests/Steps/Loading/Http/Paginators/QueryParamsPaginatorTest.php
+++ b/tests/Steps/Loading/Http/Paginators/QueryParamsPaginatorTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace tests\Steps\Loading\Http\Paginators;
+
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Loading\Http\Paginators\QueryParamsPaginator;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+
+it('increases and decreases values in request url query params', function () {
+    $paginator = QueryParamsPaginator::paramsInUrl()
+        ->increase('page')
+        ->increase('offset', 20)
+        ->decrease('foo', 10)
+        ->decrease('bar', 20);
+
+    $request = new Request('GET', 'https://www.example.com/list?page=1&offset=20&foo=40&bar=10');
+
+    $respondedRequest = new RespondedRequest($request, new Response());
+
+    $paginator->processLoaded($request->getUri(), $request, $respondedRequest);
+
+    $nextRequest = $paginator->getNextRequest();
+
+    expect($nextRequest?->getUri()->__toString())->toBe('https://www.example.com/list?page=2&offset=40&foo=30&bar=-10');
+});
+
+it('increases and decreases values in query params in the body', function () {
+    $paginator = QueryParamsPaginator::paramsInBody()
+        ->increase('page')
+        ->increase('offset', 20)
+        ->decrease('foo', 10)
+        ->decrease('bar', 20);
+
+    $request = new Request('POST', 'https://www.example.com/list', body: 'page=1&offset=20&foo=40&bar=10');
+
+    $respondedRequest = new RespondedRequest($request, new Response());
+
+    $paginator->processLoaded($request->getUri(), $request, $respondedRequest);
+
+    $nextRequest = $paginator->getNextRequest();
+
+    expect($nextRequest?->getMethod())
+        ->toBe('POST')
+        ->and($nextRequest?->getUri()->__toString())
+        ->toBe('https://www.example.com/list')
+        ->and($nextRequest?->getBody()->getContents())
+        ->toBe('page=2&offset=40&foo=30&bar=-10');
+});

--- a/tests/Steps/Loading/Http/Paginators/StopRules/IsEmptyInHtmlTest.php
+++ b/tests/Steps/Loading/Http/Paginators/StopRules/IsEmptyInHtmlTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace tests\Steps\Loading\Http\Paginators\StopRules;
+
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Loading\Http\Paginators\StopRules\PaginatorStopRules;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+
+it('should stop, when called without a RespondedRequest object', function () {
+    $rule = PaginatorStopRules::isEmptyInHtml('#list .item');
+
+    expect($rule->shouldStop(new Request('GET', 'https://www.crwl.io/'), null))->toBeTrue();
+});
+
+it('should stop, when response is not HTML', function () {
+    $rule = PaginatorStopRules::isEmptyInHtml('#list .item');
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwl.io/'),
+        new Response(body: '{ "foo": "bar" }'),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeTrue();
+});
+
+it('should stop, when the selector target does not exist in the HTML response', function () {
+    $rule = PaginatorStopRules::isEmptyInHtml('#list');
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwl.io/'),
+        new Response(body: '<div id="foo"></div>'),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeTrue();
+});
+
+it('should stop, when the selector target is empty in the response', function () {
+    $rule = PaginatorStopRules::isEmptyInHtml('#list');
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwl.io/'),
+        new Response(body: '<div id="list">  </div>'),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeTrue();
+});
+
+it('should not stop, when the selector target is not empty in the response', function () {
+    $rule = PaginatorStopRules::isEmptyInHtml('#list');
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwl.io/'),
+        new Response(body: '<div id="list">a</div>'),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeFalse();
+
+    // Also if the content is only child elements.
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwl.io/'),
+        new Response(body: '<div id="list"><span class="child"></span></div>'),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeFalse();
+});

--- a/tests/Steps/Loading/Http/Paginators/StopRules/IsEmptyInJsonTest.php
+++ b/tests/Steps/Loading/Http/Paginators/StopRules/IsEmptyInJsonTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace tests\Steps\Loading\Http\Paginators\StopRules;
+
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Loading\Http\Paginators\StopRules\PaginatorStopRules;
+use Crwlr\Utils\Exceptions\InvalidJsonException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+
+it('should stop, when called without a RespondedRequest object', function () {
+    $rule = PaginatorStopRules::isEmptyInJson('data.items');
+
+    expect($rule->shouldStop(new Request('GET', 'https://www.crwl.io/'), null))->toBeTrue();
+});
+
+it('throws an exception when response is not valid JSON', function () {
+    $rule = PaginatorStopRules::isEmptyInJson('data.items');
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwl.io/'),
+        new Response(body: '<html></html>'),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeTrue();
+})->throws(InvalidJsonException::class);
+
+it('should stop, when the dot notation key does not exist in the response', function () {
+    $rule = PaginatorStopRules::isEmptyInJson('data.items');
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwl.io/'),
+        new Response(body: '{ "data": { "foo": "bar" } }'),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeTrue();
+});
+
+it('should stop, when the dot notation key is empty in the response', function () {
+    $rule = PaginatorStopRules::isEmptyInJson('data.items');
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwl.io/'),
+        new Response(body: '{ "data": { "items": [] } }'),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeTrue();
+});
+
+it('should not stop, when the dot notation key is not empty in the response', function () {
+    $rule = PaginatorStopRules::isEmptyInJson('data.items');
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwl.io/'),
+        new Response(body: '{ "data": { "items": ["foo", "bar"] } }'),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeFalse();
+});

--- a/tests/Steps/Loading/Http/Paginators/StopRules/IsEmptyInXmlTest.php
+++ b/tests/Steps/Loading/Http/Paginators/StopRules/IsEmptyInXmlTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace tests\Steps\Loading\Http\Paginators\StopRules;
+
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Loading\Http\Paginators\StopRules\PaginatorStopRules;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+
+it('should stop, when called without a RespondedRequest object', function () {
+    $rule = PaginatorStopRules::isEmptyInXml('channel item');
+
+    expect($rule->shouldStop(new Request('GET', 'https://www.crwl.io/'), null))->toBeTrue();
+});
+
+it('should stop, when response is not XML', function () {
+    $rule = PaginatorStopRules::isEmptyInXml('channel item');
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwl.io/'),
+        new Response(body: '{}'),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeTrue();
+});
+
+it('should stop, when the selector target does not exist in the XML response', function () {
+    $rule = PaginatorStopRules::isEmptyInXml('channel item');
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwl.io/'),
+        new Response(body: '<?xml version="1.0" encoding="UTF-8" ?><rss version="2.0"><channel></channel></rss>'),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeTrue();
+});
+
+it('should stop, when the selector target is empty in the response', function () {
+    $rule = PaginatorStopRules::isEmptyInXml('channel item');
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwl.io/'),
+        new Response(
+            body: '<?xml version="1.0" encoding="UTF-8" ?><rss version="2.0"><channel><item>  </item></channel></rss>'
+        ),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeTrue();
+});
+
+it('should not stop, when the selector target is not empty in the response', function () {
+    $rule = PaginatorStopRules::isEmptyInXml('channel item');
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwl.io/'),
+        new Response(
+            body: '<?xml version="1.0" encoding="UTF-8" ?><rss version="2.0"><channel><item>a</item></channel></rss>'
+        ),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeFalse();
+
+    // Also if the content is only child elements.
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwl.io/'),
+        new Response(
+            body: '<?xml version="1.0" encoding="UTF-8" ?><rss version="2.0"><channel><item><foo></foo></item></channel></rss>'
+        ),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeFalse();
+});

--- a/tests/Steps/Loading/Http/Paginators/StopRules/IsEmptyResponseTest.php
+++ b/tests/Steps/Loading/Http/Paginators/StopRules/IsEmptyResponseTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace tests\Steps\Loading\Http\Paginators\StopRules;
+
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Loading\Http\Paginators\StopRules\PaginatorStopRules;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+
+it('should stop, when no RespondedRequest object is provided', function () {
+    $rule = PaginatorStopRules::isEmptyResponse();
+
+    expect($rule->shouldStop(new Request('GET', 'https://www.crwl.io/'), null))->toBeTrue();
+});
+
+it('should stop, when the response body is empty', function () {
+    $rule = PaginatorStopRules::isEmptyResponse();
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwl.io/'),
+        new Response(body: ''),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeTrue();
+});
+
+it('should stop, when the response body is only spaces', function () {
+    $rule = PaginatorStopRules::isEmptyResponse();
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.example.com/'),
+        new Response(body: " \n\r\t "),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeTrue();
+});
+
+it('should stop, when the response body is an empty JSON array', function () {
+    $rule = PaginatorStopRules::isEmptyResponse();
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwlr.software/packages'),
+        new Response(body: " [] "),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeTrue();
+});
+
+it('should stop, when the response body is an empty JSON object', function () {
+    $rule = PaginatorStopRules::isEmptyResponse();
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwl.io/en/home'),
+        new Response(body: "{}"),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeTrue();
+});

--- a/tests/Utils/RequestKeyTest.php
+++ b/tests/Utils/RequestKeyTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace tests\Utils;
+
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Utils\RequestKey;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+
+it('makes a cache key from a Request object', function () {
+    $request = new Request('GET', 'https://www.crwlr.software/packages', ['accept-encoding' => 'gzip, deflate, br']);
+
+    expect(RequestKey::from($request))->toBe('fc2a9e78c97e68674201853cea4a3d74');
+
+    $request = $request->withAddedHeader('accept-language', 'de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7');
+
+    expect(RequestKey::from($request))->not()->toBe('fc2a9e78c97e68674201853cea4a3d74');
+});
+
+it('makes a cache key from a RespondedRequest object', function () {
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwl.io/en/home', ['accept-encoding' => 'gzip, deflate, br']),
+        new Response(),
+    );
+
+    expect(RequestKey::from($respondedRequest))->toBe('08bcc643c9fb21af5e4f3361243e2220');
+});
+
+test('when creating the key it ignores cookies in the sent headers by default', function () {
+    $request = new Request('GET', 'https://www.crwlr.software/packages', ['accept-encoding' => 'gzip, deflate, br']);
+
+    $keyWithoutCookie = RequestKey::from($request);
+
+    $request = new Request('GET', 'https://www.crwlr.software/packages', [
+        'accept-encoding' => 'gzip, deflate, br',
+        'Cookie' => 'cookieName=v4lu3',
+    ]);
+
+    expect(RequestKey::from($request))->toBe($keyWithoutCookie);
+});
+
+it('also ignores other headers when provided in second parameter', function () {
+    $request = new Request('GET', 'https://www.example.com', ['accept-encoding' => 'gzip, deflate, br']);
+
+    $keyWithAcceptEncodingHeader = RequestKey::from($request);
+
+    $keyWithoutAcceptEncodingHeader = RequestKey::from($request, ['accept-encoding']);
+
+    expect($keyWithAcceptEncodingHeader)->not()->toBe($keyWithoutAcceptEncodingHeader);
+
+    $request = new Request('GET', 'https://www.example.com', ['Accept-Encoding' => 'gzip']);
+
+    $anotherKeyWithoutAcceptEncodingHeader = RequestKey::from($request, ['accept-encoding']);
+
+    expect($keyWithoutAcceptEncodingHeader)->toBe($anotherKeyWithoutAcceptEncodingHeader);
+});

--- a/tests/_Integration/Http/QueryParamPaginationTest.php
+++ b/tests/_Integration/Http/QueryParamPaginationTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace tests\_Integration\Http;
+
+use Crwlr\Crawler\HttpCrawler;
+use Crwlr\Crawler\Loader\LoaderInterface;
+use Crwlr\Crawler\Steps\Loading\Http;
+use Crwlr\Crawler\Steps\Loading\Http\Paginator;
+use Crwlr\Crawler\Steps\Loading\Http\Paginators\QueryParamsPaginator;
+use Crwlr\Crawler\Steps\Loading\Http\Paginators\StopRules\PaginatorStopRules;
+use Crwlr\Crawler\UserAgents\UserAgent;
+use Crwlr\Crawler\UserAgents\UserAgentInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+use function tests\helper_generatorToArray;
+use function tests\helper_getFastLoader;
+
+class QueryParamPaginationCrawler extends HttpCrawler
+{
+    protected function userAgent(): UserAgentInterface
+    {
+        return new UserAgent('QueryParamPaginationCrawler');
+    }
+
+    protected function loader(UserAgentInterface $userAgent, LoggerInterface $logger): LoaderInterface
+    {
+        return helper_getFastLoader($userAgent, $logger);
+    }
+}
+
+/** @var TestCase $this */
+
+it('paginates using query params sent in the request body', function () {
+    $crawler = new QueryParamPaginationCrawler();
+
+    $crawler
+        ->input('http://localhost:8000/query-param-pagination')
+        ->addStep(
+            Http::post(body: 'page=1')
+                ->paginate(
+                    Paginator::queryParams(5)
+                        ->inBody()
+                        ->increase('page')
+                        ->stopWhen(PaginatorStopRules::isEmptyInJson('data.items'))
+                )->addToResult(['body'])
+        );
+
+    $results = helper_generatorToArray($crawler->run());
+
+    expect($results)->toHaveCount(4);
+});
+
+it('paginates using URL query params', function () {
+    $crawler = new QueryParamPaginationCrawler();
+
+    $crawler
+        ->input('http://localhost:8000/query-param-pagination?page=1')
+        ->addStep(
+            Http::get()
+                ->paginate(
+                    Paginator::queryParams(5)
+                        ->inUrl()
+                        ->increase('page')
+                        ->stopWhen(PaginatorStopRules::isEmptyInJson('data.items'))
+                )->addToResult(['body'])
+        );
+
+    $results = helper_generatorToArray($crawler->run());
+
+    expect($results)->toHaveCount(4);
+});
+
+it('paginates only until the max pages limit', function () {
+    $crawler = new QueryParamPaginationCrawler();
+
+    $crawler
+        ->input('http://localhost:8000/query-param-pagination?page=1')
+        ->addStep(
+            Http::get()
+                ->paginate(
+                    QueryParamsPaginator::paramsInUrl(2)
+                        ->increase('page')
+                        ->stopWhen(PaginatorStopRules::isEmptyInJson('data.items'))
+                )->addToResult(['body'])
+        );
+
+    $results = helper_generatorToArray($crawler->run());
+
+    expect($results)->toHaveCount(2);
+});

--- a/tests/_Integration/Server.php
+++ b/tests/_Integration/Server.php
@@ -33,6 +33,10 @@ if (str_starts_with($route, '/paginated-listing')) {
     return include(__DIR__ . '/_Server/PaginatedListing.php');
 }
 
+if (str_starts_with($route, '/query-param-pagination')) {
+    return include(__DIR__ . '/_Server/QueryParamPagination.php');
+}
+
 if ($route === '/blog-post-with-json-ld') {
     return include(__DIR__ . '/_Server/BlogPostWithJsonLd.php');
 }

--- a/tests/_Integration/_Server/QueryParamPagination.php
+++ b/tests/_Integration/_Server/QueryParamPagination.php
@@ -1,0 +1,13 @@
+<?php
+
+if (isset($_GET['page'])) {
+    $query = 'page=' . $_GET['page'];
+} else {
+    $query = file_get_contents('php://input');
+}
+
+if (in_array($query, ['page=1', 'page=2', 'page=3'], true)) {
+    echo '{ "data": { "items": ["one", "two", "three"] } }';
+} else {
+    echo '{ "data": { "items": [] } }';
+}

--- a/tests/_Stubs/AbstractTestPaginator.php
+++ b/tests/_Stubs/AbstractTestPaginator.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace tests\_Stubs;
+
+use Crwlr\Crawler\Steps\Loading\Http\AbstractPaginator;
+use Crwlr\Crawler\Steps\Loading\Http\Paginator;
+use Psr\Http\Message\RequestInterface;
+
+class AbstractTestPaginator extends AbstractPaginator
+{
+    public function __construct(
+        int $maxPages = Paginator::MAX_PAGES_DEFAULT,
+        private readonly string $nextUrl = 'https://www.example.com/bar',
+    ) {
+        parent::__construct($maxPages);
+    }
+
+    public function getNextUrl(): ?string
+    {
+        return $this->nextUrl;
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    public function getLoaded(): array
+    {
+        return $this->loaded;
+    }
+
+    public function getLoadedCount(): int
+    {
+        return $this->loadedCount;
+    }
+
+    public function getLatestRequest(): ?RequestInterface
+    {
+        return $this->latestRequest;
+    }
+
+    public function limitReached(): bool
+    {
+        return $this->maxPagesReached();
+    }
+
+    public function setFinished(): AbstractPaginator
+    {
+        return parent::setFinished();
+    }
+}

--- a/tests/_Stubs/DummyLogger.php
+++ b/tests/_Stubs/DummyLogger.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace tests\_Stubs;
+
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Stringable;
+use UnexpectedValueException;
+
+class DummyLogger implements LoggerInterface
+{
+    /**
+     * @var array<int, array<string, string>>
+     */
+    public array $messages = [];
+
+    public function emergency(string|Stringable $message, array $context = []): void
+    {
+        $this->log('emergency', $message, $context);
+    }
+
+    public function alert(string|Stringable $message, array $context = []): void
+    {
+        $this->log('alert', $message, $context);
+    }
+
+    public function critical(string|Stringable $message, array $context = []): void
+    {
+        $this->log('critical', $message, $context);
+    }
+
+    public function error(string|Stringable $message, array $context = []): void
+    {
+        $this->log('error', $message, $context);
+    }
+
+    public function warning(string|Stringable $message, array $context = []): void
+    {
+        $this->log('warning', $message, $context);
+    }
+
+    public function notice(string|Stringable $message, array $context = []): void
+    {
+        $this->log('notice', $message, $context);
+    }
+
+    public function info(string|Stringable $message, array $context = []): void
+    {
+        $this->log('info', $message, $context);
+    }
+
+    public function debug(string|Stringable $message, array $context = []): void
+    {
+        $this->log('debug', $message, $context);
+    }
+
+    public function log($level, string|Stringable $message, array $context = []): void
+    {
+        if (!is_string($level)) {
+            throw new InvalidArgumentException('Level must be string.');
+        }
+
+        if (!in_array($level, ['emergency', 'alert', 'critical', 'error', 'warning', 'notice', 'info', 'debug'], true)) {
+            throw new UnexpectedValueException('Unknown log level.');
+        }
+
+        $this->messages[] = ['level' => $level, 'message' => $message];
+    }
+}


### PR DESCRIPTION
New `QueryParamsPaginator` to paginate by increasing and/or decreasing one or multiple query params, either in the URL or in the body of requests.

New method `stopWhen` in the new
`Crwlr\Crawler\Steps\Loading\Http\AbstractPaginator` class. You can pass implementations of the new `StopRule` interface or custom closures to that method and then, every time the Paginator receives a loaded response to process, those stop rules are called with the response. If any of the conditions of the stop rules is met, the Paginator stops paginating. Of course also add a few stop rules to use with that new method: `IsEmptyInHtml`, `IsEmptyInJson`, `IsEmptyInXml` and `IsEmptyResponse`, also available via static methods: `PaginatorStopRules::isEmptyInHtml()`,
`PaginatorStopRules::isEmptyInJson()`,
`PaginatorStopRules::isEmptyInXml()` and
`PaginatorStopRules::isEmptyResponse()`.

Deprecate the `Crwlr\Crawler\Steps\Loading\Http\PaginatorInterface` and the `Crwlr\Crawler\Steps\Loading\Http\Paginators\AbstractPaginator`. Instead, added a new version of the `AbstractPaginator` as `Crwlr\Crawler\Steps\Loading\Http\AbstractPaginator` that can be used. Did this, because we're adding multiple new class properties and methods that could collide with properties and methods in user implementations. So to avoid a breaking change, moved to a new abstract class and to also not having an interface, because adding methods, when having an interface is always definitely breaking backwards compatibility.