### PR TITLE
Post Browser Navigate Hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2024-10-17
+### Added
+* The new `postBrowserNavigateHook()` method in the `Http` step classes, which allows to define callback functions that are triggered after the headless browser navigated to the specified URL. They are called with the chrome-php `Page` object as argument.
+
 ## [2.0.1] - 2024-10-15
 ### Fixed
 * Issue with the `afterLoad` hook of the `HttpLoader`, introduced in v2. Calling the hook was commented out, which slipped through because the test case was faulty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.0] - 2024-10-17
+## [2.1.0] - 2024-10-18
 ### Added
-* The new `postBrowserNavigateHook()` method in the `Http` step classes, which allows to define callback functions that are triggered after the headless browser navigated to the specified URL. They are called with the chrome-php `Page` object as argument.
+* The new `postBrowserNavigateHook()` method in the `Http` step classes, which allows to define callback functions that are triggered after the headless browser navigated to the specified URL. They are called with the chrome-php `Page` object as argument, so you can interact with the page. Also, there is a new class `BrowserAction` providing some simple actions (like wait for element, click element,...) as Closures via static methods. You can use it like `Http::get()->postBrowserNavigateHook(BrowserAction::clickElement('#element'))`.
 
 ## [2.0.1] - 2024-10-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.0] - 2024-10-18
+## [2.1.0] - 2024-10-19
 ### Added
 * The new `postBrowserNavigateHook()` method in the `Http` step classes, which allows to define callback functions that are triggered after the headless browser navigated to the specified URL. They are called with the chrome-php `Page` object as argument, so you can interact with the page. Also, there is a new class `BrowserAction` providing some simple actions (like wait for element, click element,...) as Closures via static methods. You can use it like `Http::get()->postBrowserNavigateHook(BrowserAction::clickElement('#element'))`.
 

--- a/src/Steps/Loading/Http/Browser/BrowserAction.php
+++ b/src/Steps/Loading/Http/Browser/BrowserAction.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Loading\Http\Browser;
+
+use Closure;
+use Crwlr\Utils\Microseconds;
+use HeadlessChromium\Page;
+
+class BrowserAction
+{
+    public static function waitUntilDocumentContainsElement(string $cssSelector): Closure
+    {
+        return function (Page $page) use ($cssSelector) {
+            $page->waitUntilContainsElement($cssSelector);
+        };
+    }
+
+    public static function clickElement(string $cssSelector): Closure
+    {
+        return function (Page $page) use ($cssSelector) {
+            $page->mouse()->find($cssSelector)->click();
+        };
+    }
+
+    public static function clickElementAndWaitForReload(string $cssSelector): Closure
+    {
+        return function (Page $page) use ($cssSelector) {
+            $page->mouse()->find($cssSelector)->click();
+
+            $page->waitForReload();
+        };
+    }
+
+    public static function evaluate(string $jsCode): Closure
+    {
+        return function (Page $page) use ($jsCode) {
+            $page->evaluate($jsCode);
+        };
+    }
+
+    public static function evaluateAndWaitForReload(string $jsCode): Closure
+    {
+        return function (Page $page) use ($jsCode) {
+            $page->evaluate($jsCode)->waitForPageReload();
+        };
+    }
+
+    public static function wait(float $seconds): Closure
+    {
+        return function (Page $page) use ($seconds) {
+            usleep(Microseconds::fromSeconds($seconds)->value);
+        };
+    }
+}

--- a/tests/Loader/Http/HeadlessBrowserLoaderHelperTest.php
+++ b/tests/Loader/Http/HeadlessBrowserLoaderHelperTest.php
@@ -133,3 +133,43 @@ it('uses the correct executable', function () {
 
     expect($invadedBrowserFactory->chromeBinary)->toBe($chromeExecutable);
 });
