### PR TITLE
Enable adding to result from nested output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2024-02-09
+### Added
+* Enable dot notation in `Step::addToResult()`, so you can get data from nested output, like: `$step->addToResult(['url' => 'response.url', 'status' => 'response.status', 'foo' => 'bar'])`.
+* When a step adds output properties to the result, and the output contains objects, it tries to serialize those objects to arrays, by calling `__serialize()`. If you want an object to be serialized differently for that purpose, you can define a `toArrayForAddToResult()` method in that class. When that method exists, it's preferred to the `__serialize()` method.
+* Implemented above-mentioned `toArrayForAddToResult()` method in the `RespondedRequest` class, so on every step that somehow yields a `RespondedRequest` object, you can use the keys `url`, `uri`, `status`, `headers` and `body` with the `addToResult()` method. Previously this only worked for `Http` steps, because it defines output key aliases (`HttpBase::outputKeyAliases()`). Now, in combination with the ability to use dot notation when adding data to the result, if your custom step returns nested output like `['response' => RespondedRequest, 'foo' => 'bar']`, you can add response data to the result like this `$step->addToResult(['url' => 'response.url', 'body' => 'response.body'])`.
+
 ## [1.5.3] - 2024-02-07
 ### Fixed
 * Merge `HttpBaseLoader` back to `HttpLoader`. It's probably not a good idea to have multiple loaders. At least not multiple loaders just for HTTP. It should be enough to publicly expose the `HeadlessBrowserLoaderHelper` via `HttpLoader::browserHelper()` for the extension steps. But keep the `HttpBase` step, to share the general HTTP functionality implemented there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.6.0] - 2024-02-09
+## [1.6.0] - 2024-02-13
 ### Added
 * Enable dot notation in `Step::addToResult()`, so you can get data from nested output, like: `$step->addToResult(['url' => 'response.url', 'status' => 'response.status', 'foo' => 'bar'])`.
 * When a step adds output properties to the result, and the output contains objects, it tries to serialize those objects to arrays, by calling `__serialize()`. If you want an object to be serialized differently for that purpose, you can define a `toArrayForAddToResult()` method in that class. When that method exists, it's preferred to the `__serialize()` method.
 * Implemented above-mentioned `toArrayForAddToResult()` method in the `RespondedRequest` class, so on every step that somehow yields a `RespondedRequest` object, you can use the keys `url`, `uri`, `status`, `headers` and `body` with the `addToResult()` method. Previously this only worked for `Http` steps, because it defines output key aliases (`HttpBase::outputKeyAliases()`). Now, in combination with the ability to use dot notation when adding data to the result, if your custom step returns nested output like `['response' => RespondedRequest, 'foo' => 'bar']`, you can add response data to the result like this `$step->addToResult(['url' => 'response.url', 'body' => 'response.body'])`.
+
+### Fixed
+* Improvement regarding the timing when a store (`Store` class instance) is called by the crawler with a final crawling result. When a crawling step initiates a crawling result (so, `addToResult()` was called on the step instance), the crawler has to wait for all child outputs (resulting from one step-input) until it calls the store, because the child outputs can all add data to the same final result object. But previously this was not only the case for all child outputs starting from a step where `addToResult()` was called, but all children of one initial crawler input. So with this change, in a lot of cases, the store will earlier be called with finished `Result` objects and memory usage will be lowered.
 
 ## [1.5.3] - 2024-02-07
 ### Fixed

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -224,11 +224,8 @@ abstract class Crawler
     /**
      * @return Generator<Output|Result>
      */
