### PR TITLE
Fix HttpLoader afterLoad hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2024-10-15
+### Fixed
+* Issue with the `afterLoad` hook of the `HttpLoader`, introduced in v2. Calling the hook was commented out, which slipped through because the test case was faulty.
+
 ## [2.0.0] - 2024-10-15
 ### Changed
 * __BREAKING__: Removed methods `BaseStep::addToResult()`, `BaseStep::addLaterToResult()`, `BaseStep::addsToOrCreatesResult()`, `BaseStep::createsResult()`, and `BaseStep::keepInputData()`. These methods were deprecated in v1.8.0 and should be replaced with `Step::keep()`, `Step::keepAs()`, `Step::keepFromInput()`, and `Step::keepInputAs()`.

--- a/src/Loader/Http/HttpLoader.php
+++ b/src/Loader/Http/HttpLoader.php
@@ -155,7 +155,7 @@ class HttpLoader extends Loader
 
             return null;
         } finally {
-            //$this->callHook('afterLoad', $request);
+            $this->callHook('afterLoad', $request);
         }
     }
 

--- a/tests/Loader/Http/HttpLoaderTest.php
+++ b/tests/Loader/Http/HttpLoaderTest.php
@@ -84,15 +84,14 @@ it(
 
         $afterLoadWasCalled = false;
 
-        $httpLoader->beforeLoad(function () use (&$afterLoadWasCalled) {
+        $httpLoader->afterLoad(function () use (&$afterLoadWasCalled) {
             $afterLoadWasCalled = true;
         });
 
         $httpLoader->load('https://www.otsch.codes');
 
-        expect($beforeLoadWasCalled)->toBeTrue();
-
-        expect($afterLoadWasCalled)->toBeTrue();
+        expect($beforeLoadWasCalled)->toBeTrue()
+            ->and($afterLoadWasCalled)->toBeTrue();
     },
 )->with([
     [100],


### PR DESCRIPTION
Calling the hook was commented out, which slipped through because the test case was faulty.