### PR TITLE
Also add a getTimeout() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.1] - 2024-06-17
+### Added
+* Also add `HeadlessBrowserLoaderHelper::getTimeout()` to get the currently configured timeout value.
+
 ## [1.9.0] - 2024-06-17
 ### Added
 * New methods `HeadlessBrowserLoaderHelper::setTimeout()` and `HeadlessBrowserLoaderHelper::waitForNavigationEvent()` to allow defining the timeout for the headless chrome in milliseconds (default 30000 = 30 seconds) and the navigation event (`load` (default), `DOMContentLoaded`, `firstMeaningfulPaint`, `networkIdle`, etc.) to wait for when loading a URL.

--- a/src/Loader/Http/HeadlessBrowserLoaderHelper.php
+++ b/src/Loader/Http/HeadlessBrowserLoaderHelper.php
@@ -158,6 +158,11 @@ class HeadlessBrowserLoaderHelper
         return $this;
     }
 
+    public function getTimeout(): int
+    {
+        return $this->timeout;
+    }
+
     public function setTimeout(int $timeout): static
     {
         $this->timeout = $timeout;

--- a/tests/Loader/Http/HeadlessBrowserLoaderHelperTest.php
+++ b/tests/Loader/Http/HeadlessBrowserLoaderHelperTest.php
@@ -66,6 +66,16 @@ it('uses the configured timeout', function () {
     expect(Http::getBodyString($response))->toBe('<html><head></head><body>Hello World!</body></html>');
 });
 
+it('returns the configured timeout', function () {
+    $helper = new HeadlessBrowserLoaderHelper();
+
+    expect($helper->getTimeout())->toBe(30_000);
+
+    $helper->setTimeout(75_000);
+
+    expect($helper->getTimeout())->toBe(75_000);
+});
+
 it('waits for the configured browser navigation event', function () {
     $browserFactoryMock = helper_setUpHeadlessChromeMocks(function (string $event, int $timeout) {
         return $event === Page::FIRST_MEANINGFUL_PAINT && $timeout === 57_000;


### PR DESCRIPTION
So we're able to get the currently configured timeout value for the headless chrome browser.