-    protected function invokeStepsRecursive(
-        Input $input,
-        StepInterface $step,
-        int $stepIndex,
-    ): Generator {
+    protected function invokeStepsRecursive(Input $input, StepInterface $step, int $stepIndex): Generator
+    {
         $outputs = $step->invokeStep($input);
 
         $nextStep = $this->nextStep($stepIndex);

--- a/src/Loader/Http/Messages/RespondedRequest.php
+++ b/src/Loader/Http/Messages/RespondedRequest.php
@@ -73,6 +73,28 @@ class RespondedRequest
     }
 
     /**
+     * @return mixed[]
+     */
+    public function toArrayForAddToResult(): array
+    {
+        $serialized = $this->__serialize();
+
+        $mapping = [
+            'url' => 'effectiveUri',
+            'uri' => 'effectiveUri',
+            'status' => 'responseStatusCode',
+            'headers' => 'responseHeaders',
+            'body' => 'responseBody',
+        ];
+
+        foreach ($mapping as $newKey => $originalKey) {
+            $serialized[$newKey] = $serialized[$originalKey];
+        }
+
+        return $serialized;
+    }
+
+    /**
      * @param mixed[] $data
      * @throws Exception
      */

--- a/tests/CrawlerTest.php
+++ b/tests/CrawlerTest.php
@@ -681,9 +681,9 @@ it(
 
         expect($outputLines[1])->toContain('step2 called');
 
-        expect($outputLines[2])->toContain('step2 called');
+        expect($outputLines[2])->toContain('Stored a result');
 
-        expect($outputLines[3])->toContain('Stored a result');
+        expect($outputLines[3])->toContain('step2 called');
 
         expect($outputLines[4])->toContain('Stored a result');
 
@@ -691,9 +691,9 @@ it(
 
         expect($outputLines[6])->toContain('step2 called');
 
-        expect($outputLines[7])->toContain('step2 called');
+        expect($outputLines[7])->toContain('Stored a result');
 
-        expect($outputLines[8])->toContain('Stored a result');
+        expect($outputLines[8])->toContain('step2 called');
 
         expect($outputLines[9])->toContain('Stored a result');
     }

--- a/tests/Loader/Http/Messages/RespondedRequestTest.php
+++ b/tests/Loader/Http/Messages/RespondedRequestTest.php
@@ -195,6 +195,29 @@ it('can be created from a serialized array', function () {
     expect($respondedRequest->effectiveUri())->toBe('/bar');
 });
 
+it('has a serializeForAddToResult() method', function () {
+    $respondedRequest = new RespondedRequest(
+        new Request('POST', '/home', ['key' => 'val'], 'bod'),
+        new Response(201, ['k' => 'v'], 'res')
+    );
+
+    expect($respondedRequest->toArrayForAddToResult())->toBe([
+        'requestMethod' => 'POST',
+        'requestUri' => '/home',
+        'requestHeaders' => ['key' => ['val']],
+        'requestBody' => 'bod',
+        'effectiveUri' => '/home',
+        'responseStatusCode' => 201,
+        'responseHeaders' => ['k' => ['v']],
+        'responseBody' => 'res',
+        'url' => '/home',
+        'uri' => '/home',
+        'status' => 201,
+        'headers' => ['k' => ['v']],
+        'body' => 'res',
+    ]);
+});
+
 it('generates a cache key for an instance', function () {
     $respondedRequest = new RespondedRequest(new Request('GET', '/foo/bar'), new Response());
 


### PR DESCRIPTION
* Enable dot notation in `Step::addToResult()`, so you can get data from nested output, like: `$step->addToResult(['url' => 'response.url', 'status' => 'response.status', 'foo' => 'bar'])`.
* When a step adds output properties to the result, and the output contains objects, it tries to serialize those objects to arrays, by calling `__serialize()`. If you want an object to be serialized differently for that purpose, you can define a `toArrayForAddToResult()` method in that class. When that method exists, it's preferred to the `__serialize()` method.
* Implemented above-mentioned `toArrayForAddToResult()` method in the `RespondedRequest` class, so on every step that somehow yields a `RespondedRequest` object, you can use the keys `url`, `uri`, `status`, `headers` and `body` with the `addToResult()` method. Previously this only worked for `Http` steps, because it defines output key aliases (`HttpBase::outputKeyAliases()`). Now, in combination with the ability to use dot notation when adding data to the result, if your custom step returns nested output like `['response' => RespondedRequest, 'foo' => 'bar']`, you can add response data to the result like this `$step->addToResult(['url' => 'response.url', 'body' => 'response.body'])`.
* Improvement regarding the timing when a store (`Store` class instance) is called by the crawler with a final crawling result. When a crawling step initiates a crawling result (so, `addToResult()` was called on the step instance), the crawler has to wait for all child outputs (resulting from one step-input) until it calls the store, because the child outputs can all add data to the same final result object. But previously this was not only the case for all child outputs starting from a step where `addToResult()` was called, but all children of one initial crawler input. So with this change, in a lot of cases, the store will earlier be called with finished `Result` objects and memory usage will be lowered.