### PR TITLE
Add forgotten getter method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.3] - 2023-12-01
+### Fixed
+* Add forgotten getter method to get the DOM query that is attached to an `InvalidDomQueryException` instance.
+
 ## [1.3.2] - 2023-12-01
 ### Fixed
 * When creating a `CssSelector` or `XPathQuery` instance with invalid selector/query syntax, an `InvalidDomQueryException` is now immediately thrown. This change is considered to be not only non-breaking, but actually a fix, because the `CssSelector` would otherwise throw an exception later when the `apply()` method is called. The `XPathQuery` would silently return no result without notifying you of the invalid query and generate a PHP warning.

--- a/src/Steps/Html/Exceptions/InvalidDomQueryException.php
+++ b/src/Steps/Html/Exceptions/InvalidDomQueryException.php
@@ -38,4 +38,9 @@ class InvalidDomQueryException extends Exception
     {
         $this->query = $domQuery;
     }
+
+    public function getDomQuery(): string
+    {
+        return $this->query;
+    }
 }

--- a/tests/Steps/Html/Exceptions/InvalidDomQueryExceptionTest.php
+++ b/tests/Steps/Html/Exceptions/InvalidDomQueryExceptionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace tests\Steps\Html\Exceptions;
+
+use Crwlr\Crawler\Steps\Html\Exceptions\InvalidDomQueryException;
+use Symfony\Component\CssSelector\Exception\ExpressionErrorException;
+use Symfony\Component\CssSelector\Exception\SyntaxErrorException;
+
+it('can be created from a symfony ExpressionErrorException', function () {
+    $exception = InvalidDomQueryException::fromSymfonyException('.foo:before', new ExpressionErrorException('error'));
+
+    expect($exception->getDomQuery())
+        ->toBe('.foo:before')
+        ->and($exception->getMessage())
+        ->toBe('error');
+});
+
+it('can be created from a symfony SyntaxErrorException', function () {
+    $exception = InvalidDomQueryException::fromSymfonyException('.foo;', new SyntaxErrorException('error message'));
+
+    expect($exception->getDomQuery())
+        ->toBe('.foo;')
+        ->and($exception->getMessage())
+        ->toBe('error message');
+});
+
+it('can be created from a message and a query', function () {
+    $exception = InvalidDomQueryException::make('message', '.foo > .bar;');
+
+    expect($exception->getDomQuery())
+        ->toBe('.foo > .bar;')
+        ->and($exception->getMessage())
+        ->toBe('message');
+});


### PR DESCRIPTION
Add forgotten getter method to get the DOM query that is attached to an `InvalidDomQueryException` instance.