### PR TITLE
Add browser cookies to the cookie jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.1] - 2024-10-20
+## [2.1.1] - 2024-10-21
 ### Fixed
 * Also add cookies, set during headless browser usage, to the cookie jar. When switching back to the (guzzle) HTTP client the cookies should also be sent.
 * Don't call `Loader::afterLoad()` when `Loader::beforeLoad()` was not called before. This can potentially happen, when an exception is thrown before the call to the `beforeLoad` hook, but it is caught and the `afterLoader` hook method is called anyway. As this most likely won't make sense to users, the `afterLoad` hook callback functions will just not be called in this case.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2024-10-20
+### Fixed
+* Also add cookies, set during headless browser usage, to the cookie jar. When switching back to the (guzzle) HTTP client the cookies should also be sent.
+
 ## [2.1.0] - 2024-10-19
 ### Added
 * The new `postBrowserNavigateHook()` method in the `Http` step classes, which allows to define callback functions that are triggered after the headless browser navigated to the specified URL. They are called with the chrome-php `Page` object as argument, so you can interact with the page. Also, there is a new class `BrowserAction` providing some simple actions (like wait for element, click element,...) as Closures via static methods. You can use it like `Http::get()->postBrowserNavigateHook(BrowserAction::clickElement('#element'))`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.1.1] - 2024-10-20
 ### Fixed
 * Also add cookies, set during headless browser usage, to the cookie jar. When switching back to the (guzzle) HTTP client the cookies should also be sent.
+* Don't call `Loader::afterLoad()` when `Loader::beforeLoad()` was not called before. This can potentially happen, when an exception is thrown before the call to the `beforeLoad` hook, but it is caught and the `afterLoader` hook method is called anyway. As this most likely won't make sense to users, the `afterLoad` hook callback functions will just not be called in this case.
+* The `Throttler` class now has protected methods `_internalTrackStartFor()`,  `_requestToUrlWasStarted()` and `_internalTrackEndFor()`. When extending the `Throttler` class (be careful, actually that's not really recommended) they can be used to check if a request to a URL was actually started before.
 
 ## [2.1.0] - 2024-10-19
 ### Added

--- a/src/Loader/Http/Cookies/CookieJar.php
+++ b/src/Loader/Http/Cookies/CookieJar.php
@@ -4,6 +4,7 @@ namespace Crwlr\Crawler\Loader\Http\Cookies;
 
 use Crwlr\Crawler\Loader\Http\Cookies\Exceptions\InvalidCookieException;
 use Crwlr\Url\Url;
+use DateTime;
 use Exception;
 use HeadlessChromium\Cookies\CookiesCollection;
 use Psr\Http\Message\ResponseInterface;
@@ -124,7 +125,7 @@ class CookieJar
         }
 
         if ($cookie->offsetExists('expires') && $cookie->offsetGet('expires') !== -1) {
-            $header .= '; Expires=' . $cookie->offsetGet('expires');
+            $header .= '; Expires=' . $this->formatExpiresValue($cookie->offsetGet('expires'));
         }
 
         if ($cookie->offsetExists('max-age') && !empty($cookie->offsetGet('path'))) {
@@ -148,5 +149,18 @@ class CookieJar
         }
 
         return $header;
+    }
+
+    private function formatExpiresValue(mixed $value): string
+    {
+        if (is_numeric($value)) {
+            $expires = DateTime::createFromFormat('U.v', (string) $value);
+
+            if ($expires !== false) {
+                return $expires->format('l, d M Y H:i:s T');
+            }
+        }
+
+        return (string) $value;
     }
 }

--- a/src/Loader/Http/Cookies/CookieJar.php
+++ b/src/Loader/Http/Cookies/CookieJar.php
@@ -52,7 +52,7 @@ class CookieJar
                 foreach ($cookieHeaders as $cookieHeader) {
                     $cookie = new Cookie($url, $cookieHeader);
 
-                    $this->jar[$cookie->domain()][$cookie->name()] = $cookie;
+                    $this->jar[$this->getForDomainFromUrl($url)][$cookie->name()] = $cookie;
                 }
             }
         }
