### PR TITLE
New DomQuery::formattedText() method

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -4,7 +4,7 @@ use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
 
 $finder = Finder::create()
-    ->exclude(['tests/_Integration/_Server', '.github', 'bin', 'examples', 'git-hooks'])
+    ->exclude(['tests/_Integration/_Server', '.github', 'bin', 'git-hooks'])
     ->in(__DIR__);
 $config = new Config();
 
@@ -13,6 +13,7 @@ return $config->setFinder($finder)
         '@PER' => true,
         'strict_param' => true,
         'single_class_element_per_statement' => false,
+        'array_syntax' => ['syntax' => 'short'],
         'no_unused_imports' => true,
     ])
     ->setRiskyAllowed(true)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.5.0] - 2024-01-26
+## [1.5.0] - 2024-01-29
 ### Added
 * The `DomQuery` class (parent of `CssSelector` (`Dom::cssSelector`) and `XPathQuery` (`Dom::xPath`)) has a new method `formattedText()` that uses the new crwlr/html-2-text package to convert the HTML to formatted plain text. You can also provide a customized instance of the `Html2Text` class to the `formattedText()` method.
+
+### Fixed
+* The `Http::crawl()` step won't yield a page again if a newly found URL responds with a redirect to a previously loaded URL.
 
 ## [1.4.0] - 2024-01-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2024-01-26
+### Added
+* The `DomQuery` class (parent of `CssSelector` (`Dom::cssSelector`) and `XPathQuery` (`Dom::xPath`)) has a new method `formattedText()` that uses the new crwlr/html-2-text package to convert the HTML to formatted plain text. You can also provide a customized instance of the `Html2Text` class to the `formattedText()` method.
+
 ## [1.4.0] - 2024-01-14
 ### Added
 * The `QueryParamsPaginator` can now also increase and decrease non first level query param values like `foo[bar][baz]=5` using dot notation: `QueryParamsPaginator::paramsInUrl()->increaseUsingDotNotation('foo.bar.baz', 5)`.

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "guzzlehttp/guzzle": "^7.4",
         "adbario/php-dot-notation": "^3.1",
         "chrome-php/chrome": "^1.7",
