### PR TITLE
Add URL refiners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 * Static method `UserAgent::mozilla5CompatibleBrowser()` to get a `UserAgent` instance with the user agent string `Mozilla/5.0 (compatible)` and also the new method `withMozilla5CompatibleUserAgent` in the `AnonymousHttpCrawlerBuilder` that you can use like this: `HttpCrawler::make()->withMozilla5CompatibleUserAgent()`.
+* URL refiners: `UrlRefiner::withScheme()`, `UrlRefiner::withHost()`, `UrlRefiner::withPort()`, `UrlRefiner::withoutPort()`, `UrlRefiner::withPath()`, `UrlRefiner::withQuery()`, `UrlRefiner::withoutQuery()`, `UrlRefiner::withFragment()` and `UrlRefiner::withoutFragment()`.
 
 ## [1.9.5] - 2024-07-25
 ### Fixed

--- a/src/Steps/Refiners/String/StrAfterFirst.php
+++ b/src/Steps/Refiners/String/StrAfterFirst.php
@@ -11,7 +11,7 @@ class StrAfterFirst extends AbstractRefiner
     public function refine(mixed $value): mixed
     {
         if (!is_string($value)) {
-            $this->logTypeWarning('Str::afterFirst()', $value);
+            $this->logTypeWarning('StringRefiner::afterFirst()', $value);
 
             return $value;
         }

--- a/src/Steps/Refiners/String/StrAfterLast.php
+++ b/src/Steps/Refiners/String/StrAfterLast.php
@@ -11,7 +11,7 @@ class StrAfterLast extends AbstractRefiner
     public function refine(mixed $value): mixed
     {
         if (!is_string($value)) {
-            $this->logTypeWarning('Str::afterLast()', $value);
+            $this->logTypeWarning('StringRefiner::afterLast()', $value);
 
             return $value;
         }

--- a/src/Steps/Refiners/String/StrBeforeFirst.php
+++ b/src/Steps/Refiners/String/StrBeforeFirst.php
@@ -11,7 +11,7 @@ class StrBeforeFirst extends AbstractRefiner
     public function refine(mixed $value): mixed
     {
         if (!is_string($value)) {
-            $this->logTypeWarning('Str::beforeFirst()', $value);
+            $this->logTypeWarning('StringRefiner::beforeFirst()', $value);
 
             return $value;
         }

--- a/src/Steps/Refiners/String/StrBeforeLast.php
+++ b/src/Steps/Refiners/String/StrBeforeLast.php
@@ -11,7 +11,7 @@ class StrBeforeLast extends AbstractRefiner
     public function refine(mixed $value): mixed
     {
         if (!is_string($value)) {
-            $this->logTypeWarning('Str::beforeLast()', $value);
+            $this->logTypeWarning('StringRefiner::beforeLast()', $value);
 
             return $value;
         }

--- a/src/Steps/Refiners/String/StrBetweenFirst.php
+++ b/src/Steps/Refiners/String/StrBetweenFirst.php
@@ -11,7 +11,7 @@ class StrBetweenFirst extends AbstractRefiner
     public function refine(mixed $value): mixed
     {
         if (!is_string($value)) {
-            $this->logTypeWarning('Str::betweenFirst()', $value);
+            $this->logTypeWarning('StringRefiner::betweenFirst()', $value);
 
             return $value;
         }

--- a/src/Steps/Refiners/String/StrBetweenLast.php
+++ b/src/Steps/Refiners/String/StrBetweenLast.php
@@ -11,7 +11,7 @@ class StrBetweenLast extends AbstractRefiner
     public function refine(mixed $value): mixed
     {
         if (!is_string($value)) {
-            $this->logTypeWarning('Str::betweenLast()', $value);
+            $this->logTypeWarning('StringRefiner::betweenLast()', $value);
 
             return $value;
         }

--- a/src/Steps/Refiners/String/StrReplace.php
+++ b/src/Steps/Refiners/String/StrReplace.php
@@ -18,7 +18,7 @@ class StrReplace extends AbstractRefiner
     public function refine(mixed $value): mixed
     {
         if (!is_string($value)) {
-            $this->logTypeWarning('Str::replace()', $value);
+            $this->logTypeWarning('StringRefiner::replace()', $value);
 
             return $value;
         }

--- a/src/Steps/Refiners/Url/AbstractUrlRefiner.php
+++ b/src/Steps/Refiners/Url/AbstractUrlRefiner.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Refiners\Url;
+
+use Crwlr\Crawler\Steps\Refiners\AbstractRefiner;
+use Crwlr\Url\Exceptions\InvalidUrlComponentException;
+use Crwlr\Url\Url;
+use Exception;
+use Psr\Http\Message\UriInterface;
+
+abstract class AbstractUrlRefiner extends AbstractRefiner
+{
+    /**
+     * @throws InvalidUrlComponentException|Exception
+     */
+    public function refine(mixed $value): mixed
+    {
+        if (!is_string($value) && !$value instanceof Url && !$value instanceof UriInterface) {
+            $this->logTypeWarning($this->staticRefinerMethod(), $value);
+
+            return $value;
+        }
+
+        if (!$value instanceof Url) {
+            $value = Url::parse($value);
+        }
+
+        return $this->refineUrl($value);
+    }
+
+    abstract protected function staticRefinerMethod(): string;
+
+    abstract protected function refineUrl(Url $url): string;
+}

--- a/src/Steps/Refiners/Url/WithFragment.php
+++ b/src/Steps/Refiners/Url/WithFragment.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Refiners\Url;
+
+use Crwlr\Url\Exceptions\InvalidUrlComponentException;
+use Crwlr\Url\Url;
+use Exception;
+
+class WithFragment extends AbstractUrlRefiner
+{
+    public function __construct(protected readonly string $fragment) {}
+
+    protected function staticRefinerMethod(): string
+    {
+        return 'UrlRefiner::withFragment()';
+    }
+
+    /**
+     * @throws InvalidUrlComponentException|Exception
+     */
+    protected function refineUrl(Url $url): string
+    {
+        $url->fragment($this->fragment);
+
+        return (string) $url;
+    }
+}

--- a/src/Steps/Refiners/Url/WithHost.php
+++ b/src/Steps/Refiners/Url/WithHost.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Refiners\Url;
+
+use Crwlr\Url\Exceptions\InvalidUrlComponentException;
+use Crwlr\Url\Url;
+use Exception;
+
+class WithHost extends AbstractUrlRefiner
+{
+    public function __construct(protected readonly string $host) {}
+
+    protected function staticRefinerMethod(): string
+    {
+        return 'UrlRefiner::withHost()';
+    }
+
+    /**
+     * @throws InvalidUrlComponentException|Exception
+     */
+    protected function refineUrl(Url $url): string
+    {
+        $url->host($this->host);
+
+        return (string) $url;
+    }
+}

--- a/src/Steps/Refiners/Url/WithPath.php
+++ b/src/Steps/Refiners/Url/WithPath.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Refiners\Url;
+
+use Crwlr\Url\Exceptions\InvalidUrlComponentException;
+use Crwlr\Url\Url;
+use Exception;
+
+class WithPath extends AbstractUrlRefiner
+{
+    public function __construct(protected readonly string $path) {}
+
+    protected function staticRefinerMethod(): string
+    {
+        return 'UrlRefiner::withPath()';
+    }
+
+    /**
+     * @throws InvalidUrlComponentException|Exception
+     */
+    protected function refineUrl(Url $url): string
+    {
+        $url->path($this->path);
+
+        return (string) $url;
+    }
+}

--- a/src/Steps/Refiners/Url/WithPort.php
+++ b/src/Steps/Refiners/Url/WithPort.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Refiners\Url;
+
+use Crwlr\Url\Exceptions\InvalidUrlComponentException;
+use Crwlr\Url\Url;
+use Exception;
+
+class WithPort extends AbstractUrlRefiner
+{
+    public function __construct(protected readonly int $port) {}
+
+    protected function staticRefinerMethod(): string
+    {
+        return 'UrlRefiner::withPort()';
+    }
+
+    /**
+     * @throws InvalidUrlComponentException|Exception
+     */
+    protected function refineUrl(Url $url): string
+    {
+        $url->port($this->port);
+
+        return (string) $url;
+    }
+}

--- a/src/Steps/Refiners/Url/WithQuery.php
+++ b/src/Steps/Refiners/Url/WithQuery.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Refiners\Url;
+
+use Crwlr\Url\Exceptions\InvalidUrlComponentException;
+use Crwlr\Url\Url;
+use Exception;
+
+class WithQuery extends AbstractUrlRefiner
+{
+    public function __construct(protected readonly string $query) {}
+
+    protected function staticRefinerMethod(): string
+    {
+        return 'UrlRefiner::withQuery()';
+    }
+
+    /**
+     * @throws InvalidUrlComponentException|Exception
+     */
+    protected function refineUrl(Url $url): string
+    {
+        $url->query($this->query);
+
+        return (string) $url;
+    }
+}

--- a/src/Steps/Refiners/Url/WithScheme.php
+++ b/src/Steps/Refiners/Url/WithScheme.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Refiners\Url;
+
+use Crwlr\Url\Exceptions\InvalidUrlComponentException;
+use Crwlr\Url\Url;
+use Exception;
+
+class WithScheme extends AbstractUrlRefiner
+{
+    public function __construct(protected readonly string $scheme) {}
+
+    protected function staticRefinerMethod(): string
+    {
+        return 'UrlRefiner::withScheme()';
+    }
+
+    /**
+     * @throws InvalidUrlComponentException|Exception
+     */
+    protected function refineUrl(Url $url): string
+    {
+        $url->scheme($this->scheme);
+
+        return (string) $url;
+    }
+}

--- a/src/Steps/Refiners/Url/WithoutPort.php
+++ b/src/Steps/Refiners/Url/WithoutPort.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Refiners\Url;
+
+use Crwlr\Url\Exceptions\InvalidUrlComponentException;
+use Crwlr\Url\Url;
+use Exception;
+
+class WithoutPort extends AbstractUrlRefiner
+{
+    protected function staticRefinerMethod(): string
+    {
+        return 'UrlRefiner::withoutPort()';
+    }
+
+    /**
+     * @throws InvalidUrlComponentException|Exception
+     */
+    protected function refineUrl(Url $url): string
+    {
+        $url->resetPort();
+
+        return (string) $url;
+    }
+}

--- a/src/Steps/Refiners/UrlRefiner.php
+++ b/src/Steps/Refiners/UrlRefiner.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Refiners;
+
+use Crwlr\Crawler\Steps\Refiners\Url\WithFragment;
+use Crwlr\Crawler\Steps\Refiners\Url\WithHost;
+use Crwlr\Crawler\Steps\Refiners\Url\WithoutPort;
+use Crwlr\Crawler\Steps\Refiners\Url\WithPath;
+use Crwlr\Crawler\Steps\Refiners\Url\WithPort;
+use Crwlr\Crawler\Steps\Refiners\Url\WithQuery;
+use Crwlr\Crawler\Steps\Refiners\Url\WithScheme;
+
+class UrlRefiner
+{
+    public static function withScheme(string $scheme): WithScheme
+    {
+        return new WithScheme($scheme);
+    }
+
+    public static function withHost(string $host): WithHost
+    {
+        return new WithHost($host);
+    }
+
+    public static function withPort(int $port): WithPort
+    {
+        return new WithPort($port);
+    }
+
+    public static function withoutPort(): WithoutPort
+    {
+        return new WithoutPort();
+    }
+
+    public static function withPath(string $path): WithPath
+    {
+        return new WithPath($path);
+    }
+
+    public static function withQuery(string $query): WithQuery
+    {
+        return new WithQuery($query);
+    }
+
+    public static function withoutQuery(): WithQuery
+    {
+        return new WithQuery('');
+    }
+
+    public static function withFragment(string $fragment): WithFragment
+    {
+        return new WithFragment($fragment);
+    }
+
+    public static function withoutFragment(): WithFragment
+    {
+        return new WithFragment('');
+    }
+}

--- a/tests/Steps/Refiners/String/AfterFirstTest.php
+++ b/tests/Steps/Refiners/String/AfterFirstTest.php
@@ -15,7 +15,7 @@ it('logs a warning and returns the unchanged value when $value is not of type st
 
     $logOutput = $this->getActualOutputForAssertion();
 
-    expect($logOutput)->toContain('Refiner Str::afterFirst() can\'t be applied to value of type ' . gettype($value));
+    expect($logOutput)->toContain('Refiner StringRefiner::afterFirst() can\'t be applied to value of type ' . gettype($value));
 
     expect($refinedValue)->toBe($value);
 })->with([

--- a/tests/Steps/Refiners/String/AfterLastTest.php
+++ b/tests/Steps/Refiners/String/AfterLastTest.php
@@ -15,7 +15,7 @@ it('logs a warning and returns the unchanged value when $value is not of type st
 
     $logOutput = $this->getActualOutputForAssertion();
 
-    expect($logOutput)->toContain('Refiner Str::afterLast() can\'t be applied to value of type ' . gettype($value));
+    expect($logOutput)->toContain('Refiner StringRefiner::afterLast() can\'t be applied to value of type ' . gettype($value));
 
     expect($refinedValue)->toBe($value);
 })->with([

--- a/tests/Steps/Refiners/String/BeforeFirstTest.php
+++ b/tests/Steps/Refiners/String/BeforeFirstTest.php
@@ -15,7 +15,7 @@ it('logs a warning and returns the unchanged value when $value is not of type st
 
     $logOutput = $this->getActualOutputForAssertion();
 
-    expect($logOutput)->toContain('Refiner Str::beforeFirst() can\'t be applied to value of type ' . gettype($value));
+    expect($logOutput)->toContain('Refiner StringRefiner::beforeFirst() can\'t be applied to value of type ' . gettype($value));
 
     expect($refinedValue)->toBe($value);
 })->with([

--- a/tests/Steps/Refiners/String/BeforeLastTest.php
+++ b/tests/Steps/Refiners/String/BeforeLastTest.php
@@ -15,7 +15,7 @@ it('logs a warning and returns the unchanged value when $value is not of type st
 
     $logOutput = $this->getActualOutputForAssertion();
 
-    expect($logOutput)->toContain('Refiner Str::beforeLast() can\'t be applied to value of type ' . gettype($value));
+    expect($logOutput)->toContain('Refiner StringRefiner::beforeLast() can\'t be applied to value of type ' . gettype($value));
 
     expect($refinedValue)->toBe($value);
 })->with([

--- a/tests/Steps/Refiners/String/BetweenFirstTest.php
+++ b/tests/Steps/Refiners/String/BetweenFirstTest.php
@@ -15,7 +15,7 @@ it('logs a warning and returns the unchanged value when $value is not of type st
 
     $logOutput = $this->getActualOutputForAssertion();
 
-    expect($logOutput)->toContain('Refiner Str::betweenFirst() can\'t be applied to value of type ' . gettype($value));
+    expect($logOutput)->toContain('Refiner StringRefiner::betweenFirst() can\'t be applied to value of type ' . gettype($value));
 
     expect($refinedValue)->toBe($value);
 })->with([

--- a/tests/Steps/Refiners/String/BetweenLastTest.php
+++ b/tests/Steps/Refiners/String/BetweenLastTest.php
@@ -15,7 +15,7 @@ it('logs a warning and returns the unchanged value when $value is not of type st
 
     $logOutput = $this->getActualOutputForAssertion();
 
-    expect($logOutput)->toContain('Refiner Str::betweenLast() can\'t be applied to value of type ' . gettype($value));
+    expect($logOutput)->toContain('Refiner StringRefiner::betweenLast() can\'t be applied to value of type ' . gettype($value));
 
     expect($refinedValue)->toBe($value);
 })->with([

--- a/tests/Steps/Refiners/String/ReplaceTest.php
+++ b/tests/Steps/Refiners/String/ReplaceTest.php
@@ -15,7 +15,7 @@ it('logs a warning and returns the unchanged value when $value is not of type st
 
     $logOutput = $this->getActualOutputForAssertion();
 
-    expect($logOutput)->toContain('Refiner Str::replace() can\'t be applied to value of type ' . gettype($value));
+    expect($logOutput)->toContain('Refiner StringRefiner::replace() can\'t be applied to value of type ' . gettype($value));
 
     expect($refinedValue)->toBe($value);
 })->with([

--- a/tests/Steps/Refiners/Url/WithFragmentTest.php
+++ b/tests/Steps/Refiners/Url/WithFragmentTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace tests\Steps\Refiners\Url;
+
+use Crwlr\Crawler\Logger\CliLogger;
+use Crwlr\Crawler\Steps\Refiners\UrlRefiner;
+use Crwlr\Url\Url;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/** @var TestCase $this */
+
+it(
+    'logs a warning and returns the unchanged value when $value is not a string or instance of UriInterface',
+    function (mixed $value) {
+        $refinedValue = UrlRefiner::withFragment('foo')
+            ->addLogger(new CliLogger())
+            ->refine($value);
+
+        $logOutput = $this->getActualOutputForAssertion();
+
+        expect($logOutput)
+            ->toContain('Refiner UrlRefiner::withFragment() can\'t be applied to value of type ' . gettype($value))
+            ->and($refinedValue)->toBe($value);
+    },
+)->with([
+    [123],
+    [true],
+    [new stdClass()],
+]);
+
+it('replaces the query in a URL', function (mixed $value, string $expected) {
+    expect(UrlRefiner::withFragment('#lorem')->refine($value))->toBe($expected);
+})->with([
+    ['https://www.example.com/path#foo', 'https://www.example.com/path#lorem'],
+    ['https://www.example.com/path', 'https://www.example.com/path#lorem'],
+    [Url::parse('https://www.crwlr.software/some/path#abc'), 'https://www.crwlr.software/some/path#lorem'],
+    [Url::parsePsr7('https://www.crwl.io/quz#'), 'https://www.crwl.io/quz#lorem'],
+]);
+
+it('resets any query', function (mixed $value, string $expected) {
+    expect(UrlRefiner::withoutFragment()->refine($value))->toBe($expected);
+})->with([
+    ['https://www.example.com/foo#bar', 'https://www.example.com/foo'],
+    ['https://www.crwlr.software/#', 'https://www.crwlr.software/'],
+]);

--- a/tests/Steps/Refiners/Url/WithHostTest.php
+++ b/tests/Steps/Refiners/Url/WithHostTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace tests\Steps\Refiners\Url;
+
+use Crwlr\Crawler\Logger\CliLogger;
+use Crwlr\Crawler\Steps\Refiners\UrlRefiner;
+use Crwlr\Url\Url;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/** @var TestCase $this */
+
+it(
+    'logs a warning and returns the unchanged value when $value is not a string or instance of UriInterface',
+    function (mixed $value) {
+        $refinedValue = UrlRefiner::withHost('www.crwlr.software')
+            ->addLogger(new CliLogger())
+            ->refine($value);
+
+        $logOutput = $this->getActualOutputForAssertion();
+
+        expect($logOutput)
+            ->toContain('Refiner UrlRefiner::withHost() can\'t be applied to value of type ' . gettype($value))
+            ->and($refinedValue)->toBe($value);
+    },
+)->with([
+    [123],
+    [true],
+    [new stdClass()],
+]);
+
+it('replaces the host in a URL', function (mixed $value, string $expected) {
+    expect(UrlRefiner::withHost('www.crwlr.software')->refine($value))->toBe($expected);
+})->with([
+    ['https://www.example.com/foo', 'https://www.crwlr.software/foo'],
+    ['https://www.crwl.io/bar', 'https://www.crwlr.software/bar'],
+    [Url::parse('https://www.crwlr.software/baz'), 'https://www.crwlr.software/baz'],
+    [Url::parsePsr7('https://crwl.io/quz'), 'https://www.crwlr.software/quz'],
+]);

--- a/tests/Steps/Refiners/Url/WithPathTest.php
+++ b/tests/Steps/Refiners/Url/WithPathTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace tests\Steps\Refiners\Url;
+
+use Crwlr\Crawler\Logger\CliLogger;
+use Crwlr\Crawler\Steps\Refiners\UrlRefiner;
+use Crwlr\Url\Url;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/** @var TestCase $this */
+
+it(
+    'logs a warning and returns the unchanged value when $value is not a string or instance of UriInterface',
+    function (mixed $value) {
+        $refinedValue = UrlRefiner::withPath('/home')
+            ->addLogger(new CliLogger())
+            ->refine($value);
+
+        $logOutput = $this->getActualOutputForAssertion();
+
+        expect($logOutput)
+            ->toContain('Refiner UrlRefiner::withPath() can\'t be applied to value of type ' . gettype($value))
+            ->and($refinedValue)->toBe($value);
+    },
+)->with([
+    [123],
+    [true],
+    [new stdClass()],
+]);
+
+it('replaces the path in a URL', function (mixed $value, string $expected) {
+    expect(UrlRefiner::withPath('/some/path/123')->refine($value))->toBe($expected);
+})->with([
+    ['https://www.example.com/foo', 'https://www.example.com/some/path/123'],
+    ['https://localhost/yo', 'https://localhost/some/path/123'],
+    [Url::parse('https://www.crwlr.software/packages'), 'https://www.crwlr.software/some/path/123'],
+    [Url::parsePsr7('https://www.crwl.io/'), 'https://www.crwl.io/some/path/123'],
+]);

--- a/tests/Steps/Refiners/Url/WithPortTest.php
+++ b/tests/Steps/Refiners/Url/WithPortTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace tests\Steps\Refiners\Url;
+
+use Crwlr\Crawler\Logger\CliLogger;
+use Crwlr\Crawler\Steps\Refiners\UrlRefiner;
+use Crwlr\Url\Url;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/** @var TestCase $this */
+
+it(
+    'logs a warning and returns the unchanged value when $value is not a string or instance of UriInterface',
+    function (mixed $value) {
+        $refinedValue = UrlRefiner::withPort(1234)
+            ->addLogger(new CliLogger())
+            ->refine($value);
+
+        $logOutput = $this->getActualOutputForAssertion();
+
+        expect($logOutput)
+            ->toContain('Refiner UrlRefiner::withPort() can\'t be applied to value of type ' . gettype($value))
+            ->and($refinedValue)->toBe($value);
+    },
+)->with([
+    [123],
+    [true],
+    [new stdClass()],
+]);
+
+it('replaces the port in a URL', function (mixed $value, string $expected) {
+    expect(UrlRefiner::withPort(1234)->refine($value))->toBe($expected);
+})->with([
+    ['https://www.example.com:8000/foo', 'https://www.example.com:1234/foo'],
+    ['https://localhost:8080/yo', 'https://localhost:1234/yo'],
+    [Url::parse('https://www.crwlr.software:5678/bar'), 'https://www.crwlr.software:1234/bar'],
+    [Url::parsePsr7('https://crwl.io/quz'), 'https://crwl.io:1234/quz'],
+]);

--- a/tests/Steps/Refiners/Url/WithQueryTest.php
+++ b/tests/Steps/Refiners/Url/WithQueryTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace tests\Steps\Refiners\Url;
+
+use Crwlr\Crawler\Logger\CliLogger;
+use Crwlr\Crawler\Steps\Refiners\UrlRefiner;
+use Crwlr\Url\Url;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/** @var TestCase $this */
+
+it(
+    'logs a warning and returns the unchanged value when $value is not a string or instance of UriInterface',
+    function (mixed $value) {
+        $refinedValue = UrlRefiner::withQuery('a=b&c=d')
+            ->addLogger(new CliLogger())
+            ->refine($value);
+
+        $logOutput = $this->getActualOutputForAssertion();
+
+        expect($logOutput)
+            ->toContain('Refiner UrlRefiner::withQuery() can\'t be applied to value of type ' . gettype($value))
+            ->and($refinedValue)->toBe($value);
+    },
+)->with([
+    [123],
+    [true],
+    [new stdClass()],
+]);
+
+it('replaces the query in a URL', function (mixed $value, string $expected) {
+    expect(UrlRefiner::withQuery('a=b&c=d')->refine($value))->toBe($expected);
+})->with([
+    ['https://www.example.com/foo?one=two', 'https://www.example.com/foo?a=b&c=d'],
+    ['https://www.example.com/bar', 'https://www.example.com/bar?a=b&c=d'],
+    [Url::parse('https://www.crwlr.software/?'), 'https://www.crwlr.software/?a=b&c=d'],
+    [Url::parsePsr7('https://www.crwl.io/quz?a=c&b=d'), 'https://www.crwl.io/quz?a=b&c=d'],
+]);
+
+it('resets any query', function (mixed $value, string $expected) {
+    expect(UrlRefiner::withoutQuery()->refine($value))->toBe($expected);
+})->with([
+    ['https://www.example.com/foo?one=two', 'https://www.example.com/foo'],
+    ['https://www.crwlr.software/?', 'https://www.crwlr.software/'],
+]);

--- a/tests/Steps/Refiners/Url/WithSchemeTest.php
+++ b/tests/Steps/Refiners/Url/WithSchemeTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace tests\Steps\Refiners\Url;
+
+use Crwlr\Crawler\Logger\CliLogger;
+use Crwlr\Crawler\Steps\Refiners\UrlRefiner;
+use Crwlr\Url\Url;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/** @var TestCase $this */
+
+it(
+    'logs a warning and returns the unchanged value when $value is not a string or instance of UriInterface',
+    function (mixed $value) {
+        $refinedValue = UrlRefiner::withScheme('https')
+            ->addLogger(new CliLogger())
+            ->refine($value);
+
+        $logOutput = $this->getActualOutputForAssertion();
+
+        expect($logOutput)
+            ->toContain('Refiner UrlRefiner::withScheme() can\'t be applied to value of type ' . gettype($value))
+            ->and($refinedValue)->toBe($value);
+    },
+)->with([
+    [123],
+    [true],
+    [new stdClass()],
+]);
+
+it('replaces the scheme in a URL', function (mixed $value, string $expected) {
+    expect(UrlRefiner::withScheme('https')->refine($value))->toBe($expected);
+})->with([
+    ['http://www.example.com/foo', 'https://www.example.com/foo'],
+    ['https://www.example.com/foo', 'https://www.example.com/foo'],
+    [Url::parse('ftp://www.example.com/bar'), 'https://www.example.com/bar'],
+    [Url::parsePsr7('http://www.example.com/baz'), 'https://www.example.com/baz'],
+]);

--- a/tests/Steps/Refiners/Url/WithoutPortTest.php
+++ b/tests/Steps/Refiners/Url/WithoutPortTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace tests\Steps\Refiners\Url;
+
+use Crwlr\Crawler\Logger\CliLogger;
+use Crwlr\Crawler\Steps\Refiners\UrlRefiner;
+use Crwlr\Url\Url;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/** @var TestCase $this */
+
+it(
+    'logs a warning and returns the unchanged value when $value is not a string or instance of UriInterface',
+    function (mixed $value) {
+        $refinedValue = UrlRefiner::withoutPort()
+            ->addLogger(new CliLogger())
+            ->refine($value);
+
+        $logOutput = $this->getActualOutputForAssertion();
+
+        expect($logOutput)
+            ->toContain('Refiner UrlRefiner::withoutPort() can\'t be applied to value of type ' . gettype($value))
+            ->and($refinedValue)->toBe($value);
+    },
+)->with([
+    [123],
+    [true],
+    [new stdClass()],
+]);
+
+it('resets the port to null in a URL', function (mixed $value, string $expected) {
+    expect(UrlRefiner::withoutPort()->refine($value))->toBe($expected);
+})->with([
+    ['https://www.example.com:8000/foo', 'https://www.example.com/foo'],
+    ['http://localhost:8080/yo', 'http://localhost/yo'],
+    [Url::parse('https://www.crwlr.software:5678/bar'), 'https://www.crwlr.software/bar'],
+    [Url::parsePsr7('https://crwl.io/quz'), 'https://crwl.io/quz'],
+]);


### PR DESCRIPTION
Added `UrlRefiner::withScheme()`, `UrlRefiner::withHost()`, `UrlRefiner::withPort()`, `UrlRefiner::withoutPort()`, `UrlRefiner::withPath()`, `UrlRefiner::withQuery()`, `UrlRefiner::withoutQuery()`, `UrlRefiner::withFragment()` and `UrlRefiner::withoutFragment()` for simple URL refinement.

And also fix old forgotten occurences of Str::... to StringRefiner::...