### PR TITLE
Restrict retrying cached error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+* The `HttpLoader::retryCachedErrorResponses()` method now returns an instance of the new `RetryManager` class, providing the methods `only()` and `except()` that can be used to restrict retries to certain HTTP response status codes.
 
 ## [1.10.0] - 2024-08-05
 ### Added

--- a/src/Loader/Http/Cache/RetryManager.php
+++ b/src/Loader/Http/Cache/RetryManager.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Crwlr\Crawler\Loader\Http\Cache;
+
+/**
+ * @internal
+ */
+class RetryManager
+{
+    /**
+     * @param int[]|null $only
+     * @param int[]|null $except
+     */
+    public function __construct(
+        private ?array $only = null,
+        private ?array $except = null,
+    ) {}
+
+    /**
+     * @param int|int[] $statusCodes
+     */
+    public function only(int|array $statusCodes): static
+    {
+        $statusCodes = is_array($statusCodes) ? $statusCodes : [$statusCodes];
+
+        $this->only = $statusCodes;
+
+        return $this;
+    }
+
+    /**
+     * @param int|int[] $statusCodes
+     */
+    public function except(int|array $statusCodes): static
+    {
+        $statusCodes = is_array($statusCodes) ? $statusCodes : [$statusCodes];
+
+        $this->except = $statusCodes;
+
+        return $this;
+    }
+
+    public function shallBeRetried(int $statusCode): bool
+    {
+        return $statusCode >= 400 &&
+            ($this->except === null || !in_array($statusCode, $this->except, true)) &&
+            ($this->only === null || in_array($statusCode, $this->only, true));
+    }
+}

--- a/src/Loader/Http/Exceptions/LoadingException.php
+++ b/src/Loader/Http/Exceptions/LoadingException.php
@@ -3,10 +3,13 @@
 namespace Crwlr\Crawler\Loader\Http\Exceptions;
 
 use Exception;
+use Psr\Http\Message\UriInterface;
 use Throwable;
 
 class LoadingException extends Exception
 {
+    public ?int $httpStatusCode = null;
+
     public static function from(Throwable $previousException): self
     {
         return new self(
@@ -14,5 +17,28 @@ class LoadingException extends Exception
             $previousException->getMessage(),
             previous: $previousException,
         );
+    }
+
+    public static function make(string|UriInterface $uri, ?int $httpStatusCode = null): self
+    {
+        if ($uri instanceof UriInterface) {
+            $uri = (string) $uri;
+        }
+
+        $message = 'Failed to load ' . $uri;
+
+        if ($httpStatusCode !== null) {
+            $message .= ' (' . $httpStatusCode . ').';
+        } else {
+            $message .= '.';
+        }
+
+        $instance = new self($message);
+
+        if ($httpStatusCode !== null) {
+            $instance->httpStatusCode = $httpStatusCode;
+        }
+
+        return $instance;
     }
 }

--- a/tests/Loader/Http/Cache/RetryManagerTest.php
+++ b/tests/Loader/Http/Cache/RetryManagerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace tests\Loader\Http\Cache;
+
+use Crwlr\Crawler\Loader\Http\Cache\RetryManager;
+
+it('returns true for status codes >= 400 when nothing else was defined', function (int $statusCode) {
+    expect((new RetryManager())->shallBeRetried($statusCode))->toBeTrue();
+})->with([[403], [404], [500], [503]]);
+
+it('returns false for status codes below 400 when nothing else was defined', function (int $statusCode) {
+    expect((new RetryManager())->shallBeRetried($statusCode))->toBeFalse();
+})->with([[100], [200], [302], [308]]);
+
+it(
+    'returns true for only one error status code when only() was used with an int',
+    function (int $statusCode, bool $expected) {
+        $retryManager = new RetryManager();
+
+        $retryManager->only(404);
+
+        expect($retryManager->shallBeRetried($statusCode))->toBe($expected);
+    },
+)->with([
+    [401, false],
+    [403, false],
+    [404, true],
+    [405, false],
+    [500, false],
+    [503, false],
+]);
+
+it(
+    'returns true for only a set of error status codes when only() was used with an array',
+    function (int $statusCode, bool $expected) {
+        $retryManager = new RetryManager();
+
+        $retryManager->only([404, 503]);
+
+        expect($retryManager->shallBeRetried($statusCode))->toBe($expected);
+    },
+)->with([
+    [401, false],
+    [403, false],
+    [404, true],
+    [405, false],
+    [500, false],
+    [503, true],
+]);
+
+it(
+    'returns true for all error status codes except one, when except() was used with an int',
+    function (int $statusCode, bool $expected) {
+        $retryManager = new RetryManager();
+
+        $retryManager->except(404);
+
+        expect($retryManager->shallBeRetried($statusCode))->toBe($expected);
+    },
+)->with([
+    [401, true],
+    [403, true],
+    [404, false],
+    [405, true],
+    [500, true],
+    [503, true],
+]);
+
+it(
+    'returns true except for a set of error status codes, when except() was used with an array',
+    function (int $statusCode, bool $expected) {
+        $retryManager = new RetryManager();
+
+        $retryManager->except([403, 410, 500]);
+
+        expect($retryManager->shallBeRetried($statusCode))->toBe($expected);
+    },
+)->with([
+    [401, true],
+    [403, false],
+    [404, true],
+    [405, true],
+    [410, false],
+    [500, false],
+    [503, true],
+]);

