### PR TITLE
Enable updating cached responses via the Loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1] - 2024-02-16
+### Changed
+* Make method `HttpLoader::addToCache()` public, so steps can update a cached response with an extended version.
+
 ## [1.6.0] - 2024-02-13
 ### Added
 * Enable dot notation in `Step::addToResult()`, so you can get data from nested output, like: `$step->addToResult(['url' => 'response.url', 'status' => 'response.status', 'foo' => 'bar'])`.

--- a/src/Loader/Http/HttpLoader.php
+++ b/src/Loader/Http/HttpLoader.php
@@ -326,6 +326,16 @@ class HttpLoader extends Loader
     }
 
     /**
+     * @throws \Psr\SimpleCache\InvalidArgumentException
+     */
+    public function addToCache(RespondedRequest $respondedRequest): void
+    {
+        if ($this->cache && $this->shouldResponseBeCached($respondedRequest)) {
+            $this->cache->set($respondedRequest->cacheKey(), $respondedRequest);
+        }
+    }
+
+    /**
      * @throws LoadingException|Throwable|\Psr\SimpleCache\InvalidArgumentException
      */
     protected function tryLoading(
@@ -556,16 +566,6 @@ class HttpLoader extends Loader
         }
 
         return null;
-    }
-
-    /**
-     * @throws \Psr\SimpleCache\InvalidArgumentException
-     */
-    protected function addToCache(RespondedRequest $respondedRequest): void
-    {
-        if ($this->cache && $this->shouldResponseBeCached($respondedRequest)) {
-            $this->cache->set($respondedRequest->cacheKey(), $respondedRequest);
-        }
     }
 
     protected function shouldResponseBeCached(RespondedRequest $respondedRequest): bool

--- a/tests/_Stubs/RespondedRequestChild.php
+++ b/tests/_Stubs/RespondedRequestChild.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace tests\_Stubs;
+
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Exception;
+
+class RespondedRequestChild extends RespondedRequest
+{
+    /**
+     * @throws Exception
+     */
+    public static function fromRespondedRequest(RespondedRequest $respondedRequest): self
+    {
+        return new self($respondedRequest->request, $respondedRequest->response);
+    }
+
+    public static function fromArray(array $data): RespondedRequestChild
+    {
+        $respondedRequest = parent::fromArray($data);
+
+        return self::fromRespondedRequest($respondedRequest);
+    }
+
+    public function itseme(): string
+    {
+        return 'mario';
+    }
+}


### PR DESCRIPTION
Make method `HttpLoader::addToCache()` public, so steps can update a cached response with an extended version.