### PR TITLE
Enable manipulating nested query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2024-01-14
+### Added
+* The `QueryParamsPaginator` can now also increase and decrease non first level query param values like `foo[bar][baz]=5` using dot notation: `QueryParamsPaginator::paramsInUrl()->increaseUsingDotNotation('foo.bar.baz', 5)`.
+
 ## [1.3.5] - 2023-12-20
 ### Fixed
 * The `FileCache` can now also read uncompressed cache files when compression is activated.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2023 Christian Olear
+Copyright (c) 2024 Christian Olear
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/src/Steps/Loading/Http/Paginators/QueryParams/AbstractQueryParamManipulator.php
+++ b/src/Steps/Loading/Http/Paginators/QueryParams/AbstractQueryParamManipulator.php
@@ -2,6 +2,7 @@
 
 namespace Crwlr\Crawler\Steps\Loading\Http\Paginators\QueryParams;
 
+use Adbar\Dot;
 use Crwlr\QueryString\Query;
 use Exception;
 
@@ -21,12 +22,26 @@ abstract class AbstractQueryParamManipulator implements QueryParamManipulator
         return $fallbackValue;
     }
 
+    protected function getCurrentValueUsingDotNotation(Query $query, mixed $fallbackValue = null): mixed
+    {
+        $dot = new Dot($query->toArray());
+
+        return $dot->get($this->queryParamName, $fallbackValue);
+    }
+
     /**
      * @throws Exception
      */
     protected function getCurrentValueAsInt(Query $query): int
     {
         $currentValue = $this->getCurrentValue($query);
+
+        return $currentValue === null ? 0 : (int) $currentValue;
+    }
+
+    protected function getCurrentValueAsIntUsingDotNotation(Query $query): int
+    {
+        $currentValue = $this->getCurrentValueUsingDotNotation($query);
 
         return $currentValue === null ? 0 : (int) $currentValue;
     }

--- a/src/Steps/Loading/Http/Paginators/QueryParams/AbstractQueryParamManipulator.php
+++ b/src/Steps/Loading/Http/Paginators/QueryParams/AbstractQueryParamManipulator.php
@@ -22,6 +22,9 @@ abstract class AbstractQueryParamManipulator implements QueryParamManipulator
         return $fallbackValue;
     }
 
+    /**
+     * @throws Exception
+     */
     protected function getCurrentValueUsingDotNotation(Query $query, mixed $fallbackValue = null): mixed
     {
         $dot = new Dot($query->toArray());
@@ -34,15 +37,14 @@ abstract class AbstractQueryParamManipulator implements QueryParamManipulator
      */
     protected function getCurrentValueAsInt(Query $query): int
     {
-        $currentValue = $this->getCurrentValue($query);
-
-        return $currentValue === null ? 0 : (int) $currentValue;
+        return (int) $this->getCurrentValue($query);
     }
 
+    /**
+     * @throws Exception
+     */
     protected function getCurrentValueAsIntUsingDotNotation(Query $query): int
     {
-        $currentValue = $this->getCurrentValueUsingDotNotation($query);
-
-        return $currentValue === null ? 0 : (int) $currentValue;
+        return (int) $this->getCurrentValueUsingDotNotation($query);
     }
 }

--- a/src/Steps/Loading/Http/Paginators/QueryParams/Decrementor.php
+++ b/src/Steps/Loading/Http/Paginators/QueryParams/Decrementor.php
@@ -2,6 +2,7 @@
 
 namespace Crwlr\Crawler\Steps\Loading\Http\Paginators\QueryParams;
 
+use Adbar\Dot;
 use Crwlr\QueryString\Query;
 use Exception;
 