--- a/tests/Loader/Http/Cookies/CookieJarTest.php
+++ b/tests/Loader/Http/Cookies/CookieJarTest.php
@@ -8,42 +8,55 @@ use GuzzleHttp\Psr7\Response;
 
 test('addFrom works with a string url', function () {
     $jar = new CookieJar();
+
     $jar->addFrom('https://www.crwl.io', new Response(200, [
         'Set-Cookie' => ['cook13=v4lu3; Secure'],
     ]));
+
     $allCookiesForDomain = $jar->allByDomain('crwl.io');
+
     expect($allCookiesForDomain)->toHaveCount(1);
 });
 
 test('addFrom works with an instance of UriInterface', function () {
     $jar = new CookieJar();
+
     $jar->addFrom(Url::parsePsr7('https://www.crwl.io'), new Response(200, [
         'Set-Cookie' => ['cook13=v4lu3; Secure'],
     ]));
+
     $allCookiesForDomain = $jar->allByDomain('crwl.io');
+
     expect($allCookiesForDomain)->toHaveCount(1);
 });
 
 test('addFrom works with an instance of Url', function () {
     $jar = new CookieJar();
+
     $jar->addFrom(Url::parse('https://www.crwl.io'), new Response(200, [
         'Set-Cookie' => ['cook13=v4lu3; Secure'],
     ]));
+
     $allCookiesForDomain = $jar->allByDomain('crwl.io');
+
     expect($allCookiesForDomain)->toHaveCount(1);
 });
 
-test('It adds all cookies from a response', function () {
+it('adds all cookies from a response', function () {
     $jar = new CookieJar();
+
     $jar->addFrom(Url::parse('https://www.otsch.codes'), new Response(200, [
         'Set-Cookie' => ['cook13=v4lu3; Secure', 'anotherCookie=andItsValue', 'oneMoreCookie=dough'],
     ]));
+
     $allCookiesForDomain = $jar->allByDomain('otsch.codes');
+
     expect($allCookiesForDomain)->toHaveCount(3);
 });
 
-test('It returns all cookies that should be sent to a url', function () {
+it('returns all cookies that should be sent to a url', function () {
     $jar = new CookieJar();
+
     $jar->addFrom(Url::parse('https://www.otsch.codes/blog'), new Response(200, [
         'Set-Cookie' => [
             'cook13=v4lu3; Secure',
@@ -51,7 +64,8 @@ test('It returns all cookies that should be sent to a url', function () {
             'oneMoreCookie=dough',
         ],
     ]));
-    expect($jar->getFor('https://www.otsch.codes/contact'))->toHaveCount(3);
-    expect($jar->getFor('https://jobs.otsch.codes/index'))->toHaveCount(2);
-    expect($jar->getFor('http://games.otsch.codes'))->toHaveCount(1);
+
+    expect($jar->getFor('https://www.otsch.codes/contact'))->toHaveCount(3)
+        ->and($jar->getFor('https://jobs.otsch.codes/index'))->toHaveCount(2)
+        ->and($jar->getFor('http://games.otsch.codes'))->toHaveCount(1);
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -21,6 +21,7 @@ use Generator;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Utils;
+use Psr\Http\Client\ClientInterface;
 use Psr\Log\LoggerInterface;
 use stdClass;
 use Symfony\Component\Process\Process;
@@ -257,9 +258,12 @@ function helper_getSimpleListHtml(): string
         HTML;
 }
 
-function helper_getFastLoader(UserAgentInterface $userAgent, ?LoggerInterface $logger = null): HttpLoader
-{
-    $loader = new HttpLoader($userAgent, logger: $logger);
+function helper_getFastLoader(
+    ?UserAgentInterface $userAgent = null,
+    ?LoggerInterface $logger = null,
+    ?ClientInterface $httpClient = null,
+): HttpLoader {
+    $loader = new HttpLoader($userAgent ?? UserAgent::mozilla5CompatibleBrowser(), $httpClient, $logger);
 
     $loader->throttle()
         ->waitBetween(new MultipleOf(0.0001), new MultipleOf(0.0002))


### PR DESCRIPTION
The `HttpLoader::retryCachedErrorResponses()` method now returns an instance of the new `RetryManager` class, providing the methods `only()` and `except()` that can be used to restrict retries to certain HTTP response status codes.