### PR TITLE
HttpLoader Separation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2024-02-05
+### Fixed
+* For being more flexible to build a separate headless browser loader (in an extension package) extract the most basic HTTP loader functionality to a new `HttpBaseLoader` and important functionality for the headless browser loader to a new `HeadlessBrowserLoaderHelper`. It's considered a fix, because there's no new functionality, just refactoring existing code for better extendability.
+
 ## [1.5.0] - 2024-01-29
 ### Added
 * The `DomQuery` class (parent of `CssSelector` (`Dom::cssSelector`) and `XPathQuery` (`Dom::xPath`)) has a new method `formattedText()` that uses the new crwlr/html-2-text package to convert the HTML to formatted plain text. You can also provide a customized instance of the `Html2Text` class to the `formattedText()` method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.5.1] - 2024-02-05
+## [1.5.1] - 2024-02-06
 ### Fixed
-* For being more flexible to build a separate headless browser loader (in an extension package) extract the most basic HTTP loader functionality to a new `HttpBaseLoader` and important functionality for the headless browser loader to a new `HeadlessBrowserLoaderHelper`. It's considered a fix, because there's no new functionality, just refactoring existing code for better extendability.
+* For being more flexible to build a separate headless browser loader (in an extension package) extract the most basic HTTP loader functionality to a new `HttpBaseLoader` and important functionality for the headless browser loader to a new `HeadlessBrowserLoaderHelper`. Further, also share functionality from the `Http` steps via a new abstract `HttpBase` step. It's considered a fix, because there's no new functionality, just refactoring existing code for better extendability.
 
 ## [1.5.0] - 2024-01-29
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -68,8 +68,8 @@
         }
     },
     "scripts": {
-        "test": "pest --exclude-group integration",
-        "test-integration": "pest --group integration",
+        "test": "pest --exclude-group integration --display-warnings",
+        "test-integration": "pest --group integration --display-warnings",
         "stan": "@php -d memory_limit=4G vendor/bin/phpstan analyse",
         "cs": "php-cs-fixer fix -v --dry-run",
         "cs-fix": "php-cs-fixer fix -v",

--- a/src/Loader/Http/HeadlessBrowserLoaderHelper.php
+++ b/src/Loader/Http/HeadlessBrowserLoaderHelper.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Crwlr\Crawler\Loader\Http;
+
+use Exception;
+use HeadlessChromium\Browser;
+use HeadlessChromium\BrowserFactory;
+use Psr\Http\Message\RequestInterface;
+
+class HeadlessBrowserLoaderHelper
+{
+    protected ?string $executable = null;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $options = [
+        'windowSize' => [1920, 1000],
+    ];
+
+    protected bool $optionsDirty = false;
+
+    protected ?Browser $browser = null;
+
+    protected ?string $proxy = null;
+
+    /**
+     * @throws Exception
+     */
+    public function getBrowser(
+        RequestInterface $request,
+        ?string $proxy = null,
+    ): Browser {
+        if (!$this->browser || $this->shouldRenewBrowser($proxy)) {
+            $this->closeBrowser();
+
+            $options = $this->optionsFromRequest($request, $proxy);
+
+            $this->browser = (new BrowserFactory($this->executable))->createBrowser($options);
+
+            $this->optionsDirty = false;
+        }
+
+        return $this->browser;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function closeBrowser(): void
+    {
+        if ($this->browser) {
+            $this->browser->close();
+
+            $this->browser = null;
+        }
+    }
+
+    public function setExecutable(string $executable): static
+    {
+        $this->executable = $executable;
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function setOptions(array $options): static
+    {
+        $this->options = $options;
+
+        $this->optionsDirty = true;
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function addOptions(array $options): static
+    {
+        foreach ($options as $key => $value) {
+            $this->options[$key] = $value;
+        }
+
+        $this->optionsDirty = true;
+
+        return $this;
+    }
+
+    /**
+     * @param string[] $headers
+     * @return string[]
+     */
+    public function sanitizeResponseHeaders(array $headers): array
+    {
+        foreach ($headers as $key => $value) {
+            $headers[$key] = explode(PHP_EOL, $value)[0];
+        }
+
+        return $headers;
+    }
+
+    protected function shouldRenewBrowser(?string $proxy): bool
+    {
+        return $this->optionsDirty || ($proxy !== $this->proxy);
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @return array<string, mixed>
+     */
+    protected function optionsFromRequest(RequestInterface $request, ?string $proxy = null): array
+    {
+        $options = $this->options;
+
+        if (isset($request->getHeader('User-Agent')[0])) {
+            $options['userAgent'] = $request->getHeader('User-Agent')[0];
+        }
+
+        $options['headers'] = array_merge(
+            $options['headers'] ?? [],
+            $this->prepareRequestHeaders($request->getHeaders()),
+        );
+
+        if (!empty($proxy)) {
+            $this->proxy = $options['proxyServer'] = $proxy;
+        } else {
+            $this->proxy = null;
+        }
+
+        return $options;
+    }
+
+    /**
+     * @param mixed[] $headers
+     * @return array<string, string>
+     */
+    protected function prepareRequestHeaders(array $headers = []): array
+    {
+        $headers = $this->removeHeadersCausingErrorWithHeadlessBrowser($headers);
+
+        return array_map(function ($headerValue) {
+            return is_array($headerValue) ? reset($headerValue) : $headerValue;
+        }, $headers);
+    }
+
+    /**
+     * @param mixed[] $headers
+     * @return mixed[]
+     */
+    protected function removeHeadersCausingErrorWithHeadlessBrowser(array $headers = []): array
+    {
+        $removeHeaders = ['host'];
+
+        foreach ($headers as $headerName => $headerValue) {
+            if (in_array(strtolower($headerName), $removeHeaders, true)) {
+                unset($headers[$headerName]);
+            }
+        }
+
+        return $headers;
+    }
+}

--- a/src/Loader/Http/HttpBaseLoader.php
+++ b/src/Loader/Http/HttpBaseLoader.php
@@ -1,0 +1,304 @@
+<?php
+
+namespace Crwlr\Crawler\Loader\Http;
+
+use Crwlr\Crawler\Loader\Http\Cookies\CookieJar;
+use Crwlr\Crawler\Loader\Http\Exceptions\LoadingException;
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Loader\Http\Politeness\RetryErrorResponseHandler;
+use Crwlr\Crawler\Loader\Http\Politeness\RobotsTxtHandler;
+use Crwlr\Crawler\Loader\Http\Politeness\Throttler;
+use Crwlr\Crawler\Loader\Loader;
+use Crwlr\Crawler\Steps\Filters\FilterInterface;
+use Crwlr\Crawler\UserAgents\UserAgentInterface;
+use Crwlr\Crawler\Utils\RequestKey;
+use Crwlr\Url\Exceptions\InvalidUrlException;
+use Crwlr\Url\Url;
+use Error;
+use Exception;
+use GuzzleHttp\Psr7\Request;
+use InvalidArgumentException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
+use Psr\Log\LoggerInterface;
+
+abstract class HttpBaseLoader extends Loader
+{
+    protected CookieJar $cookieJar;
+
+    protected bool $useCookies = true;
+
+    protected RobotsTxtHandler $robotsTxtHandler;
+
+    protected Throttler $throttler;
+
+    protected int $maxRedirects = 10;
+
+    protected bool $retryCachedErrorResponses = false;
+
+    protected bool $writeOnlyCache = false;
+
+    /**
+     * @var array<int, FilterInterface>
+     */
+    protected array $cacheUrlFilters = [];
+
+    protected ?ProxyManager $proxies = null;
+
+    public function __construct(
+        UserAgentInterface $userAgent,
+        ?LoggerInterface $logger = null,
+        ?Throttler $throttler = null,
+        protected RetryErrorResponseHandler $retryErrorResponseHandler = new RetryErrorResponseHandler(),
+    ) {
+        parent::__construct($userAgent, $logger);
+
+        $this->retryErrorResponseHandler->setLogger($this->logger);
+
+        $this->onSuccess(function (RequestInterface $request, ResponseInterface $response, LoggerInterface $logger) {
+            $logger->info('Loaded ' . $request->getUri()->__toString());
+        });
+
+        $this->onError(function (RequestInterface $request, Exception|Error|ResponseInterface $exceptionOrResponse, $logger) {
+            $logMessage = 'Failed to load ' . $request->getUri()->__toString() . ': ';
+
+            if ($exceptionOrResponse instanceof ResponseInterface) {
+                $logMessage .= 'got response ' . $exceptionOrResponse->getStatusCode() . ' - ' .
+                    $exceptionOrResponse->getReasonPhrase();
+            } else {
+                $logMessage .= $exceptionOrResponse->getMessage();
+            }
+
+            $logger->error($logMessage);
+        });
+
+        $this->cookieJar = new CookieJar();
+
+        $this->robotsTxtHandler = new RobotsTxtHandler($this, $this->logger);
+
+        $this->throttler = $throttler ?? new Throttler();
+    }
+
+    public function dontUseCookies(): static
+    {
+        $this->useCookies = false;
+
+        return $this;
+    }
+
+    public function flushCookies(): void
+    {
+        $this->cookieJar->flush();
+    }
+
+    public function setMaxRedirects(int $maxRedirects): static
+    {
+        $this->maxRedirects = $maxRedirects;
+
+        return $this;
+    }
+
+    public function robotsTxt(): RobotsTxtHandler
+    {
+        return $this->robotsTxtHandler;
+    }
+
+    public function throttle(): Throttler
+    {
+        return $this->throttler;
+    }
+
+    public function retryCachedErrorResponses(): static
+    {
+        $this->retryCachedErrorResponses = true;
+
+        return $this;
+    }
+
+    public function writeOnlyCache(): static
+    {
+        $this->writeOnlyCache = true;
+
+        return $this;
+    }
+
+    public function cacheOnlyWhereUrl(FilterInterface $filter): static
+    {
+        $this->cacheUrlFilters[] = $filter;
+
+        return $this;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function useProxy(string $proxyUrl): void
+    {
+        $this->checkIfProxiesCanBeUsed();
+
+        $this->proxies = new ProxyManager([$proxyUrl]);
+    }
+
+    /**
+     * @param string[] $proxyUrls
+     * @throws Exception
+     */
+    public function useRotatingProxies(array $proxyUrls): void
+    {
+        $this->checkIfProxiesCanBeUsed();
+
+        $this->proxies = new ProxyManager($proxyUrls);
+    }
+
+    /**
+     * Optionally implement in child class and throw an Exception when proxies can't be used.
+     *
+     * @throws Exception
+     */
+    protected function checkIfProxiesCanBeUsed(): void
+    {
+        return;
+    }
+
+    /**
+     * @throws LoadingException
+     * @throws Exception
+     */
+    protected function isAllowedToBeLoaded(UriInterface $uri, bool $throwsException = false): bool
+    {
+        if (!$this->robotsTxtHandler->isAllowed($uri)) {
+            $message = 'Crawler is not allowed to load ' . $uri . ' according to robots.txt file.';
+
+            $this->logger->warning($message);
+
+            if ($throwsException) {
+                throw new LoadingException($message);
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     * @throws Exception
+     */
+    protected function getFromCache(RequestInterface $request): ?RespondedRequest
+    {
+        if (!$this->cache || $this->writeOnlyCache) {
+            return null;
+        }
+
+        $key = RequestKey::from($request);
+
+        if ($this->cache->has($key)) {
+            $this->logger->info('Found ' . $request->getUri()->__toString() . ' in cache.');
+
+            $respondedRequest = $this->cache->get($key);
+
+            // Previously, until v0.7 just used serialized arrays. Leave this for backwards compatibility.
+            if (is_array($respondedRequest)) {
+                $respondedRequest = RespondedRequest::fromArray($respondedRequest);
+            }
+
+            if ($this->retryCachedErrorResponses && $respondedRequest->response->getStatusCode() >= 400) {
+                $this->logger->info('Cached response was an error response, retry.');
+
+                return null;
+            }
+
+            return $respondedRequest;
+        }
+
+        return null;
+    }
+
+    /**
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     */
+    protected function addToCache(RespondedRequest $respondedRequest): void
+    {
+        if ($this->cache && $this->shouldResponseBeCached($respondedRequest)) {
+            $this->cache->set($respondedRequest->cacheKey(), $respondedRequest);
+        }
+    }
+
+    protected function shouldResponseBeCached(RespondedRequest $respondedRequest): bool
+    {
+        if (!empty($this->cacheUrlFilters)) {
+            foreach ($this->cacheUrlFilters as $filter) {
+                foreach ($respondedRequest->allUris() as $url) {
+                    if (!$filter->evaluate($url)) {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    protected function validateSubjectType(RequestInterface|string $requestOrUri): RequestInterface
+    {
+        if (is_string($requestOrUri)) {
+            try {
+                return new Request('GET', Url::parsePsr7($requestOrUri));
+            } catch (InvalidUrlException) {
+                throw new InvalidArgumentException('Invalid URL.');
+            }
+        }
+
+        return $requestOrUri;
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function prepareRequest(RequestInterface $request): RequestInterface
+    {
+        $request = $request->withHeader('User-Agent', $this->userAgent->__toString());
+
+        // When writing tests I found that guzzle somehow messed up headers with multiple strings as value in the PSR-7
+        // request object. It sent only the last part of the array, instead of concatenating the array of strings to a
+        // comma separated string. Don't know if that happens with all handlers (curl, stream), will investigate
+        // further. But until this is fixed, we just prepare the headers ourselves.
+        foreach ($request->getHeaders() as $headerName => $headerValues) {
+            $request = $request->withHeader($headerName, $request->getHeaderLine($headerName));
+        }
+
+        return $this->addCookiesToRequest($request);
+    }
+
+    protected function addCookiesToJar(RespondedRequest $respondedRequest): void
+    {
+        if ($this->useCookies) {
+            try {
+                $this->cookieJar->addFrom($respondedRequest->effectiveUri(), $respondedRequest->response);
+            } catch (Exception $exception) {
+                $this->logger->warning('Problem when adding cookies to the Jar: ' . $exception->getMessage());
+            }
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function addCookiesToRequest(RequestInterface $request): RequestInterface
+    {
+        if (!$this->useCookies) {
+            return $request;
+        }
+
+        foreach ($this->cookieJar->getFor($request->getUri()) as $cookie) {
+            $request = $request->withAddedHeader('Cookie', $cookie->__toString());
+        }
+
+        return $request;
+    }
+}

--- a/src/Loader/Http/HttpLoader.php
+++ b/src/Loader/Http/HttpLoader.php
@@ -2,26 +2,18 @@
 
 namespace Crwlr\Crawler\Loader\Http;
 
-use Crwlr\Crawler\Loader\Http\Cookies\CookieJar;
 use Crwlr\Crawler\Loader\Http\Exceptions\LoadingException;
 use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
 use Crwlr\Crawler\Loader\Http\Politeness\RetryErrorResponseHandler;
-use Crwlr\Crawler\Loader\Http\Politeness\RobotsTxtHandler;
 use Crwlr\Crawler\Loader\Http\Politeness\Throttler;
-use Crwlr\Crawler\Loader\Loader;
 use Crwlr\Crawler\Steps\Filters\FilterInterface;
 use Crwlr\Crawler\UserAgents\UserAgentInterface;
-use Crwlr\Crawler\Utils\RequestKey;
-use Crwlr\Url\Exceptions\InvalidUrlException;
 use Crwlr\Url\Url;
-use Error;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use HeadlessChromium\Browser;
-use HeadlessChromium\BrowserFactory;
 use HeadlessChromium\Exception\CommunicationException;
 use HeadlessChromium\Exception\NavigationExpired;
 use HeadlessChromium\Exception\NoResponseAvailable;
@@ -31,36 +23,16 @@ use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\UriInterface;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
-class HttpLoader extends Loader
+class HttpLoader extends HttpBaseLoader
 {
     protected ClientInterface $httpClient;
 
-    protected CookieJar $cookieJar;
-
-    protected bool $useCookies = true;
+    protected ?HeadlessBrowserLoaderHelper $browserHelper = null;
 
     protected bool $useHeadlessBrowser = false;
-
-    protected ?string $chromeExecutable = null;
-
-    /**
-     * @var mixed[]
-     */
-    protected array $headlessBrowserOptions = [
-        'windowSize' => [1920, 1000],
-    ];
-
-    protected bool $headlessBrowserOptionsDirty = false;
-
-    protected ?Browser $headlessBrowser = null;
-
-    protected RobotsTxtHandler $robotsTxtHandler;
-
-    protected Throttler $throttler;
 
     /**
      * @var mixed[]
@@ -69,12 +41,6 @@ class HttpLoader extends Loader
         'connect_timeout' => 10,
         'timeout' => 60,
     ];
-
-    protected int $maxRedirects = 10;
-
-    protected bool $retryCachedErrorResponses = false;
-
-    protected bool $writeOnlyCache = false;
 
     /**
      * @var array<int, FilterInterface>
@@ -91,37 +57,14 @@ class HttpLoader extends Loader
         ?ClientInterface $httpClient = null,
         ?LoggerInterface $logger = null,
         ?Throttler $throttler = null,
-        protected RetryErrorResponseHandler $retryErrorResponseHandler = new RetryErrorResponseHandler(),
+        RetryErrorResponseHandler $retryErrorResponseHandler = new RetryErrorResponseHandler(),
         array $defaultGuzzleClientConfig = [],
     ) {
-        parent::__construct($userAgent, $logger);
-
-        $this->retryErrorResponseHandler->setLogger($this->logger);
+        parent::__construct($userAgent, $logger, $throttler, $retryErrorResponseHandler);
 
         $this->httpClient = $httpClient ?? new Client($this->mergeClientConfigWithDefaults($defaultGuzzleClientConfig));
 
-        $this->onSuccess(function (RequestInterface $request, ResponseInterface $response, LoggerInterface $logger) {
-            $logger->info('Loaded ' . $request->getUri()->__toString());
-        });
 
-        $this->onError(function (RequestInterface $request, Exception|Error|ResponseInterface $exceptionOrResponse, $logger) {
-            $logMessage = 'Failed to load ' . $request->getUri()->__toString() . ': ';
-
-            if ($exceptionOrResponse instanceof ResponseInterface) {
-                $logMessage .= 'got response ' . $exceptionOrResponse->getStatusCode() . ' - ' .
-                    $exceptionOrResponse->getReasonPhrase();
-            } else {
-                $logMessage .= $exceptionOrResponse->getMessage();
-            }
-
-            $logger->error($logMessage);
-        });
-
-        $this->cookieJar = new CookieJar();
-
-        $this->robotsTxtHandler = new RobotsTxtHandler($this, $this->logger);
-
-        $this->throttler = $throttler ?? new Throttler();
     }
 
     /**
@@ -223,21 +166,18 @@ class HttpLoader extends Loader
         }
     }
 
-    public function dontUseCookies(): static
+    public function useHeadlessBrowser(): static
     {
-        $this->useCookies = false;
+        $this->useHeadlessBrowser = true;
 
         return $this;
     }
 
-    public function flushCookies(): void
+    public function useHttpClient(): static
     {
-        $this->cookieJar->flush();
-    }
+        $this->useHeadlessBrowser = false;
 
-    public function useHeadlessBrowser(): static
-    {
-        $this->useHeadlessBrowser = true;
+        $this->browserHelper()->closeBrowser();
 
         return $this;
     }
@@ -247,105 +187,31 @@ class HttpLoader extends Loader
         return $this->useHeadlessBrowser;
     }
 
-    public function useHttpClient(): static
-    {
-        $this->useHeadlessBrowser = false;
-
-        $this->headlessBrowser = null;
-
-        return $this;
-    }
-
     /**
-     * @param mixed[] $options
+     * @param array<string, mixed> $options
      */
     public function setHeadlessBrowserOptions(array $options): static
     {
-        $this->headlessBrowserOptions = $options;
-
-        $this->headlessBrowserOptionsDirty = true;
+        $this->browserHelper()->setOptions($options);
 
         return $this;
     }
 
     /**
-     * @param mixed[] $options
+     * @param array<string, mixed> $options
      */
     public function addHeadlessBrowserOptions(array $options): static
     {
-        foreach ($options as $key => $value) {
-            $this->headlessBrowserOptions[$key] = $value;
-        }
-
-        $this->headlessBrowserOptionsDirty = true;
+        $this->browserHelper()->addOptions($options);
 
         return $this;
     }
 
     public function setChromeExecutable(string $executable): static
     {
-        $this->chromeExecutable = $executable;
+        $this->browserHelper()->setExecutable($executable);
 
         return $this;
-    }
-
-    public function setMaxRedirects(int $maxRedirects): static
-    {
-        $this->maxRedirects = $maxRedirects;
-
-        return $this;
-    }
-
-    public function robotsTxt(): RobotsTxtHandler
-    {
-        return $this->robotsTxtHandler;
-    }
-
-    public function throttle(): Throttler
-    {
-        return $this->throttler;
-    }
-
-    public function retryCachedErrorResponses(): static
-    {
-        $this->retryCachedErrorResponses = true;
-
-        return $this;
-    }
-
-    public function writeOnlyCache(): static
-    {
-        $this->writeOnlyCache = true;
-
-        return $this;
-    }
-
-    public function cacheOnlyWhereUrl(FilterInterface $filter): static
-    {
-        $this->cacheUrlFilters[] = $filter;
-
-        return $this;
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function useProxy(string $proxyUrl): void
-    {
-        $this->checkIfProxiesCanBeUsed();
-
-        $this->proxies = new ProxyManager([$proxyUrl]);
-    }
-
-    /**
-     * @param string[] $proxyUrls
-     * @throws Exception
-     */
-    public function useRotatingProxies(array $proxyUrls): void
-    {
-        $this->checkIfProxiesCanBeUsed();
-
-        $this->proxies = new ProxyManager($proxyUrls);
     }
 
     /**
@@ -375,120 +241,6 @@ class HttpLoader extends Loader
         }
 
         return $merged;
-    }
-
-    /**
-     * @throws LoadingException
-     * @throws Exception
-     */
-    protected function isAllowedToBeLoaded(UriInterface $uri, bool $throwsException = false): bool
-    {
-        if (!$this->robotsTxtHandler->isAllowed($uri)) {
-            $message = 'Crawler is not allowed to load ' . $uri . ' according to robots.txt file.';
-
-            $this->logger->warning($message);
-
-            if ($throwsException) {
-                throw new LoadingException($message);
-            }
-
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * @throws \Psr\SimpleCache\InvalidArgumentException
-     * @throws Exception
-     */
-    protected function getFromCache(RequestInterface $request): ?RespondedRequest
-    {
-        if (!$this->cache || $this->writeOnlyCache) {
-            return null;
-        }
-
-        $key = RequestKey::from($request);
-
-        if ($this->cache->has($key)) {
-            $this->logger->info('Found ' . $request->getUri()->__toString() . ' in cache.');
-
-            $respondedRequest = $this->cache->get($key);
-
-            // Previously, until v0.7 just used serialized arrays. Leave this for backwards compatibility.
-            if (is_array($respondedRequest)) {
-                $respondedRequest = RespondedRequest::fromArray($respondedRequest);
-            }
-
-            if ($this->retryCachedErrorResponses && $respondedRequest->response->getStatusCode() >= 400) {
-                $this->logger->info('Cached response was an error response, retry.');
-
-                return null;
-            }
-
-            return $respondedRequest;
-        }
-
-        return null;
-    }
-
-    /**
-     * @throws \Psr\SimpleCache\InvalidArgumentException
-     */
-    protected function addToCache(RespondedRequest $respondedRequest): void
-    {
-        if ($this->cache && $this->shouldResponseBeCached($respondedRequest)) {
-            $this->cache->set($respondedRequest->cacheKey(), $respondedRequest);
-        }
-    }
-
-    protected function shouldResponseBeCached(RespondedRequest $respondedRequest): bool
-    {
-        if (!empty($this->cacheUrlFilters)) {
-            foreach ($this->cacheUrlFilters as $filter) {
-                foreach ($respondedRequest->allUris() as $url) {
-                    if (!$filter->evaluate($url)) {
-                        return false;
-                    }
-                }
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * @throws InvalidArgumentException
-     */
-    protected function validateSubjectType(RequestInterface|string $requestOrUri): RequestInterface
-    {
-        if (is_string($requestOrUri)) {
-            try {
-                return new Request('GET', Url::parsePsr7($requestOrUri));
-            } catch (InvalidUrlException) {
-                throw new InvalidArgumentException('Invalid URL.');
-            }
-        }
-
-        return $requestOrUri;
-    }
-
-    /**
-     * @throws Exception
-     */
-    protected function prepareRequest(RequestInterface $request): RequestInterface
-    {
-        $request = $request->withHeader('User-Agent', $this->userAgent->__toString());
-
-        // When writing tests I found that guzzle somehow messed up headers with multiple strings as value in the PSR-7
-        // request object. It sent only the last part of the array, instead of concatenating the array of strings to a
-        // comma separated string. Don't know if that happens with all handlers (curl, stream), will investigate
-        // further. But until this is fixed, we just prepare the headers ourselves.
-        foreach ($request->getHeaders() as $headerName => $headerValues) {
-            $request = $request->withHeader($headerName, $request->getHeaderLine($headerName));
-        }
-
-        return $this->addCookiesToRequest($request);
     }
 
     /**
@@ -636,7 +388,7 @@ class HttpLoader extends Loader
             function ($params) use (&$statusCode, &$responseHeaders) {
                 $statusCode = $params['response']['status'];
 
-                $responseHeaders = $this->sanitizeResponseHeaders($params['response']['headers']);
+                $responseHeaders = $this->browserHelper()->sanitizeResponseHeaders($params['response']['headers']);
             }
         );
 
@@ -656,107 +408,24 @@ class HttpLoader extends Loader
         );
     }
 
+    protected function browserHelper(): HeadlessBrowserLoaderHelper
+    {
+        if (!$this->browserHelper) {
+            $this->browserHelper = new HeadlessBrowserLoaderHelper();
+        }
+
+        return $this->browserHelper;
+    }
+
     /**
      * @throws Exception
      */
     protected function getBrowser(RequestInterface $request): Browser
     {
-        if (!$this->headlessBrowser || $this->shouldRenewHeadlessBrowserInstance()) {
-            $this->headlessBrowser?->close();
-
-            $options = $this->headlessBrowserOptions;
-
-            $options['userAgent'] = $this->userAgent->__toString();
-
-            $options['headers'] = array_merge(
-                $options['headers'] ?? [],
-                $this->prepareRequestHeadersForHeadlessBrowser($request->getHeaders()),
-            );
-
-            if (!empty($this->proxies)) {
-                $options['proxyServer'] = $this->proxies->getProxy();
-            }
-
-            $this->headlessBrowser = (new BrowserFactory($this->chromeExecutable))->createBrowser($options);
-
-            $this->headlessBrowserOptionsDirty = false;
+        if (!empty($this->proxies)) {
+            return $this->browserHelper()->getBrowser($request, $this->proxies->getProxy());
         }
 
-        return $this->headlessBrowser;
-    }
-
-    protected function shouldRenewHeadlessBrowserInstance(): bool
-    {
-        return $this->headlessBrowserOptionsDirty || ($this->proxies && $this->proxies->hasMultipleProxies());
-    }
-
-    protected function addCookiesToJar(RespondedRequest $respondedRequest): void
-    {
-        if ($this->useCookies) {
-            try {
-                $this->cookieJar->addFrom($respondedRequest->effectiveUri(), $respondedRequest->response);
-            } catch (Exception $exception) {
-                $this->logger->warning('Problem when adding cookies to the Jar: ' . $exception->getMessage());
-            }
-        }
-    }
-
-    /**
-     * @throws Exception
-     */
-    protected function addCookiesToRequest(RequestInterface $request): RequestInterface
-    {
-        if (!$this->useCookies) {
-            return $request;
-        }
-
-        foreach ($this->cookieJar->getFor($request->getUri()) as $cookie) {
-            $request = $request->withAddedHeader('Cookie', $cookie->__toString());
-        }
-
-        return $request;
-    }
-
-    /**
-     * @param string[] $headers
-     * @return string[]
-     */
-    protected function sanitizeResponseHeaders(array $headers): array
-    {
-        foreach ($headers as $key => $value) {
-            $headers[$key] = explode(PHP_EOL, $value)[0];
-        }
-
-        return $headers;
-    }
-
-    /**
-     * @param mixed[] $headers
-     * @return array<string, string>
-     */
-    protected function prepareRequestHeadersForHeadlessBrowser(array $headers = []): array
-    {
-        $headers = $this->removeHeadersCausingErrorWithHeadlessBrowser($headers);
-
-        return array_map(function ($headerValue) {
-            return is_array($headerValue) ? reset($headerValue) : $headerValue;
-        }, $headers);
-    }
-
-    /**
-     * @param mixed[] $headers
-     * @return mixed[]
-     */
-    protected function removeHeadersCausingErrorWithHeadlessBrowser(array $headers = []): array
-    {
-        $removeHeaders = ['host'];
-
-        foreach ($headers as $headerName => $headerValue) {
-            if (in_array(strtolower($headerName), $removeHeaders, true)) {
-                unset($headers[$headerName]);
-            }
-        }
-
-        return $headers;
+        return $this->browserHelper()->getBrowser($request);
     }
 }

--- a/src/Loader/Http/HttpLoader.php
+++ b/src/Loader/Http/HttpLoader.php
@@ -76,6 +76,9 @@ class HttpLoader extends HttpBaseLoader
         });
     }
 
+    /**
+     * @throws LoadingException
+     */
     public function loadOrFail(mixed $subject): RespondedRequest
     {
         return $this->handleLoadOrFail($subject, function (RequestInterface $request) {

--- a/src/Steps/Loading/Http.php
+++ b/src/Steps/Loading/Http.php
@@ -2,60 +2,20 @@
 
 namespace Crwlr\Crawler\Steps\Loading;
 
-use Crwlr\Crawler\Loader\Http\Exceptions\LoadingException;
 use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
 use Crwlr\Crawler\Steps\Html\Exceptions\InvalidDomQueryException;
 use Crwlr\Crawler\Steps\Loading\Http\AbstractPaginator;
 use Crwlr\Crawler\Steps\Loading\Http\Paginate;
 use Crwlr\Crawler\Steps\Loading\Http\Paginator;
 use Crwlr\Crawler\Steps\Loading\Http\PaginatorInterface;
-use Crwlr\Crawler\Utils\HttpHeaders;
 use Exception;
 use Generator;
-use GuzzleHttp\Psr7\Request;
-use InvalidArgumentException;
 use Psr\Http\Message\MessageInterface;
-use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
-class Http extends LoadingStep
+class Http extends HttpBase
 {
-    protected bool $stopOnErrorResponse = false;
-
-    protected bool $yieldErrorResponses = false;
-
-    protected ?string $useAsUrl = null;
-
-    protected ?string $useAsBody = null;
-
-    protected ?string $inputBody = null;
-
-    protected ?string $useAsHeaders = null;
-
-    /**
-     * @var null|array<string, string>
-     */
-    protected ?array $useAsHeader = null;
-
-    /**
-     * @var null|array<string, string|string[]>
-     */
-    protected ?array $inputHeaders = null;
-
-    /**
-     * @param string $method
-     * @param array<string, string|string[]> $headers
-     * @param string|StreamInterface|null $body
-     * @param string $httpVersion
-     */
-    public function __construct(
-        protected readonly string $method = 'GET',
-        protected readonly array $headers = [],
-        protected readonly string|StreamInterface|null $body = null,
-        protected readonly string $httpVersion = '1.1',
-    ) {}
-
     /**
      * @param array|(string|string[])[] $headers
      */
@@ -153,101 +113,6 @@ class Http extends LoadingStep
         return new Paginate($paginator, $this->method, $this->headers, $this->body, $this->httpVersion);
     }
 
-    public function stopOnErrorResponse(): static
-    {
-        $this->stopOnErrorResponse = true;
-
-        return $this;
-    }
-
-    public function yieldErrorResponses(): static
-    {
-        $this->yieldErrorResponses = true;
-
-        return $this;
-    }
-
-    /**
-     * Chose key from array input to use its value as request URL
-     *
-     * If input is an array with string keys, you can define which key from that array should be used as the URL for
-     * the HTTP request.
-     */
-    public function useInputKeyAsUrl(string $key): static
-    {
-        $this->useAsUrl = $key;
-
-        return $this;
-    }
-
-    /**
-     * Chose key from array input to use its value as request body
-     *
-     * If input is an array with string keys, you can define which key from that array should be used as the body for
-     * the HTTP request.
-     */
-    public function useInputKeyAsBody(string $key): static
-    {
-        $this->useAsBody = $key;
-
-        return $this;
-    }
-
-    /**
-     * Chose key from array input to use its value as a request header
-     *
-     * If input is an array with string keys, you can choose a key from that array and map it to an HTTP request header.
-     */
-    public function useInputKeyAsHeader(string $key, string $asHeader = null): static
-    {
-        $asHeader = $asHeader ?? $key;
-
-        if ($this->useAsHeader === null) {
-            $this->useAsHeader = [];
-        }
-
-        $this->useAsHeader[$key] = $asHeader;
-
-        return $this;
-    }
-
-    /**
-     * Chose key from array input to use its value as request headers
-     *
-     * If input is an array with string keys, you can choose a key from that array that will be used as headers for the
-     * HTTP request. So, the value behind that array key, has to be an array with header names as keys. If you want to
-     * map just one single HTTP header from input, use the `useInputKeyAsHeader()` method.
-     */
-    public function useInputKeyAsHeaders(string $key): static
-    {
-        $this->useAsHeaders = $key;
-
-        return $this;
-    }
-
-    /**
-     * @return UriInterface|UriInterface[]
-     * @throws InvalidArgumentException
-     */
-    protected function validateAndSanitizeInput(mixed $input): mixed
-    {
-        $this->getBodyFromArrayInput($input);
-
-        $this->getHeadersFromArrayInput($input);
-
-        $input = $this->getUrlFromArrayInput($input);
-
-        if (is_array($input)) {
-            foreach ($input as $key => $url) {
-                $input[$key] = $this->validateAndSanitizeToUriInterface($url);
-            }
-
-            return $input;
-        }
-
-        return $this->validateAndSanitizeToUriInterface($input);
-    }
-
     /**
      * @param UriInterface|UriInterface[] $input
      * @return Generator<RespondedRequest>
@@ -266,166 +131,5 @@ class Http extends LoadingStep
         }
 
         $this->resetInputRequestParams();
-    }
-
-    protected function outputKeyAliases(): array
-    {
-        return [
-            'url' => 'effectiveUri',
-            'uri' => 'effectiveUri',
-            'status' => 'responseStatusCode',
-            'headers' => 'responseHeaders',
-            'body' => 'responseBody',
-        ];
-    }
-
-    /**
-     * @throws LoadingException
-     */
-    protected function getResponseFromInputUri(UriInterface $input): ?RespondedRequest
-    {
-        $request = $this->getRequestFromInputUri($input);
-
-        return $this->getResponseFromRequest($request);
-    }
-
-    protected function getRequestFromInputUri(UriInterface $uri): RequestInterface
-    {
-        $body = $this->inputBody ?? $this->body;
-
-        $headers = $this->mergeHeaders();
-
-        return new Request($this->method, $uri, $headers, $body, $this->httpVersion);
-    }
-
-    /**
-     * @throws LoadingException
-     */
-    protected function getResponseFromRequest(RequestInterface $request): ?RespondedRequest
-    {
-        if ($this->stopOnErrorResponse) {
-            $response = $this->loader->loadOrFail($request);
-        } else {
-            $response = $this->loader->load($request);
-        }
-
-        if ($response !== null && ($response->response->getStatusCode() < 400 || $this->yieldErrorResponses)) {
-            return $response;
-        }
-
-        return null;
-    }
-
-    /**
-     * @return mixed
-     */
-    protected function getUrlFromArrayInput(mixed $input): mixed
-    {
-        if ($this->useAsUrl) {
-            if (!is_array($input)) {
-                $this->logger?->warning('Input is not array, therefore can\'t get URL from input by key.');
-            } elseif (array_key_exists($this->useAsUrl, $input)) {
-                return [$input[$this->useAsUrl]];
-            } else {
-                $this->logger?->warning(
-                    'Input key ' . $this->useAsUrl . ' that should be used as request URL isn\'t present in input.'
-                );
-            }
-        } elseif (is_array($input) && array_key_exists('url', $input)) {
-            return $input['url'];
-        } elseif (is_array($input) && array_key_exists('uri', $input)) {
-            return $input['uri'];
-        }
-
-        return $input;
-    }
-
-    protected function getBodyFromArrayInput(mixed $input): void
-    {
-        if ($this->useAsBody) {
-            if (!is_array($input)) {
-                $this->logger?->warning('Input is not array, therefore can\'t get body from input by key.');
-            } elseif (array_key_exists($this->useAsBody, $input)) {
-                $this->inputBody = $input[$this->useAsBody];
-            } else {
-                $this->logger?->warning(
-                    'Input key ' . $this->useAsBody . ' that should be used as request body isn\'t present in input.'
-                );
-            }
-        }
-    }
-
-    protected function getHeadersFromArrayInput(mixed $input): void
-    {
-        if ($this->useAsHeaders) {
-            if (!is_array($input)) {
-                $this->logger?->warning('Input is not array, therefore can\'t get headers from input by key.');
-            } elseif (array_key_exists($this->useAsHeaders, $input)) {
-                $this->inputHeaders = $input[$this->useAsHeaders];
-            } else {
-                $this->logger?->warning(
-                    'Input key ' . $this->useAsHeaders . ' that should be used as request headers isn\'t present in ' .
-                    'input.'
-                );
-            }
-        }
-
-        if (is_array($this->useAsHeader)) {
-            if (!is_array($input)) {
-                $this->logger?->warning('Input is not array, therefore can\'t get header from input by key.');
-            } else {
-                foreach ($this->useAsHeader as $inputKey => $headerName) {
-                    $this->addToInputHeadersFromInput($input, $inputKey, $headerName);
-                }
-            }
-        }
-    }
-
-    protected function addToInputHeadersFromInput(mixed $input, string $inputKey, string $headerName): void
-    {
-        if (!is_array($this->inputHeaders)) {
-            $this->inputHeaders = [];
-        }
-
-        if (!array_key_exists($inputKey, $input)) {
-            $this->logger?->warning(
-                'Input key ' . $inputKey . ' that should be used as a request header, isn\'t present in input.'
-            );
-
-            return;
-        }
-
-        $inputValue = $input[$inputKey];
-
-        if (!array_key_exists($headerName, $this->inputHeaders)) {
-            $this->inputHeaders[$headerName] = is_array($inputValue) ? $inputValue : [$inputValue];
-
-            return;
-        }
-
-        $this->inputHeaders = HttpHeaders::addTo(HttpHeaders::normalize($this->inputHeaders), $headerName, $inputValue);
-    }
-
-    /**
-     * @return array<string, string[]>
-     */
-    protected function mergeHeaders(): array
-    {
-        $headers = HttpHeaders::normalize($this->headers);
-
-        if (is_array($this->inputHeaders)) {
-            $inputHeaders = HttpHeaders::normalize($this->inputHeaders);
-
-            $headers = HttpHeaders::merge($headers, $inputHeaders);
-        }
-
-        return $headers;
-    }
-
-    protected function resetInputRequestParams(): void
-    {
-        $this->inputHeaders = null;
-
-        $this->inputBody = null;
     }
 }

--- a/src/Steps/Loading/HttpBase.php
+++ b/src/Steps/Loading/HttpBase.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading;
+
+use Crwlr\Crawler\Loader\Http\Exceptions\LoadingException;
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Utils\HttpHeaders;
+use GuzzleHttp\Psr7\Request;
+use InvalidArgumentException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+
+abstract class HttpBase extends LoadingStep
+{
+    protected bool $stopOnErrorResponse = false;
+
+    protected bool $yieldErrorResponses = false;
+
+    protected ?string $useAsUrl = null;
+
+    protected ?string $useAsBody = null;
+
+    protected ?string $inputBody = null;
+
+    protected ?string $useAsHeaders = null;
+
+    /**
+     * @var null|array<string, string>
+     */
+    protected ?array $useAsHeader = null;
+
+    /**
+     * @var null|array<string, string|string[]>
+     */
+    protected ?array $inputHeaders = null;
+
+    /**
+     * @param string $method
+     * @param array<string, string|string[]> $headers
+     * @param string|StreamInterface|null $body
+     * @param string $httpVersion
+     */
+    public function __construct(
+        protected readonly string $method = 'GET',
+        protected readonly array $headers = [],
+        protected readonly string|StreamInterface|null $body = null,
+        protected readonly string $httpVersion = '1.1',
+    ) {}
+
+    public function stopOnErrorResponse(): static
+    {
+        $this->stopOnErrorResponse = true;
+
+        return $this;
+    }
+
+    public function yieldErrorResponses(): static
+    {
+        $this->yieldErrorResponses = true;
+
+        return $this;
+    }
+
+    /**
+     * Chose key from array input to use its value as request URL
+     *
+     * If input is an array with string keys, you can define which key from that array should be used as the URL for
+     * the HTTP request.
+     */
+    public function useInputKeyAsUrl(string $key): static
+    {
+        $this->useAsUrl = $key;
+
+        return $this;
+    }
+
+    /**
+     * Chose key from array input to use its value as request body
+     *
+     * If input is an array with string keys, you can define which key from that array should be used as the body for
+     * the HTTP request.
+     */
+    public function useInputKeyAsBody(string $key): static
+    {
+        $this->useAsBody = $key;
+
+        return $this;
+    }
+
+    /**
+     * Chose key from array input to use its value as a request header
+     *
+     * If input is an array with string keys, you can choose a key from that array and map it to an HTTP request header.
+     */
+    public function useInputKeyAsHeader(string $key, string $asHeader = null): static
+    {
+        $asHeader = $asHeader ?? $key;
+
+        if ($this->useAsHeader === null) {
+            $this->useAsHeader = [];
+        }
+
+        $this->useAsHeader[$key] = $asHeader;
+
+        return $this;
+    }
+
+    /**
+     * Chose key from array input to use its value as request headers
+     *
+     * If input is an array with string keys, you can choose a key from that array that will be used as headers for the
+     * HTTP request. So, the value behind that array key, has to be an array with header names as keys. If you want to
+     * map just one single HTTP header from input, use the `useInputKeyAsHeader()` method.
+     */
+    public function useInputKeyAsHeaders(string $key): static
+    {
+        $this->useAsHeaders = $key;
+
+        return $this;
+    }
+
+    /**
+     * @return UriInterface|UriInterface[]
+     * @throws InvalidArgumentException
+     */
+    protected function validateAndSanitizeInput(mixed $input): mixed
+    {
+        $this->getBodyFromArrayInput($input);
+
+        $this->getHeadersFromArrayInput($input);
+
+        $input = $this->getUrlFromArrayInput($input);
+
+        if (is_array($input)) {
+            foreach ($input as $key => $url) {
+                $input[$key] = $this->validateAndSanitizeToUriInterface($url);
+            }
+
+            return $input;
+        }
+
+        return $this->validateAndSanitizeToUriInterface($input);
+    }
+
+    protected function outputKeyAliases(): array
+    {
+        return [
+            'url' => 'effectiveUri',
+            'uri' => 'effectiveUri',
+            'status' => 'responseStatusCode',
+            'headers' => 'responseHeaders',
+            'body' => 'responseBody',
+        ];
+    }
+
+    /**
+     * @throws LoadingException
+     */
+    protected function getResponseFromInputUri(UriInterface $input): ?RespondedRequest
+    {
+        $request = $this->getRequestFromInputUri($input);
+
+        return $this->getResponseFromRequest($request);
+    }
+
+    protected function getRequestFromInputUri(UriInterface $uri): RequestInterface
+    {
+        $body = $this->inputBody ?? (property_exists($this, 'body') ? $this->body : '');
+
+        $headers = $this->mergeHeaders();
+
+        return new Request($this->method, $uri, $headers, $body, $this->httpVersion);
+    }
+
+    /**
+     * @throws LoadingException
+     */
+    protected function getResponseFromRequest(RequestInterface $request): ?RespondedRequest
+    {
+        if ($this->stopOnErrorResponse) {
+            $response = $this->loader->loadOrFail($request);
+        } else {
+            $response = $this->loader->load($request);
+        }
+
+        if ($response !== null && ($response->response->getStatusCode() < 400 || $this->yieldErrorResponses)) {
+            return $response;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return mixed
+     */
+    protected function getUrlFromArrayInput(mixed $input): mixed
+    {
+        if ($this->useAsUrl) {
+            if (!is_array($input)) {
+                $this->logger?->warning('Input is not array, therefore can\'t get URL from input by key.');
+            } elseif (array_key_exists($this->useAsUrl, $input)) {
+                return [$input[$this->useAsUrl]];
+            } else {
+                $this->logger?->warning(
+                    'Input key ' . $this->useAsUrl . ' that should be used as request URL isn\'t present in input.'
+                );
+            }
+        } elseif (is_array($input) && array_key_exists('url', $input)) {
+            return $input['url'];
+        } elseif (is_array($input) && array_key_exists('uri', $input)) {
+            return $input['uri'];
+        }
+
+        return $input;
+    }
+
+    protected function getBodyFromArrayInput(mixed $input): void
+    {
+        if ($this->useAsBody) {
+            if (!is_array($input)) {
+                $this->logger?->warning('Input is not array, therefore can\'t get body from input by key.');
+            } elseif (array_key_exists($this->useAsBody, $input)) {
+                $this->inputBody = $input[$this->useAsBody];
+            } else {
+                $this->logger?->warning(
+                    'Input key ' . $this->useAsBody . ' that should be used as request body isn\'t present in input.'
+                );
+            }
+        }
+    }
+
+    protected function getHeadersFromArrayInput(mixed $input): void
+    {
+        if ($this->useAsHeaders) {
+            if (!is_array($input)) {
+                $this->logger?->warning('Input is not array, therefore can\'t get headers from input by key.');
+            } elseif (array_key_exists($this->useAsHeaders, $input)) {
+                $this->inputHeaders = $input[$this->useAsHeaders];
+            } else {
+                $this->logger?->warning(
+                    'Input key ' . $this->useAsHeaders . ' that should be used as request headers isn\'t present in ' .
+                    'input.'
+                );
+            }
+        }
+
+        if (is_array($this->useAsHeader)) {
+            if (!is_array($input)) {
+                $this->logger?->warning('Input is not array, therefore can\'t get header from input by key.');
+            } else {
+                foreach ($this->useAsHeader as $inputKey => $headerName) {
+                    $this->addToInputHeadersFromInput($input, $inputKey, $headerName);
+                }
+            }
+        }
+    }
+
+    protected function addToInputHeadersFromInput(mixed $input, string $inputKey, string $headerName): void
+    {
+        if (!is_array($this->inputHeaders)) {
+            $this->inputHeaders = [];
+        }
+
+        if (!array_key_exists($inputKey, $input)) {
+            $this->logger?->warning(
+                'Input key ' . $inputKey . ' that should be used as a request header, isn\'t present in input.'
+            );
+
+            return;
+        }
+
+        $inputValue = $input[$inputKey];
+
+        if (!array_key_exists($headerName, $this->inputHeaders)) {
+            $this->inputHeaders[$headerName] = is_array($inputValue) ? $inputValue : [$inputValue];
+
+            return;
+        }
+
+        $this->inputHeaders = HttpHeaders::addTo(HttpHeaders::normalize($this->inputHeaders), $headerName, $inputValue);
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    protected function mergeHeaders(): array
+    {
+        $headers = HttpHeaders::normalize($this->headers);
+
+        if (is_array($this->inputHeaders)) {
+            $inputHeaders = HttpHeaders::normalize($this->inputHeaders);
+
+            $headers = HttpHeaders::merge($headers, $inputHeaders);
+        }
+
+        return $headers;
+    }
+
+    protected function resetInputRequestParams(): void
+    {
+        $this->inputHeaders = null;
+
+        $this->inputBody = null;
+    }
+}

--- a/src/Steps/Step.php
+++ b/src/Steps/Step.php
@@ -147,6 +147,10 @@ abstract class Step extends BaseStep
         string $exceptionMessage = 'Input must be string, stringable or HTTP response (RespondedRequest)',
         bool $allowOnlyRespondedRequest = false
     ): string {
+        if (is_array($inputValue) && count($inputValue) > 1 && array_key_exists('response', $inputValue)) {
+            $inputValue = $inputValue['response'];
+        }
+
         $inputValue = $this->getSingleElementFromArray($inputValue);
 
         if (

--- a/tests/Loader/Http/HttpLoaderPolitenessTest.php
+++ b/tests/Loader/Http/HttpLoaderPolitenessTest.php
@@ -3,6 +3,7 @@
 namespace tests\Loader\Http;
 
 use Crwlr\Crawler\Loader\Http\Exceptions\LoadingException;
+use Crwlr\Crawler\Loader\Http\HeadlessBrowserLoaderHelper;
 use Crwlr\Crawler\Loader\Http\HttpLoader;
 use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
 use Crwlr\Crawler\UserAgents\BotUserAgent;
@@ -86,9 +87,13 @@ it('also throttles requests using the headless browser', function ($loadingMetho
 
     $browserMock->shouldReceive('createPage')->andReturn($pageMock);
 
+    $browserHelperMock = Mockery::mock(HeadlessBrowserLoaderHelper::class);
+
+    $browserHelperMock->shouldReceive('getBrowser')->andReturn($browserMock);
+
     $loader = new HttpLoader(new UserAgent('SomeUserAgent'));
 
-    invade($loader)->headlessBrowser = $browserMock;
+    invade($loader)->browserHelper = $browserHelperMock;
 
     $loader->useHeadlessBrowser();
 

--- a/tests/Loader/Http/HttpLoaderPolitenessTest.php
+++ b/tests/Loader/Http/HttpLoaderPolitenessTest.php
@@ -112,7 +112,7 @@ it('also throttles requests using the headless browser', function ($loadingMetho
     expect($diff)->toBeGreaterThan(0.3);
 
     expect($diff)->toBeLessThan(0.62);
-})->with(['load', 'loadOrFail']);
+})->with(['load', 'loadOrFail'])->skip('Have to rewrite this somehow');
 
 it('does not throttle requests to different domains', function ($loadingMethod) {
     $httpClient = Mockery::mock(ClientInterface::class);

--- a/tests/Loader/Http/HttpLoaderPolitenessTest.php
+++ b/tests/Loader/Http/HttpLoaderPolitenessTest.php
@@ -87,9 +87,12 @@ it('also throttles requests using the headless browser', function ($loadingMetho
 
     $browserMock->shouldReceive('createPage')->andReturn($pageMock);
 
-    $browserHelperMock = Mockery::mock(HeadlessBrowserLoaderHelper::class);
+    $browserHelperMock = Mockery::mock(HeadlessBrowserLoaderHelper::class)->makePartial();
 
-    $browserHelperMock->shouldReceive('getBrowser')->andReturn($browserMock);
+    $browserHelperMock
+        ->shouldAllowMockingProtectedMethods()
+        ->shouldReceive('getBrowser')
+        ->andReturn($browserMock);
 
     $loader = new HttpLoader(new UserAgent('SomeUserAgent'));
 
@@ -112,7 +115,7 @@ it('also throttles requests using the headless browser', function ($loadingMetho
     expect($diff)->toBeGreaterThan(0.3);
 
     expect($diff)->toBeLessThan(0.62);
-})->with(['load', 'loadOrFail'])->skip('Have to rewrite this somehow');
+})->with(['load', 'loadOrFail']);
 
 it('does not throttle requests to different domains', function ($loadingMethod) {
     $httpClient = Mockery::mock(ClientInterface::class);

--- a/tests/_Integration/Http/ProxyingTest.php
+++ b/tests/_Integration/Http/ProxyingTest.php
@@ -160,7 +160,7 @@ it('can also use a proxy when using the headless browser', function () {
         ->toBeInstanceOf(Result::class)
         ->and($results[0]->get('body'))
         ->toContain('["Accept-Language"]=&gt;' . PHP_EOL . '  string(35) "de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7"');
-});
+})->only();
 
 it('can also use rotating proxies when using the headless browser', function () {
     $crawler = helper_getFastCrawler();
@@ -199,4 +199,4 @@ it('can also use rotating proxies when using the headless browser', function () 
         ->toBeInstanceOf(Result::class)
         ->and($results[2]->get('body'))
         ->toContain('Port: 8001');          // And finally the third request with the first proxy again.
-});
+})->only();

--- a/tests/_Integration/Http/ProxyingTest.php
+++ b/tests/_Integration/Http/ProxyingTest.php
@@ -160,7 +160,7 @@ it('can also use a proxy when using the headless browser', function () {
         ->toBeInstanceOf(Result::class)
         ->and($results[0]->get('body'))
         ->toContain('["Accept-Language"]=&gt;' . PHP_EOL . '  string(35) "de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7"');
-})->only();
+});
 
 it('can also use rotating proxies when using the headless browser', function () {
     $crawler = helper_getFastCrawler();
@@ -199,4 +199,4 @@ it('can also use rotating proxies when using the headless browser', function () 
         ->toBeInstanceOf(Result::class)
         ->and($results[2]->get('body'))
         ->toContain('Port: 8001');          // And finally the third request with the first proxy again.
-})->only();
+});


### PR DESCRIPTION
For being more flexible to build a separate headless browser loader (in an extension package) extract the most basic HTTP loader functionality to a new `HttpBaseLoader` and important functionality for the headless browser loader to a new `HeadlessBrowserLoaderHelper`. It's considered a fix, because there's no new functionality, just refactoring existing code for better extendability.

Also add `--display-warnings` option to test commands.