@@ -70,7 +70,7 @@ class CookieJar
             foreach ($collection as $cookie) {
                 $cookie = new Cookie($url, $this->buildSetCookieHeaderFromBrowserCookie($cookie));
 
-                $this->jar[$cookie->domain()][$cookie->name()] = $cookie;
+                $this->jar[$this->getForDomainFromUrl($url)][$cookie->name()] = $cookie;
             }
         }
     }
@@ -154,7 +154,15 @@ class CookieJar
     private function formatExpiresValue(mixed $value): string
     {
         if (is_numeric($value)) {
-            $expires = DateTime::createFromFormat('U.v', (string) $value);
+            $value = (string) $value;
+
+            if (str_contains($value, '.')) {
+                $expires = strlen(explode('.', $value, 2)[1]) <= 3 ?
+                    DateTime::createFromFormat('U.v', $value) :
+                    DateTime::createFromFormat('U.u', $value);
+            } else {
+                $expires = DateTime::createFromFormat('U', $value);
+            }
 
             if ($expires !== false) {
                 return $expires->format('l, d M Y H:i:s T');

--- a/src/Loader/Http/HttpLoader.php
+++ b/src/Loader/Http/HttpLoader.php
@@ -387,7 +387,12 @@ class HttpLoader extends Loader
         if ($this->useHeadlessBrowser) {
             $proxy = $this->proxies?->getProxy() ?? null;
 
-            return $this->browser()->navigateToPageAndGetRespondedRequest($request, $this->throttler, $proxy);
+            return $this->browser()->navigateToPageAndGetRespondedRequest(
+                $request,
+                $this->throttler,
+                $proxy,
+                $this->cookieJar,
+            );
         }
 
         return $this->handleRedirects($request);
@@ -626,7 +631,7 @@ class HttpLoader extends Loader
      */
     protected function addCookiesToRequest(RequestInterface $request): RequestInterface
     {
-        if (!$this->useCookies) {
+        if (!$this->useCookies || $this->usesHeadlessBrowser()) {
             return $request;
         }
 

--- a/src/Loader/Http/HttpLoader.php
+++ b/src/Loader/Http/HttpLoader.php
@@ -119,6 +119,8 @@ class HttpLoader extends Loader
      */
     public function load(mixed $subject): ?RespondedRequest
     {
+        $this->_resetCalledHooks();
+
         try {
             $request = $this->validateSubjectType($subject);
         } catch (InvalidArgumentException) {

--- a/tests/Loader/Http/Cookies/CookieJarTest.php
+++ b/tests/Loader/Http/Cookies/CookieJarTest.php
@@ -5,6 +5,8 @@ namespace tests\Loader\Http\Cookies;
 use Crwlr\Crawler\Loader\Http\Cookies\CookieJar;
 use Crwlr\Url\Url;
 use GuzzleHttp\Psr7\Response;
+use HeadlessChromium\Cookies\Cookie;
+use HeadlessChromium\Cookies\CookiesCollection;
 
 test('addFrom works with a string url', function () {
     $jar = new CookieJar();
@@ -40,6 +42,23 @@ test('addFrom works with an instance of Url', function () {
     $allCookiesForDomain = $jar->allByDomain('crwl.io');
 
     expect($allCookiesForDomain)->toHaveCount(1);
+});
+
+test('addFrom() works with a CookieCollection from the chrome-php lib', function () {
+    $jar = new CookieJar();
+
+    $jar->addFrom(Url::parse('https://www.crwl.io'), new CookiesCollection([
+        new Cookie(['name' => 'foo', 'value' => 'one', 'domain' => '.www.crwl.io', 'expires' => '1745068860']),
+        new Cookie(['name' => 'bar', 'value' => 'two', 'domain' => '.www.crwl.io', 'expires' => '1729603260.5272']),
+        new Cookie(['name' => 'baz', 'value' => 'three', 'domain' => '.www.crwl.io', 'expires' => '1764076860.878']),
+    ]));
+
+    $allCookiesForDomain = $jar->allByDomain('crwl.io');
+
+    expect($allCookiesForDomain)->toHaveCount(3)
+        ->and($allCookiesForDomain['foo']->expires()?->dateTime()->format('Y-m-d H:i'))->toBe('2025-04-19 13:21')
+        ->and($allCookiesForDomain['bar']->expires()?->dateTime()->format('Y-m-d H:i'))->toBe('2024-10-22 13:21')
+        ->and($allCookiesForDomain['baz']->expires()?->dateTime()->format('Y-m-d H:i'))->toBe('2025-11-25 13:21');
 });
 
 it('adds all cookies from a response', function () {

--- a/tests/Loader/Http/HttpLoaderPolitenessTest.php
+++ b/tests/Loader/Http/HttpLoaderPolitenessTest.php
@@ -11,6 +11,7 @@ use Crwlr\Crawler\UserAgents\UserAgent;
 use GuzzleHttp\Psr7\Response;
 use HeadlessChromium\Browser;
 use HeadlessChromium\Communication\Session;
+use HeadlessChromium\Cookies\CookiesCollection;
 use HeadlessChromium\Page;
 use HeadlessChromium\PageUtils\PageNavigation;
 use Mockery;
@@ -54,9 +55,8 @@ it('throttles requests to the same domain', function ($loadingMethod) {
 
     $diff = $secondResponse - $firstResponse;
 
-    expect($diff)->toBeGreaterThan(0.3);
-
-    expect($diff)->toBeLessThan(0.62);
+    expect($diff)->toBeGreaterThan(0.3)
+        ->and($diff)->toBeLessThan(0.62);
 })->with(['load', 'loadOrFail']);
 
 it('also throttles requests using the headless browser', function ($loadingMethod) {
@@ -83,6 +83,8 @@ it('also throttles requests using the headless browser', function ($loadingMetho
             return $pageNavigationMock;
         });
 
+    $pageMock->shouldReceive('getCookies')->andReturn(new CookiesCollection());
+
     $pageMock->shouldReceive('getHtml')->andReturn('<html>foo</html>');
 
     $browserMock->shouldReceive('createPage')->andReturn($pageMock);
@@ -104,6 +106,8 @@ it('also throttles requests using the headless browser', function ($loadingMetho
 
     $pageMock->shouldReceive('navigate')->andReturn($pageNavigationMock);
 
+    $pageMock->shouldReceive('getCookies')->andReturn(new CookiesCollection());
+
     $firstResponse = microtime(true);
 
     $loader->{$loadingMethod}('https://www.example.com/bar');
@@ -112,9 +116,8 @@ it('also throttles requests using the headless browser', function ($loadingMetho
 
     $diff = $secondResponse - $firstResponse;
 
-    expect($diff)->toBeGreaterThan(0.3);
-
-    expect($diff)->toBeLessThan(0.62);
+    expect($diff)->toBeGreaterThan(0.3)
+        ->and($diff)->toBeLessThan(0.62);
 })->with(['load', 'loadOrFail']);
 
 it('does not throttle requests to different domains', function ($loadingMethod) {

--- a/tests/Loader/LoaderTest.php
+++ b/tests/Loader/LoaderTest.php
@@ -6,6 +6,7 @@ use Crwlr\Crawler\Loader\Loader;
 use Crwlr\Crawler\UserAgents\BotUserAgent;
 use Mockery;
 use Psr\SimpleCache\CacheInterface;
+use tests\_Stubs\DummyLogger;
 
 test('You can set multiple hook callbacks for one type and they are executed when called', function (string $hookName) {
     $loader = new class (new BotUserAgent('FooBot'), $hookName) extends Loader {
@@ -16,7 +17,12 @@ test('You can set multiple hook callbacks for one type and they are executed whe
 
         public function load(mixed $subject): mixed
         {
+            if ($this->hookName === 'afterLoad') {
+                $this->callHook('beforeLoad'); // Loader won't run afterLoad when beforeLoad wasn't called.
+            }
+
             $this->callHook($this->hookName);
+
             return 'something';
         }
 
@@ -40,9 +46,9 @@ test('You can set multiple hook callbacks for one type and they are executed whe
 
     $loader->load('something');
 
-    expect($callback1Called)->toBeTrue();
-    expect($callback2Called)->toBeTrue();
-    expect($callback3Called)->toBeTrue();
+    expect($callback1Called)->toBeTrue()
+        ->and($callback2Called)->toBeTrue()
+        ->and($callback3Called)->toBeTrue();
 })->with([
     'beforeLoad',
     'onCacheHit',
@@ -50,6 +56,68 @@ test('You can set multiple hook callbacks for one type and they are executed whe
     'onError',
     'afterLoad',
 ]);
+
+it('does not call the afterLoad hook when beforeLoad was not called before it', function () {
+    $logger = new DummyLogger();
+
+    $loader = new class (new BotUserAgent('FooBot'), $logger) extends Loader {
+        public function load(mixed $subject): mixed
+        {
+            $this->callHook('afterLoad');
+
+            return 'something';
+        }
+
+        public function loadOrFail(mixed $subject): mixed
+        {
+            return 'something';
+        }
+    };
+
+    $callbackCalled = false;
+
+    $loader->afterLoad(function () use (&$callbackCalled) {
+        $callbackCalled = true;
+    });
+
+    $loader->load('something');
+
+    expect($callbackCalled)->toBeFalse()
+        ->and($logger->messages[0]['message'])->toStartWith(
+            'The afterLoad hook was called without a preceding call to the beforeLoad hook.',
+        );
+});
+
+it('calls the afterLoad hook when beforeLoad was called before it', function () {
+    $logger = new DummyLogger();
+
+    $loader = new class (new BotUserAgent('FooBot'), $logger) extends Loader {
+        public function load(mixed $subject): mixed
+        {
+            $this->callHook('beforeLoad');
+
+            $this->callHook('afterLoad');
+
+            return 'something';
+        }
+
+        public function loadOrFail(mixed $subject): mixed
+        {
+            return 'something';
+        }
+    };
+
+    $callbackCalled = false;
+
+    $loader->afterLoad(function () use (&$callbackCalled) {
+        $callbackCalled = true;
+    });
+
+    $loader->load('something');
+
+    expect($callbackCalled)->toBeTrue()
+        ->and($logger->messages)->toHaveCount(0);
+});
 
 test('You can set a cache and use it in the load function', function () {
     $loader = new class (new BotUserAgent('FooBot')) extends Loader {

--- a/tests/_Integration/Server.php
+++ b/tests/_Integration/Server.php
@@ -57,6 +57,18 @@ if ($route === '/set-js-cookie') {
     return include(__DIR__ . '/_Server/SetCookieJs.php');
 }
 
+if ($route === '/scripts/set-cookie.js') {
+    echo <<<JS
+        document.addEventListener("DOMContentLoaded", function () {
+            document.getElementById('consent_btn').addEventListener('click', function (ev) {
+                ev.preventDefault();
+                document.cookie = "testcookie=javascriptcookie";
+            }, false);
+        }, false);
+        JS;
+    return;
+}
+
 if ($route === '/set-delayed-js-cookie') {
     return include(__DIR__ . '/_Server/SetDelayedCookieJs.php');
 }

--- a/tests/_Integration/_Server/SetCookieJs.php
+++ b/tests/_Integration/_Server/SetCookieJs.php
@@ -1,4 +1,3 @@
-<?php setcookie('testcookie', 'foo123'); ?>
 <!doctype html>
 <html lang="de">
 <head><meta charset=utf-8><title>yo</title></head>

--- a/tests/_Integration/_Server/SetDelayedCookieJs.php
+++ b/tests/_Integration/_Server/SetDelayedCookieJs.php
@@ -1,10 +1,14 @@
-<?php setcookie('testcookie', 'foo123'); ?>
 <!doctype html>
 <html lang="de">
-<head><meta charset=utf-8><title>Hey</title></head>
+<head>
+    <meta charset=utf-8><title>Hey</title>
+    <script src="/scripts/set-cookie.js"></script>
+</head>
 <body>
 <div>
-    <button id="setCookieButton" onclick="document.cookie = 'testcookie=jscookie'"></button>
+    <button type="button" id="consent_btn">
+        Accept Cookie
+    </button>
 </div>
 </body>
 </html>


### PR DESCRIPTION
Also add cookies, set during headless browser usage, to the cookie jar. When switching back to the (guzzle) HTTP client the cookies should also be sent.