### PR TITLE
Allow further headless chrome configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2024-06-17
+### Added
+* New methods `HeadlessBrowserLoaderHelper::setTimeout()` and `HeadlessBrowserLoaderHelper::waitForNavigationEvent()` to allow defining the timeout for the headless chrome in milliseconds (default 30000 = 30 seconds) and the navigation event (`load` (default), `DOMContentLoaded`, `firstMeaningfulPaint`, `networkIdle`, etc.) to wait for when loading a URL.
+
 ## [1.8.0] - 2024-06-05
 ### Added
 * New methods `Step::keep()` and `Step::keepAs()`, as well as `Step::keepFromInput()` and `Step::keepInputAs()`, as alternatives to `Step::addToResult()` (or `Step::addLaterToResult()`). The `keep()` method can be called without any argument, to keep all from the output data. It can be called with a string, to keep a certain key or with an array to keep a list of keys. If the step yields scalar value outputs (not an associative array or object with keys) you need to use the `keepAs()` method with the key you want the output value to have in the kept data. The methods `keepFromInput()` and `keepInputAs()` work the same, but uses the input (not the output) that the step receives. Most likely only needed with a first step, to keep data from initial inputs (or in a sub crawler, see below). Kept properties can also be accessed with the `Step::useInputKey()` method, so you can easily reuse properties from multiple steps ago as input.

--- a/tests/Loader/Http/HeadlessBrowserLoaderHelperTest.php
+++ b/tests/Loader/Http/HeadlessBrowserLoaderHelperTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace tests\Loader\Http;
+
+use Closure;
+use Crwlr\Crawler\Loader\Http\HeadlessBrowserLoaderHelper;
+use Crwlr\Crawler\Steps\Loading\Http;
+use GuzzleHttp\Psr7\Request;
+use HeadlessChromium\Browser\ProcessAwareBrowser;
+use HeadlessChromium\BrowserFactory;
+use HeadlessChromium\Communication\Session;
+use HeadlessChromium\Page;
+use HeadlessChromium\PageUtils\PageNavigation;
+use Mockery;
+
+use function tests\helper_getMinThrottler;
+
+function helper_setUpHeadlessChromeMocks(
+    ?Closure $pageNavigationArgsClosure = null,
+): BrowserFactory {
+    $browserFactoryMock = Mockery::mock(BrowserFactory::class);
+
+    $browserMock = Mockery::mock(ProcessAwareBrowser::class);
+
+    $browserFactoryMock->shouldReceive('createBrowser')->andReturn($browserMock);
+
+    $pageMock = Mockery::mock(Page::class);
+
+    $browserMock->shouldReceive('createPage')->andReturn($pageMock);
+
+    $sessionMock = Mockery::mock(Session::class);
+
+    $pageMock->shouldReceive('getSession')->andReturn($sessionMock);
+
+    $sessionMock->shouldReceive('once');
+
+    $pageNavigationMock = Mockery::mock(PageNavigation::class);
+
+    $pageMock->shouldReceive('navigate')->andReturn($pageNavigationMock);
+
+    $pageMock->shouldReceive('getHtml')->andReturn('<html><head></head><body>Hello World!</body></html>');
+
+    $waitForNavigationCall = $pageNavigationMock->shouldReceive('waitForNavigation');
+
+    if ($pageNavigationArgsClosure) {
+        $waitForNavigationCall->withArgs($pageNavigationArgsClosure);
+    }
+
+    return $browserFactoryMock;
+}
+
+it('uses the configured timeout', function () {
+    $browserFactoryMock = helper_setUpHeadlessChromeMocks(function (string $event, int $timeout) {
+        return $event === Page::LOAD && $timeout === 45_000;
+    });
+
+    $helper = new HeadlessBrowserLoaderHelper($browserFactoryMock);
+
+    $helper->setTimeout(45_000);
+
+    $response = $helper->navigateToPageAndGetRespondedRequest(
+        new Request('GET', 'https://www.example.com/foo'),
+        helper_getMinThrottler(),
+    );
+
+    expect(Http::getBodyString($response))->toBe('<html><head></head><body>Hello World!</body></html>');
+});
+
+it('waits for the configured browser navigation event', function () {
+    $browserFactoryMock = helper_setUpHeadlessChromeMocks(function (string $event, int $timeout) {
+        return $event === Page::FIRST_MEANINGFUL_PAINT && $timeout === 57_000;
+    });
+
+    $helper = new HeadlessBrowserLoaderHelper($browserFactoryMock);
+
+    $helper
+        ->waitForNavigationEvent(Page::FIRST_MEANINGFUL_PAINT)
+        ->setTimeout(57_000);
+
+    $response = $helper->navigateToPageAndGetRespondedRequest(
+        new Request('GET', 'https://www.example.com/foo'),
+        helper_getMinThrottler(),
+    );
+
+    expect(Http::getBodyString($response))->toBe('<html><head></head><body>Hello World!</body></html>');
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -6,6 +6,7 @@ use Crwlr\Crawler\HttpCrawler;
 use Crwlr\Crawler\Input;
 use Crwlr\Crawler\Loader\Http\HttpLoader;
 use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Loader\Http\Politeness\Throttler;
 use Crwlr\Crawler\Loader\Http\Politeness\TimingUnits\MultipleOf;
 use Crwlr\Crawler\Loader\LoaderInterface;
 use Crwlr\Crawler\Output;
@@ -280,6 +281,11 @@ function helper_getFastCrawler(): HttpCrawler
             return helper_getFastLoader($userAgent, $logger);
         }
     };
+}
+
+function helper_getMinThrottler(): Throttler
+{
+    return new Throttler(new MultipleOf(0.0001), new MultipleOf(0.0002), Microseconds::fromSeconds(0.0001));
 }
 
 /**


### PR DESCRIPTION
New methods `HeadlessBrowserLoaderHelper::setTimeout()` and `HeadlessBrowserLoaderHelper::waitForNavigationEvent()` to allow defining the timeout for the headless chrome in milliseconds (default 30000 = 30 seconds) and the navigation event (`load` (default), `DOMContentLoaded`, `firstMeaningfulPaint`, `networkIdle`, etc.) to wait for when loading a URL.