### PR TITLE
JSON step improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2024-03-04
+### Added
+* Allow getting the whole decoded JSON as array with the new `Json::all()` and also allow to get the whole decoded JSON, when using `Json::get()`, inside a mapping using either empty string or `*` as target. Example: `Json::get(['all' => '*'])`. `*` only works, when there is no key `*` in the decoded data.
+
+### Fixed
+* Make it work with responses loaded by a headless browser. If decoding the input string fails, it now checks if it could be HTML. If that's the case, it extracts the text content of the `<body>` and tries to decode this instead.
+
 ## [1.6.2] - 2024-02-26
 ### Fixed
 * When using `HttpLoader::cacheOnlyWhereUrl()` and a request was redirected (maybe even multiple times), previously all URLs in the chain had to match the filter rule. As this isn't really practicable, now only one of the URLs has to match the rule.

--- a/src/Steps/Json.php
+++ b/src/Steps/Json.php
@@ -6,13 +6,20 @@ use Adbar\Dot;
 use Crwlr\Utils\Json as JsonUtil;
 use Crwlr\Utils\Exceptions\InvalidJsonException;
 use Generator;
+use Symfony\Component\DomCrawler\Crawler;
+use Throwable;
 
 class Json extends Step
 {
     /**
      * @param mixed[] $propertyMapping
      */
-    final public function __construct(protected array $propertyMapping = [], protected ?string $each = null) {}
+    final public function __construct(protected ?array $propertyMapping = [], protected ?string $each = null) {}
+
+    public static function all(): static
+    {
+        return new static(null);
+    }
 
     /**
      * @param mixed[] $propertyMapping
@@ -37,10 +44,14 @@ class Json extends Step
 
     protected function invoke(mixed $input): Generator
     {
-        try {
-            $array = JsonUtil::stringToArray($input);
-        } catch (InvalidJsonException) {
-            $this->logger?->warning('Failed to decode JSON string.');
+        $array = $this->inputStringToArray($input);
+
+        if ($array === null || $this->propertyMapping === null) {
+            if ($array === null) {
+                $this->logger?->warning('Failed to decode JSON string.');
+            } elseif ($this->propertyMapping === null) {
+                yield $array;
+            }
 
             return;
         }
@@ -63,11 +74,37 @@ class Json extends Step
     }
 
     /**
+     * @return mixed[]|null
+     */
+    protected function inputStringToArray(string $input): ?array
+    {
+        try {
+            return JsonUtil::stringToArray($input);
+        } catch (InvalidJsonException) {
+            // If headless browser is used in loader, the JSON in the response body is wrapped in an HTML document.
+            if (str_contains($input, '<html') || str_contains($input, '<HTML')) {
+                try {
+                    $bodyText = (new Crawler($input))->filter('body')->text();
+
+                    return JsonUtil::stringToArray($bodyText);
+                } catch (Throwable) {
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * @param Dot<int|string, mixed> $dot
      * @return mixed[]
      */
     protected function mapProperties(Dot $dot): array
     {
+        if ($this->propertyMapping === null || $this->propertyMapping === []) {
+            return [];
+        }
+
         $mapped = [];
 
         foreach ($this->propertyMapping as $propertyKey => $dotNotation) {
@@ -75,7 +112,11 @@ class Json extends Step
                 $propertyKey = $dotNotation;
             }
 
-            $mapped[$propertyKey] = $dot->get($dotNotation);
+            if ($dotNotation === '' || ($dotNotation === '*' && $dot->get('*') === null)) {
+                $mapped[$propertyKey] = $dot->all();
+            } else {
+                $mapped[$propertyKey] = $dot->get($dotNotation);
+            }
         }
 
         return $mapped;

--- a/tests/Steps/JsonTest.php
+++ b/tests/Steps/JsonTest.php
@@ -21,9 +21,8 @@ it('accepts RespondedRequest as input', function () {
 
     $output = helper_invokeStepWithInput(Json::get(['foo' => 'data.foo']), $respondedRequest);
 
-    expect($output)->toHaveCount(1);
-
-    expect($output[0]->get())->toBe(['foo' => 'bar']);
+    expect($output)->toHaveCount(1)
+        ->and($output[0]->get())->toBe(['foo' => 'bar']);
 });
 
 it('accepts PSR-7 Response as input', function () {
@@ -33,9 +32,8 @@ it('accepts PSR-7 Response as input', function () {
 
     $output = helper_invokeStepWithInput(Json::get(['foo' => 'data.foo']), $response);
 
-    expect($output)->toHaveCount(1);
-
-    expect($output[0]->get())->toBe(['foo' => 'bar']);
+    expect($output)->toHaveCount(1)
+        ->and($output[0]->get())->toBe(['foo' => 'bar']);
 });
 
 it('extracts data defined using dot notation', function () {
@@ -53,9 +51,8 @@ it('extracts data defined using dot notation', function () {
 
     $output = helper_invokeStepWithInput(Json::get(['foo' => 'data.target.foo', 'baz' => 'data.target.baz']), $json);
 
-    expect($output)->toHaveCount(1);
-
-    expect($output[0]->get())->toBe(['foo' => 'bar', 'baz' => 'yo']);
+    expect($output)->toHaveCount(1)
+        ->and($output[0]->get())->toBe(['foo' => 'bar', 'baz' => 'yo']);
 });
 
 it('uses the array values in the mapping as output key when no string keys defined in the mapping array', function () {
@@ -110,13 +107,10 @@ test('Using the each method you can iterate over a json array and yield multiple
 
     $output = helper_invokeStepWithInput(Json::each('list.people', ['name' => 'name', 'age' => 'age.years']), $json);
 
-    expect($output)->toHaveCount(3);
-
-    expect($output[0]->get())->toBe(['name' => 'Peter', 'age' => 19]);
-
-    expect($output[1]->get())->toBe(['name' => 'Paul', 'age' => 22]);
-
-    expect($output[2]->get())->toBe(['name' => 'Mary', 'age' => 20]);
+    expect($output)->toHaveCount(3)
+        ->and($output[0]->get())->toBe(['name' => 'Peter', 'age' => 19])
+        ->and($output[1]->get())->toBe(['name' => 'Paul', 'age' => 22])
+        ->and($output[2]->get())->toBe(['name' => 'Mary', 'age' => 20]);
 });
 
 test('When the root element is an array you can use each with empty string as param', function () {
@@ -131,15 +125,12 @@ test('When the root element is an array you can use each with empty string as pa
 
     $output = helper_invokeStepWithInput(Json::each('', ['nickname']), $jsonString);
 
-    expect($output)->toHaveCount(4);
+    expect($output)->toHaveCount(4)
+        ->and($output[0]->get())->toBe(['nickname' => 'Axel'])
+        ->and($output[1]->get())->toBe(['nickname' => 'Lilo'])
+        ->and($output[2]->get())->toBe(['nickname' => 'Poppi'])
+        ->and($output[3]->get())->toBe(['nickname' => 'Dominik']);
 
-    expect($output[0]->get())->toBe(['nickname' => 'Axel']);
-
-    expect($output[1]->get())->toBe(['nickname' => 'Lilo']);
-
-    expect($output[2]->get())->toBe(['nickname' => 'Poppi']);
-
-    expect($output[3]->get())->toBe(['nickname' => 'Dominik']);
 });
 
 it('yields no results and logs a warning when the target for "each" does not exist', function () {
@@ -169,9 +160,8 @@ it('also works with JS style JSON objects without quotes around keys', function 
 
     $outputs = helper_invokeStepWithInput(Json::get(['foo', 'bar', 'baz']), $jsonString);
 
-    expect($outputs)->toHaveCount(1);
-
-    expect($outputs[0]->get())->toBe(['foo' => 'one', 'bar' => 'two', 'baz' => 'three']);
+    expect($outputs)->toHaveCount(1)
+        ->and($outputs[0]->get())->toBe(['foo' => 'one', 'bar' => 'two', 'baz' => 'three']);
 });
 
 it('also correctly fixes keys without quotes, even when values contain colons', function () {
@@ -185,13 +175,13 @@ it('also correctly fixes keys without quotes, even when values contain colons', 
 
     $outputs = helper_invokeStepWithInput(Json::get(['foo', 'bar', 'baz']), $jsonString);
 
-    expect($outputs)->toHaveCount(1);
-
-    expect($outputs[0]->get())->toBe([
-        'foo' => 'https://www.example.com',
-        'bar' => 2,
-        'baz' => 'some: thing',
-    ]);
+    expect($outputs)->toHaveCount(1)
+        ->and($outputs[0]->get())
+        ->toBe([
+            'foo' => 'https://www.example.com',
+            'bar' => 2,
+            'baz' => 'some: thing',
+        ]);
 });
 
 it('also correctly fixes keys without quotes, when the value is an empty string', function () {
@@ -204,10 +194,128 @@ it('also correctly fixes keys without quotes, when the value is an empty string'
 
     $outputs = helper_invokeStepWithInput(Json::get(['foo', 'bar']), $jsonString);
 
-    expect($outputs)->toHaveCount(1);
+    expect($outputs)->toHaveCount(1)
+        ->and($outputs[0]->get())
+        ->toBe([
+            'foo' => '',
+            'bar' => 'baz',
+        ]);
+});
 
-    expect($outputs[0]->get())->toBe([
-        'foo' => '',
-        'bar' => 'baz',
-    ]);
+it('works with a string that is an HTML document and inside the body there\'s a JSON object', function () {
+    $jsonString = <<<HTML
+        <!doctype html>
+        <html lang="en">
+        <head>
+        <title>JSON</title>
+        </head>
+        <body>
+        { "foo": "Hello World!", "bar": "baz" }
+        </body>
+        HTML;
+
+    $outputs = helper_invokeStepWithInput(Json::get(['title' => 'foo']), $jsonString);
+
+    expect($outputs)->toHaveCount(1)
+        ->and($outputs[0]->get())
+        ->toBe(['title' => 'Hello World!']);
+});
+
+it('gets the whole JSON object as array, when using the all() method', function () {
+    $jsonString = <<<JSON
+        {
+            "foo": "one",
+            "bar": "two",
+            "array": ["one", "two", "three"]
+        }
+        JSON;
+
+    $outputs = helper_invokeStepWithInput(Json::all(), $jsonString);
+
+    expect($outputs)->toHaveCount(1)
+        ->and($outputs[0]->get())
+        ->toBe([
+            'foo' => 'one',
+            'bar' => 'two',
+            'array' => ['one', 'two', 'three'],
+        ]);
+});
+
+it('can also map the whole decoded data array to a output property', function () {
+    $jsonString = <<<JSON
+        {
+            "foo": "one",
+            "bar": "two",
+            "array": ["one", "two", "three"]
+        }
+        JSON;
+
+    $outputs = helper_invokeStepWithInput(Json::get(['all' => '*']), $jsonString);
+
+    expect($outputs)
+        ->toHaveCount(1)
+        ->and($outputs[0]->get())
+        ->toBe([
+            'all' => [
+                'foo' => 'one',
+                'bar' => 'two',
+                'array' => ['one', 'two', 'three'],
+            ]
+        ]);
+});
+
+test('when there is a key * in the object, the * gets that key, not the whole decoded data', function () {
+    $jsonString = <<<JSON
+        {
+            "*": "yes",
+            "foo": "bar",
+            "baz": "quz"
+        }
+        JSON;
+
+    $outputs = helper_invokeStepWithInput(Json::get(['shouldBeYes' => '*']), $jsonString);
+
+    expect($outputs)
+        ->toHaveCount(1)
+        ->and($outputs[0]->get())
+        ->toBe(['shouldBeYes' => 'yes']);
+});
+
+it('can also get the whole decoded data in the each() context', function () {
+    $jsonString = <<<JSON
+        [
+            { "name": "foo", "value": "one" },
+            { "name": "bar", "value": "two" },
+            { "name": "baz", "value": "three" }
+        ]
+        JSON;
+
+    $outputs = helper_invokeStepWithInput(Json::each('', ['full' => '*']), $jsonString);
+
+    expect($outputs)
+        ->toHaveCount(3)
+        ->and($outputs[0]->get())
+        ->toBe(['full' => ['name' => 'foo', 'value' => 'one']])
+        ->and($outputs[1]->get())
+        ->toBe(['full' => ['name' => 'bar', 'value' => 'two']])
+        ->and($outputs[2]->get())
+        ->toBe(['full' => ['name' => 'baz', 'value' => 'three']]);
+});
+
+test('in the each() context, when there is a key *, it gets that, not the whole decoded data', function () {
+    $jsonString = <<<JSON
+        [
+            { "name": "foo", "value": "one", "*": "yo" },
+            { "name": "bar", "value": "two" }
+        ]
+        JSON;
+
+    $outputs = helper_invokeStepWithInput(Json::each('', ['full' => '*']), $jsonString);
+
+    expect($outputs)
+        ->toHaveCount(2)
+        ->and($outputs[0]->get())
+        ->toBe(['full' => 'yo'])
+        ->and($outputs[1]->get())
+        ->toBe(['full' => ['name' => 'bar', 'value' => 'two']]);
 });

--- a/tests/_Integration/Http/RequestParamsFromInputTest.php
+++ b/tests/_Integration/Http/RequestParamsFromInputTest.php
@@ -2,6 +2,7 @@
 
 namespace tests\_Integration\Http;
 
+use Crwlr\Crawler\Steps\Json;
 use Crwlr\Crawler\Steps\Loading\Http;
 use Crwlr\Crawler\Steps\Step;
 use Generator;
@@ -26,13 +27,6 @@ test('Http steps can receive url, body and headers from an input array', functio
         }
     };
 
-    $getJsonDataStep = new class () extends Step {
-        protected function invoke(mixed $input): Generator
-        {
-            yield json_decode(Http::getBodyString($input->response), true);
-        }
-    };
-
     $crawler = helper_getFastCrawler();
 
     $crawler
@@ -45,7 +39,7 @@ test('Http steps can receive url, body and headers from an input array', functio
                 ->useInputKeyAsHeader('header-y', 'header-y')
                 ->useInputKeyAsHeader('header-z', 'header-z')
         )
-        ->addStep($getJsonDataStep);
+        ->addStep(Json::all());
 
     $results = helper_generatorToArray($crawler->run());
 


### PR DESCRIPTION
Allow getting the whole decoded JSON as array with the new `Json::all()` and also allow to get the whole decoded JSON, when using `Json::get()`, inside a mapping using either empty string or `*` as target. Example: `Json::get(['all' => '*'])`. `*` only works, when there is no key `*` in the decoded data.

Make it work with responses loaded by a headless browser. If decoding the input string fails, it now checks if it could be HTML. If that's the case, it extracts the text content of the `<body>` and tries to decode this instead.