### PR TITLE
Fix issue with cache filters and redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.2] - 2024-02-26
+### Fixed
+* When using `HttpLoader::cacheOnlyWhereUrl()` and a request was redirected (maybe even multiple times), previously all URLs in the chain had to match the filter rule. As this isn't really practicable, now only one of the URLs has to match the rule.
+
 ## [1.6.1] - 2024-02-16
 ### Changed
 * Make method `HttpLoader::addToCache()` public, so steps can update a cached response with an extended version.

--- a/src/HttpCrawler.php
+++ b/src/HttpCrawler.php
@@ -8,6 +8,10 @@ use Crwlr\Crawler\Loader\LoaderInterface;
 use Crwlr\Crawler\UserAgents\UserAgentInterface;
 use Psr\Log\LoggerInterface;
 
+/**
+ * @method HttpLoader getLoader()
+ */
+
 abstract class HttpCrawler extends Crawler
 {
     /**

--- a/src/Loader/Http/HttpLoader.php
+++ b/src/Loader/Http/HttpLoader.php
@@ -572,12 +572,20 @@ class HttpLoader extends Loader
     {
         if (!empty($this->cacheUrlFilters)) {
             foreach ($this->cacheUrlFilters as $filter) {
+                $noUrlMatched = true;
+
                 foreach ($respondedRequest->allUris() as $url) {
-                    if (!$filter->evaluate($url)) {
-                        return false;
+                    if ($filter->evaluate($url)) {
+                        $noUrlMatched = false;
                     }
                 }
+
+                if ($noUrlMatched) {
+                    return false;
+                }
             }
+
+            return true;
         }
 
         return true;

--- a/tests/_Stubs/Crawlers/DummyOne.php
+++ b/tests/_Stubs/Crawlers/DummyOne.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace tests\_Stubs\Crawlers;
+
+use Crwlr\Crawler\Crawler;
+use Crwlr\Crawler\Loader\LoaderInterface;
+use Crwlr\Crawler\UserAgents\BotUserAgent;
+use Crwlr\Crawler\UserAgents\UserAgentInterface;
+use Mockery;
+use Psr\Log\LoggerInterface;
+
+class DummyOne extends Crawler
+{
+    /**
+     * @return BotUserAgent
+     */
+    public function userAgent(): UserAgentInterface
+    {
+        return new BotUserAgent('FooBot');
+    }
+
+    public function loader(UserAgentInterface $userAgent, LoggerInterface $logger): LoaderInterface
+    {
+        return Mockery::mock(LoaderInterface::class);
+    }
+}

--- a/tests/_Stubs/Crawlers/DummyTwo.php
+++ b/tests/_Stubs/Crawlers/DummyTwo.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace tests\_Stubs\Crawlers;
+
+use Crwlr\Crawler\Crawler;
+use Crwlr\Crawler\Loader\LoaderInterface;
+use Crwlr\Crawler\UserAgents\UserAgentInterface;
+use Psr\Log\LoggerInterface;
+use tests\_Stubs\Crawlers\DummyTwo\DummyTwoLoader;
+use tests\_Stubs\Crawlers\DummyTwo\DummyTwoLogger;
+use tests\_Stubs\Crawlers\DummyTwo\DummyTwoUserAgent;
+
+/**
+ * @property DummyTwoUserAgent $userAgent
+ * @property DummyTwoLogger $logger
+ * @property DummyTwoLoader $loader
+ * @method DummyTwoUserAgent getUserAgent()
+ * @method DummyTwoLogger getLogger()
+ * @method DummyTwoLoader getLoader()
+ */
+
+class DummyTwo extends Crawler
+{
+    public int $userAgentCalled = 0;
+
+    public int $loggerCalled = 0;
+
+    public int $loaderCalled = 0;
+
+    /**
+     * @return DummyTwoUserAgent
+     */
+    protected function userAgent(): UserAgentInterface
+    {
+        $this->userAgentCalled += 1;
+
+        return new DummyTwoUserAgent('FooBot');
+    }
+
+    /**
+     * @return DummyTwoLogger
+     */
+    protected function logger(): LoggerInterface
+    {
+        $this->loggerCalled += 1;
+
+        return new DummyTwoLogger();
+    }
+
+    /**
+     * @return DummyTwoLoader
+     */
+    protected function loader(UserAgentInterface $userAgent, LoggerInterface $logger): LoaderInterface
+    {
+        $this->loaderCalled += 1;
+
+        return new DummyTwoLoader($userAgent, null, $logger);
+    }
+}

--- a/tests/_Stubs/Crawlers/DummyTwo/DummyTwoLoader.php
+++ b/tests/_Stubs/Crawlers/DummyTwo/DummyTwoLoader.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace tests\_Stubs\Crawlers\DummyTwo;
+
+use Crwlr\Crawler\Loader\Http\HttpLoader;
+
+class DummyTwoLoader extends HttpLoader
+{
+    public string $testProperty = 'foo';
+}

--- a/tests/_Stubs/Crawlers/DummyTwo/DummyTwoLogger.php
+++ b/tests/_Stubs/Crawlers/DummyTwo/DummyTwoLogger.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace tests\_Stubs\Crawlers\DummyTwo;
+
+use Crwlr\Crawler\Logger\CliLogger;
+
+class DummyTwoLogger extends CliLogger
+{
+    public string $testProperty = 'foo';
+}

--- a/tests/_Stubs/Crawlers/DummyTwo/DummyTwoUserAgent.php
+++ b/tests/_Stubs/Crawlers/DummyTwo/DummyTwoUserAgent.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace tests\_Stubs\Crawlers\DummyTwo;
+
+use Crwlr\Crawler\UserAgents\BotUserAgent;
+
+class DummyTwoUserAgent extends BotUserAgent
+{
+    public string $testProperty = 'foo';
+}


### PR DESCRIPTION
When using `HttpLoader::cacheOnlyWhereUrl()` and a request was redirected (maybe even multiple times), previously all URLs in the chain had to match the filter rule. As this isn't really practicable, now only one of the URLs has to match the rule.