### PR TITLE
New paginator stop rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.10.0] - 2024-08-05
 ### Added
-* Static method `UserAgent::mozilla5CompatibleBrowser()` to get a `UserAgent` instance with the user agent string `Mozilla/5.0 (compatible)` and also the new method `withMozilla5CompatibleUserAgent` in the `AnonymousHttpCrawlerBuilder` that you can use like this: `HttpCrawler::make()->withMozilla5CompatibleUserAgent()`.
 * URL refiners: `UrlRefiner::withScheme()`, `UrlRefiner::withHost()`, `UrlRefiner::withPort()`, `UrlRefiner::withoutPort()`, `UrlRefiner::withPath()`, `UrlRefiner::withQuery()`, `UrlRefiner::withoutQuery()`, `UrlRefiner::withFragment()` and `UrlRefiner::withoutFragment()`.
 * New paginator stop rules `PaginatorStopRules::contains()` and `PaginatorStopRules::notContains()`.
+* Static method `UserAgent::mozilla5CompatibleBrowser()` to get a `UserAgent` instance with the user agent string `Mozilla/5.0 (compatible)` and also the new method `withMozilla5CompatibleUserAgent` in the `AnonymousHttpCrawlerBuilder` that you can use like this: `HttpCrawler::make()->withMozilla5CompatibleUserAgent()`.
 
 ## [1.9.5] - 2024-07-25
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Static method `UserAgent::mozilla5CompatibleBrowser()` to get a `UserAgent` instance with the user agent string `Mozilla/5.0 (compatible)` and also the new method `withMozilla5CompatibleUserAgent` in the `AnonymousHttpCrawlerBuilder` that you can use like this: `HttpCrawler::make()->withMozilla5CompatibleUserAgent()`.
 * URL refiners: `UrlRefiner::withScheme()`, `UrlRefiner::withHost()`, `UrlRefiner::withPort()`, `UrlRefiner::withoutPort()`, `UrlRefiner::withPath()`, `UrlRefiner::withQuery()`, `UrlRefiner::withoutQuery()`, `UrlRefiner::withFragment()` and `UrlRefiner::withoutFragment()`.
+* New paginator stop rules `PaginatorStopRules::contains()` and `PaginatorStopRules::notContains()`.
 
 ## [1.9.5] - 2024-07-25
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-phpunit": "^1.0",
         "friendsofphp/php-cs-fixer": "^3.6",
-        "spatie/invade": "^1.0",
+        "spatie/invade": "^2.0",
         "symfony/process": "^6.0|^7.0"
     },
     "suggest": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,3 +8,5 @@ parameters:
             - tests/_Integration/_Server
     ignoreErrors:
         - "#^Call to an undefined method Pest\\\\PendingCalls\\\\TestCall\\|Pest\\\\Support\\\\HigherOrderTapProxy\\:\\:(with|throws)\\(\\).$#"
+        - "#^Access to an undefined property Spatie\\\\Invade\\\\Invader#"
+        - "#^Call to an undefined method Spatie\\\\Invade\\\\Invader#"

--- a/src/Steps/Loading/Http/Paginators/StopRules/Contains.php
+++ b/src/Steps/Loading/Http/Paginators/StopRules/Contains.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading\Http\Paginators\StopRules;
+
+use Crwlr\Crawler\Cache\Exceptions\MissingZlibExtensionException;
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Loading\Http;
+use Psr\Http\Message\RequestInterface;
+
+class Contains implements StopRule
+{
+    public function __construct(protected string $contains) {}
+
+    /**
+     * @throws MissingZlibExtensionException
+     */
+    public function shouldStop(RequestInterface $request, ?RespondedRequest $respondedRequest): bool
+    {
+        if (!$respondedRequest) {
+            return true;
+        }
+
+        $content = trim(Http::getBodyString($respondedRequest->response));
+
+        return str_contains($content, $this->contains);
+    }
+}

--- a/src/Steps/Loading/Http/Paginators/StopRules/NotContains.php
+++ b/src/Steps/Loading/Http/Paginators/StopRules/NotContains.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading\Http\Paginators\StopRules;
+
+use Crwlr\Crawler\Cache\Exceptions\MissingZlibExtensionException;
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Loading\Http;
+use Psr\Http\Message\RequestInterface;
+
+class NotContains implements StopRule
+{
+    public function __construct(protected string $contains) {}
+
+    /**
+     * @throws MissingZlibExtensionException
+     */
+    public function shouldStop(RequestInterface $request, ?RespondedRequest $respondedRequest): bool
+    {
+        if (!$respondedRequest) {
+            return true;
+        }
+
+        $content = trim(Http::getBodyString($respondedRequest->response));
+
+        return !str_contains($content, $this->contains);
+    }
+}

--- a/src/Steps/Loading/Http/Paginators/StopRules/PaginatorStopRules.php
+++ b/src/Steps/Loading/Http/Paginators/StopRules/PaginatorStopRules.php
@@ -25,4 +25,14 @@ class PaginatorStopRules
     {
         return new IsEmptyInXml($selector);
     }
+
+    public static function contains(string $string): Contains
+    {
+        return new Contains($string);
+    }
+
+    public static function notContains(string $string): NotContains
+    {
+        return new NotContains($string);
+    }
 }

--- a/tests/Steps/Loading/Http/Paginators/StopRules/ContainsTest.php
+++ b/tests/Steps/Loading/Http/Paginators/StopRules/ContainsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace tests\Steps\Loading\Http\Paginators\StopRules;
+
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Loading\Http\Paginators\StopRules\PaginatorStopRules;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+
+it('stops when called without a RespondedRequest object', function () {
+    $rule = PaginatorStopRules::contains('foo');
+
+    expect($rule->shouldStop(new Request('GET', 'https://www.example.com/foo'), null))->toBeTrue();
+});
+
+it('stops when the string is contained in the response body', function () {
+    $rule = PaginatorStopRules::contains('foo');
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwl.io/'),
+        new Response(body: 'This string contains foo'),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeTrue();
+});
+
+it('does not stop when the string is not contained in the response body', function () {
+    $rule = PaginatorStopRules::contains('foo');
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwl.io/'),
+        new Response(body: 'This does not contain the string'),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeFalse();
+});

--- a/tests/Steps/Loading/Http/Paginators/StopRules/NotContainsTest.php
+++ b/tests/Steps/Loading/Http/Paginators/StopRules/NotContainsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace tests\Steps\Loading\Http\Paginators\StopRules;
+
+use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
+use Crwlr\Crawler\Steps\Loading\Http\Paginators\StopRules\PaginatorStopRules;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+
+it('stops when called without a RespondedRequest object', function () {
+    $rule = PaginatorStopRules::notContains('foo');
+
+    expect($rule->shouldStop(new Request('GET', 'https://www.example.com/foo'), null))->toBeTrue();
+});
+
+it('stops when the string is not contained in the response body', function () {
+    $rule = PaginatorStopRules::notContains('foo');
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwl.io/'),
+        new Response(body: 'This does not contain the string'),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeTrue();
+});
+
+it('does not stop when the string is contained in the response body', function () {
+    $rule = PaginatorStopRules::notContains('foo');
+
+    $respondedRequest = new RespondedRequest(
+        new Request('GET', 'https://www.crwl.io/'),
+        new Response(body: 'This contains the string foo'),
+    );
+
+    expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeFalse();
+});


### PR DESCRIPTION
Adds `PaginatorStopRules::contains()` and
`PaginatorStopRules::notContains()` causing the paginator to stop when a certain string is contained (or not) in the response body.