### PR TITLE
Mozilla 5.0 compatible user agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+* Static method `UserAgent::mozilla5CompatibleBrowser()` to get a `UserAgent` instance with the user agent string `Mozilla/5.0 (compatible)` and also the new method `withMozilla5CompatibleUserAgent` in the `AnonymousHttpCrawlerBuilder` that you can use like this: `HttpCrawler::make()->withMozilla5CompatibleUserAgent()`.
 
 ## [1.9.5] - 2024-07-25
 ### Fixed

--- a/src/HttpCrawler/AnonymousHttpCrawlerBuilder.php
+++ b/src/HttpCrawler/AnonymousHttpCrawlerBuilder.php
@@ -25,7 +25,7 @@ class AnonymousHttpCrawlerBuilder
         return $instance;
     }
 
-    public function withUserAgent(string $userAgent): HttpCrawler
+    public function withUserAgent(string|UserAgentInterface $userAgent): HttpCrawler
     {
         $instance = new class () extends HttpCrawler {
             protected function userAgent(): UserAgentInterface
@@ -34,8 +34,15 @@ class AnonymousHttpCrawlerBuilder
             }
         };
 
-        $instance->setUserAgent(new UserAgent($userAgent));
+        $userAgent = $userAgent instanceof UserAgentInterface ? $userAgent : new UserAgent($userAgent);
+
+        $instance->setUserAgent($userAgent);
 
         return $instance;
+    }
+
+    public function withMozilla5CompatibleUserAgent(): HttpCrawler
+    {
+        return $this->withUserAgent(UserAgent::mozilla5CompatibleBrowser());
     }
 }

--- a/src/UserAgents/UserAgent.php
+++ b/src/UserAgents/UserAgent.php
@@ -10,4 +10,9 @@ class UserAgent implements UserAgentInterface
     {
         return $this->userAgent;
     }
+
+    public static function mozilla5CompatibleBrowser(): self
+    {
+        return new self('Mozilla/5.0 (compatible)');
+    }
 }

--- a/tests/HttpCrawler/AnonymousHttpCrawlerBuilderTest.php
+++ b/tests/HttpCrawler/AnonymousHttpCrawlerBuilderTest.php
@@ -39,3 +39,11 @@ it('creates an HttpCrawler instance with a non bot user agent', function () {
 
     expect($userAgent->__toString())->toBe('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ...');
 });
+
+it('creates an HttpCrawler instance with a mozilla 5.0 compatible user agent', function () {
+    $crawler = HttpCrawler::make()->withMozilla5CompatibleUserAgent();
+
+    $userAgent = $crawler->getLoader()->userAgent();
+
+    expect($userAgent->__toString())->toBe('Mozilla/5.0 (compatible)');
+});


### PR DESCRIPTION
Static method `UserAgent::mozilla5CompatibleBrowser()` to get a `UserAgent` instance with the user agent string
`Mozilla/5.0 (compatible)` and also the new method `withMozilla5CompatibleUserAgent` in the `AnonymousHttpCrawlerBuilder` that you can use like this:
`HttpCrawler::make()->withMozilla5CompatibleUserAgent()`.