### PR TITLE
Fail soft when input key is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.2] - 2024-03-19
+### Fixed
+* When the `useInputKey()` method is used on a step and the defined key does not exist in input, it logs a warning and does not invoke the step instead of throwing an `Exception`.
+
 ## [1.7.1] - 2024-03-11
 ### Fixed
 * A PHP error that happened when the loader returns `null` for the initial request in the `Http::crawl()` step.

--- a/src/Steps/BaseStep.php
+++ b/src/Steps/BaseStep.php
@@ -227,14 +227,22 @@ abstract class BaseStep implements StepInterface
         $this->uniqueOutputKeys = $this->uniqueInputKeys = [];
     }
 
-    /**
-     * @throws Exception
-     */
-    protected function getInputKeyToUse(Input $input): Input
+    protected function getInputKeyToUse(Input $input): ?Input
     {
         if ($this->useInputKey !== null) {
-            if (!array_key_exists($this->useInputKey, $input->get())) {
-                throw new Exception('Key ' . $this->useInputKey . ' does not exist in input');
+            $inputValue = $input->get();
+
+            if (!is_array($inputValue)) {
+                $this->logger?->warning(
+                    'Can\'t get key from input, because input is of type ' . gettype($inputValue) . ' instead of ' .
+                    'array.'
+                );
+
+                return null;
+            } elseif (!array_key_exists($this->useInputKey, $inputValue)) {
+                $this->logger?->warning('Can\'t get key from input, because it does not exist.');
+
+                return null;
             }
 
             $input = new Input($input->get()[$this->useInputKey], $input->result, $input->addLaterToResult);

--- a/src/Steps/Group.php
+++ b/src/Steps/Group.php
@@ -44,24 +44,26 @@ final class Group extends BaseStep
         // but keep the original input, because we want to use it e.g. for the keepInputData() functionality.
         $inputForStepInvocation = $this->getInputKeyToUse($input);
 
-        foreach ($this->steps as $key => $step) {
-            foreach ($step->invokeStep($inputForStepInvocation) as $nthOutput => $output) {
-                if (method_exists($step, 'callUpdateInputUsingOutput')) {
-                    $inputForStepInvocation = $step->callUpdateInputUsingOutput($inputForStepInvocation, $output);
-                }
+        if ($inputForStepInvocation) {
+            foreach ($this->steps as $key => $step) {
+                foreach ($step->invokeStep($inputForStepInvocation) as $nthOutput => $output) {
+                    if (method_exists($step, 'callUpdateInputUsingOutput')) {
+                        $inputForStepInvocation = $step->callUpdateInputUsingOutput($inputForStepInvocation, $output);
+                    }
 
-                if ($this->includeOutput($step)) {
-                    $combinedOutput = $this->addOutputToCombinedOutputs(
-                        $output->get(),
-                        $combinedOutput,
-                        $key,
-                        $nthOutput,
-                    );
+                    if ($this->includeOutput($step)) {
+                        $combinedOutput = $this->addOutputToCombinedOutputs(
+                            $output->get(),
+                            $combinedOutput,
+                            $key,
+                            $nthOutput,
+                        );
+                    }
                 }
             }
-        }
 
-        yield from $this->prepareCombinedOutputs($combinedOutput, $input);
+            yield from $this->prepareCombinedOutputs($combinedOutput, $input);
+        }
     }
 
     public function addsToOrCreatesResult(): bool

--- a/src/Steps/Step.php
+++ b/src/Steps/Step.php
@@ -42,10 +42,14 @@ abstract class Step extends BaseStep
             return;
         }
 
-        $validInputValue = $this->validateAndSanitizeInput($this->getInputKeyToUse($input)->get());
+        $inputForStepInvocation = $this->getInputKeyToUse($input);
 
-        if ($this->uniqueInput === false || $this->inputOrOutputIsUnique(new Input($validInputValue))) {
-            yield from $this->invokeAndYield($validInputValue, $input);
+        if ($inputForStepInvocation) {
+            $validInputValue = $this->validateAndSanitizeInput($inputForStepInvocation->get());
+
+            if ($this->uniqueInput === false || $this->inputOrOutputIsUnique(new Input($validInputValue))) {
+                yield from $this->invokeAndYield($validInputValue, $input);
+            }
         }
     }
 


### PR DESCRIPTION
When the `useInputKey()` method is used on a step and the defined key does not exist in input, it logs a warning and does not invoke the step instead of throwing an `Exception`.