### PR TITLE
Replace browserHelper() with browser()

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -2,13 +2,15 @@
 
 use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 
 $finder = Finder::create()
     ->exclude(['tests/_Integration/_Server', '.github', 'bin', 'git-hooks'])
     ->in(__DIR__);
-$config = new Config();
 
-return $config->setFinder($finder)
+return (new Config())
+    ->setFinder($finder)
+    ->setParallelConfig(ParallelConfigFactory::detect())
     ->setRules([
         '@PER-CS' => true,
         'strict_param' => true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.3] - 2024-07-05
+### Fixed
+* Add `HttpLoader::browser()` as a replacement for `HttpLoader::browserHelper()` and deprecate the `browserHelper()` method. It's an alias and just because it will read a little better: `$loader->browser()->xyz()` vs. `$loader->browserHelper()->xyz()`. `HttpLoader::browserHelper()` will be removed in v2.0.
+* Also deprecate `HttpLoader::setHeadlessBrowserOptions()`, `HttpLoader::addHeadlessBrowserOptions()` and `HttpLoader::setChromeExecutable()`. Use `$loader->browser()->setOptions()`, `$loader->browser()->addOptions()` and `$loader->browser()->setExecutable()` instead.
+
 ## [1.9.2] - 2024-06-18
 ### Fixed
 * Issue with setting the headless chrome executable, introduced in 1.9.0. 

--- a/src/Loader/Http/HttpLoader.php
+++ b/src/Loader/Http/HttpLoader.php
@@ -216,7 +216,7 @@ class HttpLoader extends Loader
     {
         $this->useHeadlessBrowser = false;
 
-        $this->browserHelper()->closeBrowser();
+        $this->browser()->closeBrowser();
 
         return $this;
     }
@@ -228,27 +228,32 @@ class HttpLoader extends Loader
 
     /**
      * @param array<string, mixed> $options
+     * @deprecated Will be removed in v2.0. Use `$loader->browser()->setOptions()` instead.
      */
     public function setHeadlessBrowserOptions(array $options): static
     {
-        $this->browserHelper()->setOptions($options);
+        $this->browser()->setOptions($options);
 
         return $this;
     }
 
     /**
      * @param array<string, mixed> $options
+     * @deprecated Will be removed in v2.0. Use `$loader->browser()->addOptions()` instead.
      */
     public function addHeadlessBrowserOptions(array $options): static
     {
-        $this->browserHelper()->addOptions($options);
+        $this->browser()->addOptions($options);
 
         return $this;
     }
 
+    /**
+     * @deprecated Will be removed in v2.0. Use `$loader->browser()->setExecutable()` instead.
+     */
     public function setChromeExecutable(string $executable): static
     {
-        $this->browserHelper()->setExecutable($executable);
+        $this->browser()->setExecutable($executable);
 
         return $this;
     }
@@ -316,7 +321,15 @@ class HttpLoader extends Loader
         $this->proxies = new ProxyManager($proxyUrls);
     }
 
+    /**
+     * @deprecated Will be removed in v2.0. Use browser() instead, it's an alias.
+     */
     public function browserHelper(): HeadlessBrowserLoaderHelper
+    {
+        return $this->browser();
+    }
+
+    public function browser(): HeadlessBrowserLoaderHelper
     {
         if (!$this->browserHelper) {
             $this->browserHelper = new HeadlessBrowserLoaderHelper();
@@ -413,7 +426,7 @@ class HttpLoader extends Loader
         if ($this->useHeadlessBrowser) {
             $proxy = $this->proxies?->getProxy() ?? null;
 
-            return $this->browserHelper()->navigateToPageAndGetRespondedRequest($request, $this->throttler, $proxy);
+            return $this->browser()->navigateToPageAndGetRespondedRequest($request, $this->throttler, $proxy);
         }
 
         return $this->handleRedirects($request);


### PR DESCRIPTION
Add `HttpLoader::browser()` as a replacement for
`HttpLoader::browserHelper()` and deprecate the `browserHelper()` method. It's an alias and just because it will read a little better: `$loader->browser()->xyz()` vs. `$loader->browserHelper()->xyz()`. `HttpLoader::browserHelper()` will be removed in v2.0.

Also deprecate `HttpLoader::setHeadlessBrowserOptions()`, `HttpLoader::addHeadlessBrowserOptions()` and
`HttpLoader::setChromeExecutable()`. Use
`$loader->browser()->setOptions()`, `$loader->browser()->addOptions()` and `$loader->browser()->setExecutable()` instead.

Further also try parallelisation in PHP CS Fixer.