+
+it('calls the temporary post navigate hooks once', function () {
+    $browserFactoryMock = helper_setUpHeadlessChromeMocks();
+
+    $helper = new HeadlessBrowserLoaderHelper($browserFactoryMock);
+
+    $hook1Called = $hook2Called = $hook3Called = false;
+
+    $helper->setTempPostNavigateHooks([
+        function (Page $page) use (& $hook1Called) {
+            $hook1Called = true;
+        },
+        function (Page $page) use (& $hook2Called) {
+            $hook2Called = true;
+        },
+        function (Page $page) use (& $hook3Called) {
+            $hook3Called = true;
+        },
+    ]);
+
+    $helper->navigateToPageAndGetRespondedRequest(
+        new Request('GET', 'https://www.example.com/foo'),
+        helper_getMinThrottler(),
+    );
+
+    expect($hook1Called)->toBeTrue()
+        ->and($hook2Called)->toBeTrue()
+        ->and($hook3Called)->toBeTrue();
+
+    $hook1Called = $hook2Called = $hook3Called = false;
+
+    $helper->navigateToPageAndGetRespondedRequest(
+        new Request('GET', 'https://www.example.com/foo'),
+        helper_getMinThrottler(),
+    );
+
+    expect($hook1Called)->toBeFalse()
+        ->and($hook2Called)->toBeFalse()
+        ->and($hook3Called)->toBeFalse();
+});

--- a/tests/_Integration/Http/HeadlessBrowserTest.php
+++ b/tests/_Integration/Http/HeadlessBrowserTest.php
@@ -6,11 +6,11 @@ use Crwlr\Crawler\HttpCrawler;
 use Crwlr\Crawler\Loader\LoaderInterface;
 use Crwlr\Crawler\Steps\Html;
 use Crwlr\Crawler\Steps\Loading\Http;
+use Crwlr\Crawler\Steps\Loading\Http\Browser\BrowserAction;
 use Crwlr\Crawler\Steps\Step;
 use Crwlr\Crawler\UserAgents\UserAgent;
 use Crwlr\Crawler\UserAgents\UserAgentInterface;
 use Generator;
-use HeadlessChromium\Page;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DomCrawler\Crawler;
 
@@ -133,16 +133,14 @@ it('also gets cookies that are set via javascript', function () {
         ->and($results[0]->get('printed-cookie'))->toBe('javascriptcookie');
 });
 