-        "crwlr/utils": "^1.1"
+        "crwlr/utils": "^1.1",
+        "crwlr/html-2-text": "^0.1.0"
     },
     "require-dev": {
         "pestphp/pest": "^2.3",

--- a/src/Cache/CacheItem.php
+++ b/src/Cache/CacheItem.php
@@ -4,6 +4,7 @@ namespace Crwlr\Crawler\Cache;
 
 use DateInterval;
 use DateTimeImmutable;
+use Exception;
 
 class CacheItem
 {
@@ -36,6 +37,9 @@ class CacheItem
         return $this->value;
     }
 
+    /**
+     * @throws Exception
+     */
     public function isExpired(): bool
     {
         $ttl = $this->ttl instanceof DateInterval ? $this->ttl : new DateInterval('PT' . $this->ttl . 'S');

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -7,6 +7,7 @@ use Crwlr\Crawler\Cache\Exceptions\ReadingCacheFailedException;
 use DateInterval;
 use Exception;
 use Psr\SimpleCache\CacheInterface;
+use Psr\SimpleCache\InvalidArgumentException;
 
 class FileCache implements CacheInterface
 {
@@ -33,8 +34,7 @@ class FileCache implements CacheInterface
     }
 
     /**
-     * @throws MissingZlibExtensionException
-     * @throws ReadingCacheFailedException
+     * @throws MissingZlibExtensionException|ReadingCacheFailedException|Exception|InvalidArgumentException
      */
     public function has(string $key): bool
     {
@@ -52,9 +52,7 @@ class FileCache implements CacheInterface
     }
 
     /**
-     * @throws ReadingCacheFailedException
-     * @throws MissingZlibExtensionException
-     * @throws Exception
+     * @throws ReadingCacheFailedException|MissingZlibExtensionException|Exception|InvalidArgumentException
      */
     public function get(string $key, mixed $default = null): mixed
     {
@@ -117,6 +115,9 @@ class FileCache implements CacheInterface
         return unlink($this->basePath . '/' . $key);
     }
 
+    /**
+     * @throws InvalidArgumentException
+     */
     public function clear(): bool
     {
         $allFiles = scandir($this->basePath);
@@ -134,8 +135,7 @@ class FileCache implements CacheInterface
 
     /**
      * @return iterable<mixed>
-     * @throws MissingZlibExtensionException
-     * @throws ReadingCacheFailedException
+     * @throws MissingZlibExtensionException|ReadingCacheFailedException|InvalidArgumentException
      */
     public function getMultiple(iterable $keys, mixed $default = null): iterable
     {

--- a/src/Loader/Http/Cookies/CookieJar.php
+++ b/src/Loader/Http/Cookies/CookieJar.php
@@ -75,6 +75,9 @@ class CookieJar
         return $cookiesToSend;
     }
 
+    /**
+     * @throws Exception
+     */
     protected function getForDomainFromUrl(string|UriInterface|Url $url): ?string
     {
         if (!$url instanceof Url) {

--- a/src/Loader/Http/HttpLoader.php
+++ b/src/Loader/Http/HttpLoader.php
@@ -400,6 +400,7 @@ class HttpLoader extends Loader
 
     /**
      * @throws \Psr\SimpleCache\InvalidArgumentException
+     * @throws Exception
      */
     protected function getFromCache(RequestInterface $request): ?RespondedRequest
     {
@@ -549,6 +550,7 @@ class HttpLoader extends Loader
      * @throws ClientExceptionInterface
      * @throws LoadingException
      * @throws GuzzleException
+     * @throws Exception
      */
     protected function handleRedirects(
         RequestInterface  $request,

--- a/src/Loader/Http/Messages/RespondedRequest.php
+++ b/src/Loader/Http/Messages/RespondedRequest.php
@@ -5,6 +5,7 @@ namespace Crwlr\Crawler\Loader\Http\Messages;
 use Crwlr\Crawler\Steps\Loading\Http;
 use Crwlr\Crawler\Utils\RequestKey;
 use Crwlr\Url\Url;
+use Exception;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\RequestInterface;
@@ -17,6 +18,9 @@ class RespondedRequest
      */
     protected array $redirects = [];
 
+    /**
+     * @throws Exception
+     */
     public function __construct(
         public RequestInterface $request,
         public ResponseInterface $response,
@@ -27,6 +31,7 @@ class RespondedRequest
     /**
      * @param mixed[] $data
      * @return RespondedRequest
+     * @throws Exception
      */
     public static function fromArray(array $data): RespondedRequest
     {
@@ -69,6 +74,7 @@ class RespondedRequest
 
     /**
      * @param mixed[] $data
+     * @throws Exception
      */
     public function __unserialize(array $data): void
     {
@@ -118,6 +124,9 @@ class RespondedRequest
         return $this->redirects;
     }
 
+    /**
+     * @throws Exception
+     */
     public function setResponse(ResponseInterface $response): void
     {
         $this->response = $response;
@@ -127,6 +136,9 @@ class RespondedRequest
         }
     }
 
+    /**
+     * @throws Exception
+     */
     public function addRedirectUri(?string $redirectUri = null): void
     {
         $redirectUri = Url::parse($this->effectiveUri())

--- a/src/Loader/Http/Politeness/RobotsTxtHandler.php
+++ b/src/Loader/Http/Politeness/RobotsTxtHandler.php
@@ -7,6 +7,7 @@ use Crwlr\Crawler\Loader\Loader;
 use Crwlr\Crawler\Steps\Loading\Http;
 use Crwlr\Crawler\UserAgents\BotUserAgent;
 use Crwlr\Crawler\UserAgents\UserAgentInterface;
+use Crwlr\RobotsTxt\Exceptions\InvalidRobotsTxtFileException;
 use Crwlr\RobotsTxt\RobotsTxt;
 use Crwlr\Url\Url;
 use Exception;
@@ -62,12 +63,16 @@ class RobotsTxtHandler
 
     /**
      * @return string[]
+     * @throws InvalidRobotsTxtFileException
      */
     public function getSitemaps(string|UriInterface|Url $url): array
     {
         return $this->getRobotsTxtFor($url)->sitemaps();
     }
 
+    /**
+     * @throws InvalidRobotsTxtFileException|Exception
+     */
     protected function getRobotsTxtFor(string|UriInterface|Url $url): RobotsTxt
     {
         $url = $this->getUrlInstance($url);

--- a/src/Loader/Http/Politeness/Throttler.php
+++ b/src/Loader/Http/Politeness/Throttler.php
@@ -5,6 +5,7 @@ namespace Crwlr\Crawler\Loader\Http\Politeness;
 use Crwlr\Crawler\Loader\Http\Politeness\TimingUnits\MultipleOf;
 use Crwlr\Url\Url;
 use Crwlr\Utils\Microseconds;
+use Exception;
 use InvalidArgumentException;
 use Psr\Http\Message\UriInterface;
 
@@ -75,6 +76,9 @@ class Throttler
         return $this;
     }
 
+    /**
+     * @throws Exception
+     */
     public function trackRequestStartFor(UriInterface $url): void
     {
         $domain = $this->getDomain($url);
@@ -82,6 +86,9 @@ class Throttler
         $this->latestRequestTimes[$domain] = $this->time();
     }
 
+    /**
+     * @throws Exception
+     */
     public function trackRequestEndFor(UriInterface $url): void
     {
         $domain = $this->getDomain($url);
@@ -97,6 +104,9 @@ class Throttler
         unset($this->latestRequestTimes[$domain]);
     }
 
+    /**
+     * @throws Exception
+     */
     public function waitForGo(UriInterface $url): void
     {
         $domain = $this->getDomain($url);
@@ -123,6 +133,9 @@ class Throttler
         return Microseconds::fromSeconds(microtime(true));
     }
 
+    /**
+     * @throws Exception
+     */
     protected function getDomain(UriInterface $url): string
     {
         $domain = Url::parse($url)->domain();

--- a/src/Steps/Dom.php
+++ b/src/Steps/Dom.php
@@ -5,6 +5,7 @@ namespace Crwlr\Crawler\Steps;
 use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
 use Crwlr\Crawler\Steps\Html\CssSelector;
 use Crwlr\Crawler\Steps\Html\DomQueryInterface;
+use Crwlr\Crawler\Steps\Html\Exceptions\InvalidDomQueryException;
 use Crwlr\Crawler\Steps\Html\XPathQuery;
 use Exception;
 use Generator;
@@ -75,11 +76,17 @@ abstract class Dom extends Step
         return $instance;
     }
 
+    /**
+     * @throws InvalidDomQueryException
+     */
     public static function cssSelector(string $selector): CssSelector
     {
         return new CssSelector($selector);
     }
 
+    /**
+     * @throws InvalidDomQueryException
+     */
     public static function xPath(string $query): XPathQuery
     {
         return new XPathQuery($query);

--- a/src/Steps/Group.php
+++ b/src/Steps/Group.php
@@ -130,6 +130,9 @@ final class Group extends BaseStep
         return $this;
     }
 
+    /**
+     * @throws UnknownLoaderKeyException
+     */
     public function addLoader(LoaderInterface $loader): self
     {
         $this->loader = $loader;

--- a/src/Steps/Html.php
+++ b/src/Steps/Html.php
@@ -4,6 +4,7 @@ namespace Crwlr\Crawler\Steps;
 
 use Crwlr\Crawler\Steps\Html\CssSelector;
 use Crwlr\Crawler\Steps\Html\DomQueryInterface;
+use Crwlr\Crawler\Steps\Html\Exceptions\InvalidDomQueryException;
 use Crwlr\Crawler\Steps\Html\GetLink;
 use Crwlr\Crawler\Steps\Html\GetLinks;
 use Crwlr\Crawler\Steps\Html\MetaData;
@@ -11,11 +12,17 @@ use Crwlr\Crawler\Steps\Html\SchemaOrg;
 
 class Html extends Dom
 {
+    /**
+     * @throws InvalidDomQueryException
+     */
     public static function getLink(?string $selector = null): GetLink
     {
         return new GetLink($selector);
     }
 
+    /**
+     * @throws InvalidDomQueryException
+     */
     public static function getLinks(?string $selector = null): GetLinks
     {
         return new GetLinks($selector);
@@ -31,6 +38,9 @@ class Html extends Dom
         return new SchemaOrg();
     }
 
+    /**
+     * @throws InvalidDomQueryException
+     */
     protected function makeDefaultDomQueryInstance(string $query): DomQueryInterface
     {
         return new CssSelector($query);

--- a/src/Steps/Html/GetLink.php
+++ b/src/Steps/Html/GetLink.php
@@ -3,6 +3,7 @@
 namespace Crwlr\Crawler\Steps\Html;
 
 use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Html\Exceptions\InvalidDomQueryException;
 use Crwlr\Crawler\Steps\Loading\Http;
 use Crwlr\Crawler\Steps\Step;
 use Crwlr\Url\Url;
@@ -34,6 +35,9 @@ class GetLink extends Step
 
     protected null|string|CssSelector $selector = null;
 
+    /**
+     * @throws InvalidDomQueryException
+     */
     public function __construct(null|string|CssSelector $selector = null)
     {
         $this->selector = is_string($selector) ? new CssSelector($selector) : $selector;
@@ -153,6 +157,9 @@ class GetLink extends Step
         return $this;
     }
 
+    /**
+     * @throws Exception
+     */
     protected function getBaseFromDocument(Crawler $document): void
     {
         $baseHref = DomQuery::getBaseHrefFromDocument($document);

--- a/src/Steps/Html/SelectorTarget.php
+++ b/src/Steps/Html/SelectorTarget.php
@@ -5,6 +5,7 @@ namespace Crwlr\Crawler\Steps\Html;
 enum SelectorTarget
 {
     case Text;
+    case FormattedText;
     case Html;
     case InnerText;
     case Attribute;

--- a/src/Steps/Loading/GetSitemapsFromRobotsTxt.php
+++ b/src/Steps/Loading/GetSitemapsFromRobotsTxt.php
@@ -3,6 +3,7 @@
 namespace Crwlr\Crawler\Steps\Loading;
 
 use Crwlr\Crawler\Loader\Http\Politeness\RobotsTxtHandler;
+use Crwlr\RobotsTxt\Exceptions\InvalidRobotsTxtFileException;
 use Exception;
 use Generator;
 use InvalidArgumentException;
@@ -10,6 +11,9 @@ use Psr\Http\Message\UriInterface;
 
 class GetSitemapsFromRobotsTxt extends LoadingStep
 {
+    /**
+     * @throws InvalidRobotsTxtFileException
+     */
     protected function invoke(mixed $input): Generator
     {
         if (!method_exists($this->loader, 'robotsTxt')) {

--- a/src/Steps/Loading/Http.php
+++ b/src/Steps/Loading/Http.php
@@ -4,6 +4,7 @@ namespace Crwlr\Crawler\Steps\Loading;
 
 use Crwlr\Crawler\Loader\Http\Exceptions\LoadingException;
 use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Html\Exceptions\InvalidDomQueryException;
 use Crwlr\Crawler\Steps\Loading\Http\AbstractPaginator;
 use Crwlr\Crawler\Steps\Loading\Http\Paginate;
 use Crwlr\Crawler\Steps\Loading\Http\Paginator;
@@ -138,6 +139,9 @@ class Http extends LoadingStep
         return $contents;
     }
 
+    /**
+     * @throws InvalidDomQueryException
+     */
     public function paginate(
         PaginatorInterface|AbstractPaginator|string $paginator,
         int $defaultPaginatorMaxPages = Paginator::MAX_PAGES_DEFAULT

--- a/src/Steps/Loading/Http/Paginator.php
+++ b/src/Steps/Loading/Http/Paginator.php
@@ -3,6 +3,7 @@
 namespace Crwlr\Crawler\Steps\Loading\Http;
 
 use Crwlr\Crawler\Steps\Html\DomQueryInterface;
+use Crwlr\Crawler\Steps\Html\Exceptions\InvalidDomQueryException;
 use Crwlr\Crawler\Steps\Loading\Http\Paginators\QueryParamsPaginator;
 use Crwlr\Crawler\Steps\Loading\Http\Paginators\SimpleWebsitePaginator;
 
@@ -10,6 +11,9 @@ class Paginator
 {
     public const MAX_PAGES_DEFAULT = 1000;
 
+    /**
+     * @throws InvalidDomQueryException
+     */
     public static function simpleWebsite(
         string|DomQueryInterface $paginationLinksSelector,
         int $maxPages = self::MAX_PAGES_DEFAULT,

--- a/src/Steps/Loading/Http/Paginators/SimpleWebsitePaginator.php
+++ b/src/Steps/Loading/Http/Paginators/SimpleWebsitePaginator.php
@@ -6,6 +6,7 @@ use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
 use Crwlr\Crawler\Steps\Dom;
 use Crwlr\Crawler\Steps\Html\DomQuery;
 use Crwlr\Crawler\Steps\Html\DomQueryInterface;
+use Crwlr\Crawler\Steps\Html\Exceptions\InvalidDomQueryException;
 use Crwlr\Crawler\Steps\Loading\Http;
 use Crwlr\Crawler\Utils\RequestKey;
 use Crwlr\Url\Url;
@@ -36,6 +37,9 @@ class SimpleWebsitePaginator extends Http\AbstractPaginator
      */
     protected array $parentRequests = [];
 
+    /**
+     * @throws InvalidDomQueryException
+     */
     public function __construct(string|DomQueryInterface $paginationLinksSelector, int $maxPages = 1000)
     {
         if (is_string($paginationLinksSelector)) {

--- a/src/Steps/Loading/Http/Paginators/StopRules/IsEmptyInDom.php
+++ b/src/Steps/Loading/Http/Paginators/StopRules/IsEmptyInDom.php
@@ -5,6 +5,7 @@ namespace Crwlr\Crawler\Steps\Loading\Http\Paginators\StopRules;
 use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
 use Crwlr\Crawler\Steps\Html\CssSelector;
 use Crwlr\Crawler\Steps\Html\DomQueryInterface;
+use Crwlr\Crawler\Steps\Html\Exceptions\InvalidDomQueryException;
 use Crwlr\Crawler\Steps\Loading\Http;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Component\DomCrawler\Crawler;
@@ -13,6 +14,9 @@ abstract class IsEmptyInDom implements StopRule
 {
     public function __construct(protected string|DomQueryInterface $selector) {}
 
+    /**
+     * @throws InvalidDomQueryException
+     */
     public function shouldStop(RequestInterface $request, ?RespondedRequest $respondedRequest): bool
     {
         if (!$respondedRequest) {

--- a/src/Steps/Loading/HttpCrawl.php
+++ b/src/Steps/Loading/HttpCrawl.php
@@ -359,6 +359,9 @@ class HttpCrawl extends Http
         return !$this->useCanonicalLinks || !array_key_exists($document->canonicalUrl(), $this->loadedUrls);
     }
 
+    /**
+     * @throws Exception
+     */
     protected function setResponseCanonicalUrl(RespondedRequest $respondedRequest, Document $document): void
     {
         if ($this->useCanonicalLinks && $respondedRequest->effectiveUri() !== $document->canonicalUrl()) {

--- a/src/Steps/Xml.php
+++ b/src/Steps/Xml.php
@@ -3,10 +3,14 @@
 namespace Crwlr\Crawler\Steps;
 
 use Crwlr\Crawler\Steps\Html\DomQueryInterface;
+use Crwlr\Crawler\Steps\Html\Exceptions\InvalidDomQueryException;
 use Crwlr\Crawler\Steps\Html\XPathQuery;
 
 class Xml extends Dom
 {
+    /**
+     * @throws InvalidDomQueryException
+     */
     public function makeDefaultDomQueryInstance(string $query): DomQueryInterface
     {
         return new XPathQuery($query);

--- a/tests/Steps/Html/CssSelectorTest.php
+++ b/tests/Steps/Html/CssSelectorTest.php
@@ -4,6 +4,7 @@ namespace tests\Steps\Html;
 
 use Crwlr\Crawler\Steps\Html\CssSelector;
 use Crwlr\Crawler\Steps\Html\Exceptions\InvalidDomQueryException;
+use Crwlr\Html2Text\Html2Text;
 use Symfony\Component\DomCrawler\Crawler;
 
 use function tests\helper_getSimpleListHtml;
@@ -93,6 +94,42 @@ it('does not contain text of children when innerText is called', function () {
     $domCrawler = new Crawler($html);
 
     expect((new CssSelector('.item'))->innerText()->apply($domCrawler))->toBe('test');
+});
+
+it('returns formatted text when formattedText() is called', function () {
+    $html = '<article id="a"><h1>headline</h1><p>paragraph</p><ul><li>item 1</li><li>item 2</li></ul></article>';
+
+    $domCrawler = new Crawler($html);
+
+    expect((new CssSelector('#a'))->formattedText()->apply($domCrawler))
+        ->toBe(<<<TEXT
+        # headline
+
+        paragraph
+
+        * item 1
+        * item 2
+        TEXT);
+});
+
+test('you can provide your own converter instance to get formattedText()', function () {
+    $html = '<article id="a"><h1>headline</h1><p>paragraph</p><ul><li>item 1</li><li>item 2</li></ul></article>';
+
+    $domCrawler = new Crawler($html);
+
+    $converter = new Html2Text();
+
+    $converter->removeConverter('ul');
+
+    expect((new CssSelector('#a'))->formattedText($converter)->apply($domCrawler))
+        ->toBe(<<<TEXT
+        # headline
+
+        paragraph
+
+        item 1
+        item 2
+        TEXT);
 });
 
 it('gets the contents of an attribute using the attribute method', function () {

--- a/tests/_Integration/Http/CrawlingTest.php
+++ b/tests/_Integration/Http/CrawlingTest.php
@@ -420,20 +420,21 @@ it('uses canonical links when useCanonicalLinks() is called', function () {
         return $result->get('url');
     }, $results);
 
-    expect($resultUrls)->toBe([
-        'http://www.example.com/crawling/main',
-        'http://www.example.com/crawling/sub1/sub1',        // actual loaded url was sub1, but canonical is sub1/sub1
-        'http://www.example.com/crawling/sub2',
-        'http://www.example.com/crawling/sub2/sub1/sub1',
-    ]);
-
-    expect($crawler->getLoader()->loadedUrls)->toBe([
-        'http://www.example.com/crawling/main',
-        'http://www.example.com/crawling/sub1',             // => /crawling/sub1/sub1 => this URL wasn't loaded yet,
-        'http://www.example.com/crawling/sub2',             // so when the link is discovered it won't load it.
-        'http://www.example.com/crawling/sub2/sub1',        // => /crawling/sub1/sub1 => this URL was already loaded,
-        'http://www.example.com/crawling/sub2/sub1/sub1',   // so the response is not yielded as a separate result.
-    ]);
+    expect($resultUrls)
+        ->toBe([
+            'http://www.example.com/crawling/main',
+            'http://www.example.com/crawling/sub1/sub1',       // actual loaded url was sub1, but canonical is sub1/sub1
+            'http://www.example.com/crawling/sub2',
+            'http://www.example.com/crawling/sub2/sub1/sub1',
+        ])
+        ->and($crawler->getLoader()->loadedUrls)
+        ->toBe([
+            'http://www.example.com/crawling/main',
+            'http://www.example.com/crawling/sub1',            // => /crawling/sub1/sub1 => this URL wasn't loaded yet,
+            'http://www.example.com/crawling/sub2',            // so when the link is discovered it won't load it.
+            'http://www.example.com/crawling/sub2/sub1',       // => /crawling/sub1/sub1 => this URL was already loaded,
+            'http://www.example.com/crawling/sub2/sub1/sub1',  // so the response is not yielded as a separate result.
+        ]);
 });
 
 it('does not yield the same page twice when a URL was redirected to an already loaded page', function () {

--- a/tests/_Integration/Http/CrawlingTest.php
+++ b/tests/_Integration/Http/CrawlingTest.php
@@ -451,15 +451,7 @@ it('does not yield the same page twice when a URL was redirected to an already l
         ->toContain('http://www.example.com/crawling/main')
         ->and($resultUrls)
         ->not()
-        ->toContain('http://www.example.com/crawling/redirect');
-
-    $output = $this->getActualOutputForAssertion();
-
-    if (!str_contains($output, 'Was already loaded before. Do not process this page again.')) {
-        error_log(var_export('---debug----', true));
-        error_log(var_export($output, true));
-        error_log(var_export('---debug----', true));
-    }
-
-    expect($output)->toContain('Was already loaded before. Do not process this page again.');
+        ->toContain('http://www.example.com/crawling/redirect')
+        ->and($this->getActualOutputForAssertion())
+        ->toContain('Was already loaded before. Do not process this page again.');
 });

--- a/tests/_Integration/Server.php
+++ b/tests/_Integration/Server.php
@@ -61,7 +61,7 @@ if ($route === '/print-cookie') {
     return include(__DIR__ . '/_Server/PrintCookie.php');
 }
 
-if (str_starts_with($route, '/crawling/')) {
+if (str_starts_with($route, '/crawling')) {
     return include(__DIR__ . '/_Server/Crawling.php');
 }
 

--- a/tests/_Integration/_Server/Crawling.php
+++ b/tests/_Integration/_Server/Crawling.php
@@ -48,7 +48,7 @@ if ($route === '/crawling' || $route === '/crawling/redirect') {
 if ($route === '/crawling/main' || $route === '/crawling/main?redirect=1') {
     $showRedirectLinkHtml = '';
 
-    if (!empty($_GET['redirect'])) {
+    if (!empty($_GET['redirect'] ?? null)) {
         $showRedirectLinkHtml = PHP_EOL . '<a href="/crawling">link</a>';
     }
 
@@ -56,6 +56,8 @@ if ($route === '/crawling/main' || $route === '/crawling/main?redirect=1') {
         <!doctype html>
         <html lang="en">
         <body>
+            {$showRedirectLinkHtml}
+
             <a href="/crawling/sub1">Subpage 1</a> <br>
             <a href="/crawling/sub2">Subpage 2</a> <br>
             <a href="/crawling/sub2#fragment1">Subpage 2 - Fragment 1</a> <br>
@@ -68,7 +70,6 @@ if ($route === '/crawling/main' || $route === '/crawling/main?redirect=1') {
             <a href="tel:+499123456789">phone link</a>
 
             <a href="//">broken link</a>
-            ${$showRedirectLinkHtml}
         </body>
         </html>
         HTML;

--- a/tests/_Integration/_Server/Crawling.php
+++ b/tests/_Integration/_Server/Crawling.php
@@ -39,7 +39,19 @@ if ($route === '/crawling/sitemap2.xml') {
 XML;
 }
 
-if ($route === '/crawling/main') {
+if ($route === '/crawling' || $route === '/crawling/redirect') {
+    header('Location: http://www.example.com/crawling/main?redirect=1', true, 301);
+
+    return '';
+}
+
+if ($route === '/crawling/main' || $route === '/crawling/main?redirect=1') {
+    $showRedirectLinkHtml = '';
+
+    if (!empty($_GET['redirect'])) {
+        $showRedirectLinkHtml = PHP_EOL . '<a href="/crawling">link</a>';
+    }
+
     echo <<<HTML
         <!doctype html>
         <html lang="en">
@@ -56,6 +68,7 @@ if ($route === '/crawling/main') {
             <a href="tel:+499123456789">phone link</a>
 
             <a href="//">broken link</a>
+            ${$showRedirectLinkHtml}
         </body>
         </html>
         HTML;


### PR DESCRIPTION
The `DomQuery` class (parent of `CssSelector` (`Dom::cssSelector`) and `XPathQuery` (`Dom::xPath`)) has a new method `formattedText()` that uses the new crwlr/html-2-text package to convert the HTML to formatted plain text. You can also provide a customized instance of the `Html2Text` class to the `formattedText()` method.

Also added a lot of missing throws doblock tags in the whole codebase and adapted PHP CS Fixer config a little.