### PR TITLE
Fix issue in Http::crawl() step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ vendor
 .php_cs.cache
 .php-cs-fixer.cache
 .phpunit.result.cache
+.phpunit.cache
 /cachedir
 /tests/_Temp/_cachedir/*
 !/tests/_Temp/_cachedir/.gitkeep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.1] - 2024-03-11
+### Fixed
+* A PHP error that happened when the loader returns `null` for the initial request in the `Http::crawl()` step.
+
 ## [1.7.0] - 2024-03-04
 ### Added
 * Allow getting the whole decoded JSON as array with the new `Json::all()` and also allow to get the whole decoded JSON, when using `Json::get()`, inside a mapping using either empty string or `*` as target. Example: `Json::get(['all' => '*'])`. `*` only works, when there is no key `*` in the decoded data.

--- a/src/Steps/Loading/HttpCrawl.php
+++ b/src/Steps/Loading/HttpCrawl.php
@@ -146,32 +146,34 @@ class HttpCrawl extends Http
 
         $response = $this->loader->load($this->getRequestFromInputUri($input));
 
+        if (!$response) {
+            return;
+        }
+
         $initialResponseDocument = new Document($response);
 
         $this->setResponseCanonicalUrl($response, $initialResponseDocument);
 
         $this->addLoadedUrlsFromResponse($response);
 
-        if ($response !== null) {
-            if (!$this->inputIsSitemap && $this->matchesAllCriteria(Url::parse($input))) {
-                $this->yieldedResponseCount++;
+        if (!$this->inputIsSitemap && $this->matchesAllCriteria(Url::parse($input))) {
+            $this->yieldedResponseCount++;
 
-                yield $response;
-            }
+            yield $response;
+        }
 
-            $this->urls = $this->getUrlsFromInitialResponse($response, $initialResponseDocument);
+        $this->urls = $this->getUrlsFromInitialResponse($response, $initialResponseDocument);
 
-            $depth = 1;
+        $depth = 1;
 
-            while (
-                !$this->depthIsExceeded($depth) &&
-                !empty($this->urls) &&
-                (!$this->maxOutputs || $this->yieldedResponseCount < $this->maxOutputs)
-            ) {
-                yield from $this->loadUrls();
+        while (
+            !$this->depthIsExceeded($depth) &&
+            !empty($this->urls) &&
+            (!$this->maxOutputs || $this->yieldedResponseCount < $this->maxOutputs)
+        ) {
+            yield from $this->loadUrls();
 
-                $depth++;
-            }
+            $depth++;
         }
     }
 


### PR DESCRIPTION
Fix a PHP error that happened when the loader returns `null` for the initial request in the `Http::crawl()` step.