@@ -9,7 +10,8 @@ class Decrementor extends AbstractQueryParamManipulator
 {
     public function __construct(
         string $queryParamName,
-        protected int $decrement = 1
+        protected int $decrement = 1,
+        protected bool $useDotNotation = false,
     ) {
         parent::__construct($queryParamName);
     }
@@ -19,6 +21,15 @@ class Decrementor extends AbstractQueryParamManipulator
      */
     public function execute(Query $query): Query
     {
+        if ($this->useDotNotation) {
+            $dot = (new Dot($query->toArray()))->set(
+                $this->queryParamName,
+                (string) ($this->getCurrentValueAsIntUsingDotNotation($query) - $this->decrement)
+            );
+
+            return new Query($dot->all());
+        }
+
         return $query->set(
             $this->queryParamName,
             (string) ($this->getCurrentValueAsInt($query) - $this->decrement),

--- a/src/Steps/Loading/Http/Paginators/QueryParams/Incrementor.php
+++ b/src/Steps/Loading/Http/Paginators/QueryParams/Incrementor.php
@@ -2,6 +2,7 @@
 
 namespace Crwlr\Crawler\Steps\Loading\Http\Paginators\QueryParams;
 
+use Adbar\Dot;
 use Crwlr\QueryString\Query;
 use Exception;
 
@@ -9,7 +10,8 @@ class Incrementor extends AbstractQueryParamManipulator
 {
     public function __construct(
         string $queryParamName,
-        protected int $increment = 1
+        protected int $increment = 1,
+        protected bool $useDotNotation = false,
     ) {
         parent::__construct($queryParamName);
     }
@@ -19,6 +21,15 @@ class Incrementor extends AbstractQueryParamManipulator
      */
     public function execute(Query $query): Query
     {
+        if ($this->useDotNotation) {
+            $dot = (new Dot($query->toArray()))->set(
+                $this->queryParamName,
+                (string) ($this->getCurrentValueAsIntUsingDotNotation($query) + $this->increment)
+            );
+
+            return new Query($dot->all());
+        }
+
         return $query->set(
             $this->queryParamName,
             (string) ($this->getCurrentValueAsInt($query) + $this->increment),

--- a/src/Steps/Loading/Http/Paginators/QueryParamsPaginator.php
+++ b/src/Steps/Loading/Http/Paginators/QueryParamsPaginator.php
@@ -53,16 +53,30 @@ class QueryParamsPaginator extends Http\AbstractPaginator
         return $this;
     }
 
-    public function increase(string $queryParamName, int $by = 1): self
+    public function increase(string $queryParamName, int $by = 1, bool $useDotNotation = false): self
     {
-        $this->manipulators[] = new Incrementor($queryParamName, $by);
+        $this->manipulators[] = new Incrementor($queryParamName, $by, $useDotNotation);
 
         return $this;
     }
 
-    public function decrease(string $queryParamName, int $by = 1): self
+    public function increaseUsingDotNotation(string $queryParamName, int $by = 1): self
     {
-        $this->manipulators[] = new Decrementor($queryParamName, $by);
+        $this->manipulators[] = new Incrementor($queryParamName, $by, true);
+
+        return $this;
+    }
+
+    public function decrease(string $queryParamName, int $by = 1, bool $useDotNotation = false): self
+    {
+        $this->manipulators[] = new Decrementor($queryParamName, $by, $useDotNotation);
+
+        return $this;
+    }
+
+    public function decreaseUsingDotNotation(string $queryParamName, int $by = 1): self
+    {
+        $this->manipulators[] = new Decrementor($queryParamName, $by, true);
 
         return $this;
     }

--- a/tests/Steps/Loading/Http/Paginators/QueryParams/DecrementorTest.php
+++ b/tests/Steps/Loading/Http/Paginators/QueryParams/DecrementorTest.php
@@ -24,3 +24,11 @@ it('reduces a query param value by a certain number', function () {
 
     expect($query->get('foo'))->toBe('-10');
 });
+
+it('reduces a non first level query param value by a certain number', function () {
+    $decrementor = new Decrementor('foo.bar.baz', 7, true);
+
+    $query = Query::fromString('foo[bar][baz]=10');
+
+    expect($decrementor->execute($query)->toString())->toBe('foo%5Bbar%5D%5Bbaz%5D=3');
+});

--- a/tests/Steps/Loading/Http/Paginators/QueryParams/IncrementorTest.php
+++ b/tests/Steps/Loading/Http/Paginators/QueryParams/IncrementorTest.php
@@ -24,3 +24,11 @@ it('increments a query param value by a certain number', function () {
 
     expect($query->get('foo'))->toBe('20');
 });
+
+it('increments a non first level query param value by a certain number', function () {
+    $incrementor = new Incrementor('foo.bar.baz', 7, true);
+
+    $query = Query::fromString('foo[bar][baz]=3');
+
+    expect($incrementor->execute($query)->toString())->toBe('foo%5Bbar%5D%5Bbaz%5D=10');
+});


### PR DESCRIPTION
The `QueryParamsPaginator` can now also increase and decrease non first level query param values like `foo[bar][baz]=5` using dot notation: `QueryParamsPaginator::paramsInUrl()->increaseUsingDotNotation('foo.bar.baz', 5)`.