-it('gets a cookie that is set via a click, executed via after navigate hook', function () {
+it('gets a cookie that is set via a click, executed via post browser navigate hook', function () {
     $crawler = new HeadlessBrowserCrawler();
 
     $crawler
         ->input('http://localhost:8000/set-delayed-js-cookie')
         ->addStep(
             Http::get()
-                ->postBrowserNavigateHook(function (Page $page) {
-                    $page->mouse()->find('#setCookieButton')->click();
-                }),
+                ->postBrowserNavigateHook(BrowserAction::clickElement('#setCookieButton')),
         )
         ->addStep(new class extends Step {
             protected function invoke(mixed $input): Generator
@@ -158,4 +156,91 @@ it('gets a cookie that is set via a click, executed via after navigate hook', fu
     expect($results)->toHaveCount(1)
         ->and($results[0]->get('printed-cookie'))->toBeString()
         ->and($results[0]->get('printed-cookie'))->toBe('jscookie');
+});
+
+test('BrowserActions waitUntilDocumentContainsElement(), clickElement() and evaluate() work as expected', function () {
+    $crawler = new HeadlessBrowserCrawler();
+
+    $crawler
+        ->input('http://localhost:8000/browser-actions')
+        ->addStep(
+            Http::get()
+                ->postBrowserNavigateHook(
+                    BrowserAction::waitUntilDocumentContainsElement('#delayed_el_container #delayed_el'),
+                )
+                ->postBrowserNavigateHook(BrowserAction::clickElement('#click_element'))
+                ->postBrowserNavigateHook(
+                    BrowserAction::evaluate(
+                        'document.getElementById(\'evaluation_container\').innerHTML = \'evaluated\'',
+                    ),
+                )
+                ->keep('body'),
+        );
+
+    $results = helper_generatorToArray($crawler->run());
+
+    $body = $results[0]->get('body');
+
+    expect($body)->toContain('<div id="delayed_el_container"><div id="delayed_el">a</div></div>')
+        ->and($body)->toContain('<div id="click_worked">yes</div>')
+        ->and($body)->toContain('<div id="evaluation_container">evaluated</div>');
+});
+
+test('BrowserAction::clickElementAndWaitForReload() works as expected', function () {
+    $crawler = new HeadlessBrowserCrawler();
+
+    $crawler
+        ->input('http://localhost:8000/browser-actions/click-and-wait-for-reload')
+        ->addStep(
+            Http::get()
+                ->postBrowserNavigateHook(BrowserAction::clickElementAndWaitForReload('#click'))
+                ->keep('body'),
+        );
+
+    $results = helper_generatorToArray($crawler->run());
+
+    $body = $results[0]->get('body');
+
+    expect($body)->toContain('<div id="reloaded">yes</div>');
+});
+
+test('BrowserAction::evaluateAndWaitForReload() works as expected', function () {
+    $crawler = new HeadlessBrowserCrawler();
+
+    $crawler
+        ->input('http://localhost:8000/browser-actions/evaluate-and-wait-for-reload')
+        ->addStep(
+            Http::get()
+                ->postBrowserNavigateHook(
+                    BrowserAction::evaluateAndWaitForReload(
+                        'window.location.href = \'http://localhost:8000/browser-actions/' .
+                            'evaluate-and-wait-for-reload-reloaded\'',
+                    ),
+                )
+                ->keep('body'),
+        );
+
+    $results = helper_generatorToArray($crawler->run());
+
+    $body = $results[0]->get('body');
+
+    expect($body)->toContain('<div id="reloaded">yay</div>');
+});
+
+test('BrowserAction::wait() works as expected', function () {
+    $crawler = new HeadlessBrowserCrawler();
+
+    $crawler
+        ->input('http://localhost:8000/browser-actions/wait')
+        ->addStep(
+            Http::get()
+                ->postBrowserNavigateHook(BrowserAction::wait(0.3))
+                ->keep('body'),
+        );
+
+    $results = helper_generatorToArray($crawler->run());
+
+    $body = $results[0]->get('body');
+
+    expect($body)->toContain('<div id="delayed_container">hooray</div>');
 });

--- a/tests/_Integration/Server.php
+++ b/tests/_Integration/Server.php
@@ -61,6 +61,28 @@ if ($route === '/set-delayed-js-cookie') {
     return include(__DIR__ . '/_Server/SetDelayedCookieJs.php');
 }
 
+if (str_starts_with($route, '/browser-actions')) {
+    if ($route === '/browser-actions') {
+        return include(__DIR__ . '/_Server/BrowserActions/Main.php');
+    }
+
+    if (str_starts_with($route, '/browser-actions/click-and-wait-for-reload')) {
+        return include(__DIR__ . '/_Server/BrowserActions/ClickAndWaitForReload.php');
+    }
+
+    if ($route === '/browser-actions/evaluate-and-wait-for-reload') {
+        return include(__DIR__ . '/_Server/BrowserActions/EvaluateAndWaitForReload.php');
+    }
+
+    if ($route === '/browser-actions/evaluate-and-wait-for-reload-reloaded') {
+        return include(__DIR__ . '/_Server/BrowserActions/EvaluateAndWaitForReloadReloaded.php');
+    }
+
+    if ($route === '/browser-actions/wait') {
+        return include(__DIR__ . '/_Server/BrowserActions/Wait.php');
+    }
+}
+
 if ($route === '/print-cookie') {
     return include(__DIR__ . '/_Server/PrintCookie.php');
 }

--- a/tests/_Integration/Server.php
+++ b/tests/_Integration/Server.php
@@ -57,6 +57,10 @@ if ($route === '/set-js-cookie') {
     return include(__DIR__ . '/_Server/SetCookieJs.php');
 }
 
+if ($route === '/set-delayed-js-cookie') {
+    return include(__DIR__ . '/_Server/SetDelayedCookieJs.php');
+}
+
 if ($route === '/print-cookie') {
     return include(__DIR__ . '/_Server/PrintCookie.php');
 }

--- a/tests/_Integration/_Server/BrowserActions/ClickAndWaitForReload.php
+++ b/tests/_Integration/_Server/BrowserActions/ClickAndWaitForReload.php
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset=utf-8>
+    <title>Hello World</title>
+</head>
+<body>
+<div>
+    <a id="click" href="?reloaded=1">Click here</a>
+
+    <?php if (isset($_GET['reloaded'])) { ?>
+        <div id="reloaded">yes</div>
+    <?php } ?>
+</div>
+</body>
+</html>

--- a/tests/_Integration/_Server/BrowserActions/EvaluateAndWaitForReload.php
+++ b/tests/_Integration/_Server/BrowserActions/EvaluateAndWaitForReload.php
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="de">
+<head><meta charset=utf-8><title>Hello World</title></head>
+<body></body>
+</html>

--- a/tests/_Integration/_Server/BrowserActions/EvaluateAndWaitForReloadReloaded.php
+++ b/tests/_Integration/_Server/BrowserActions/EvaluateAndWaitForReloadReloaded.php
@@ -1,0 +1,7 @@
+<!doctype html>
+<html lang="de">
+<head><meta charset=utf-8><title>Hello World</title></head>
+<body>
+<div id="reloaded">yay</div>
+</body>
+</html>

--- a/tests/_Integration/_Server/BrowserActions/Main.php
+++ b/tests/_Integration/_Server/BrowserActions/Main.php
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset=utf-8>
+    <title>Hello World</title>
+</head>
+<body>
+<div>
+    <div id="delayed_el_container"></div>
+
+    <div id="click_worked"></div>
+    <div id="click_element" onclick="document.getElementById('click_worked').innerHTML = 'yes'">Click me</div>
+
+    <div id="evaluation_container"></div>
+
+    <script>
+        setTimeout(function () {
+            document.getElementById('delayed_el_container').innerHTML = '<div id="delayed_el">a</div>';
+        }, 300);
+    </script>
+</div>
+</body>
+</html>

--- a/tests/_Integration/_Server/BrowserActions/Wait.php
+++ b/tests/_Integration/_Server/BrowserActions/Wait.php
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset=utf-8>
+    <title>Hello World</title>
+</head>
+<body>
+<div>
+    <div id="delayed_container"></div>
+
+    <script>
+        setTimeout(function () {
+            document.getElementById('delayed_container').innerHTML = 'hooray';
+        }, 200);
+    </script>
+</div>
+</body>
+</html>

--- a/tests/_Integration/_Server/SetCookieJs.php
+++ b/tests/_Integration/_Server/SetCookieJs.php
@@ -1,3 +1,4 @@
+<?php setcookie('testcookie', 'foo123'); ?>
 <!doctype html>
 <html lang="de">
 <head><meta charset=utf-8><title>yo</title></head>

--- a/tests/_Integration/_Server/SetDelayedCookieJs.php
+++ b/tests/_Integration/_Server/SetDelayedCookieJs.php
@@ -1,0 +1,10 @@
+<?php setcookie('testcookie', 'foo123'); ?>
+<!doctype html>
+<html lang="de">
+<head><meta charset=utf-8><title>Hey</title></head>
+<body>
+<div>
+    <button id="setCookieButton" onclick="document.cookie = 'testcookie=jscookie'"></button>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Adds post browser navigate hooks that are passed from `Http` steps to the browser loader helper and are executed after the headless browser navigated to the specified URL. They are called with the chrome-php `Page` object as argument, so you can run things on that page before getting the HTML and returning the response.