### PR TITLE
Make buildSetCookieHeaderFromBrowserCookie robust

### DIFF
--- a/src/Loader/Http/Cookies/CookieJar.php
+++ b/src/Loader/Http/Cookies/CookieJar.php
@@ -142,7 +142,7 @@ class CookieJar
             }
 
             // "Expires" attribute
-            if ($name === 'expires')) {
+            if ($name === 'expires') {
                 if ($setCookieValue !== -1) {
                     $header[] = sprintf('%s=%s', $setCookieName, $this->formatExpiresValue($setCookieValue));
                 }

--- a/src/Loader/Http/Cookies/CookieJar.php
+++ b/src/Loader/Http/Cookies/CookieJar.php
@@ -123,37 +123,42 @@ class CookieJar
 
     protected function buildSetCookieHeaderFromBrowserCookie(BrowserCookie $cookie): string
     {
-        $header = $cookie->getName() . '=' . $cookie->getValue();
+        $attributes = [
+            'domain' => 'Domain',
+            'expires' => 'Expires',
+            'max-age' => 'Max-Age',
+            'path' => 'Path',
+            'secure' => 'Secure',
+            'httpOnly' => 'HttpOnly',
+            'sameSite' => 'SameSite',
+        ];
 
-        if ($cookie->getDomain() !== null) {
-            $header .= '; Domain=' . $cookie->getDomain();
+        $header = [sprintf('%s=%s', $cookie->getName(), $cookie->getValue())];
+
+        foreach ($attributes as $name => $setCookieName) {
+            $setCookieValue = $cookie->offsetGet($name);
+            if ($setCookieValue === null) {
+                continue;
+            }
+
+            // "Expires" attribute
+            if ($name === 'expires')) {
+                if ($setCookieValue !== -1) {
+                    $header[] = sprintf('%s=%s', $setCookieName, $this->formatExpiresValue($setCookieValue));
+                }
+                continue;
+            }
+
+            // Flag attributes
+            if ($setCookieValue === true) {
+                $header[] = $setCookieName;
+                continue;
+            }
+
+            $header[] = sprintf('%s=%s', $setCookieName, $setCookieValue);
         }
 
-        if ($cookie->offsetExists('expires') && $cookie->offsetGet('expires') !== -1) {
-            $header .= '; Expires=' . $this->formatExpiresValue($cookie->offsetGet('expires'));
-        }
-
-        if ($cookie->offsetExists('max-age') && !empty($cookie->offsetGet('max-age'))) {
-            $header .= '; Max-Age=' . $cookie->offsetGet('max-age');
-        }
-
-        if ($cookie->offsetExists('path') && !empty($cookie->offsetGet('path'))) {
-            $header .= '; Path=' . $cookie->offsetGet('path');
-        }
-
-        if ($cookie->offsetExists('secure') && $cookie->offsetGet('secure') === true) {
-            $header .= '; Secure';
-        }
-
-        if ($cookie->offsetExists('httpOnly') && $cookie->offsetGet('httpOnly') === true) {
-            $header .= '; HttpOnly';
-        }
-
-        if ($cookie->offsetExists('sameSite') && !empty($cookie->offsetGet('sameSite'))) {
-            $header .= '; SameSite=' . $cookie->offsetGet('sameSite');
-        }
-
-        return $header;
+        return implode('; ', $header);
     }
 
     private function formatExpiresValue(mixed $value): string

--- a/src/Loader/Http/Cookies/CookieJar.php
+++ b/src/Loader/Http/Cookies/CookieJar.php
@@ -137,7 +137,7 @@ class CookieJar
 
         foreach ($attributes as $name => $setCookieName) {
             $setCookieValue = $cookie->offsetGet($name);
-            if ($setCookieValue === null) {
+            if (empty($setCookieValue)) {
                 continue;
             }
 
@@ -150,10 +150,8 @@ class CookieJar
             }
 
             // Flag attributes
-            if (is_bool($setCookieValue)) {
-                if ($setCookieValue === true) {
-                    $parts[] = $setCookieName;
-                }
+            if ($setCookieValue === true) {
+                $parts[] = $setCookieName;
                 continue;
             }
 

--- a/src/Loader/Http/Cookies/CookieJar.php
+++ b/src/Loader/Http/Cookies/CookieJar.php
@@ -133,7 +133,7 @@ class CookieJar
             'sameSite' => 'SameSite',
         ];
 
-        $header = [sprintf('%s=%s', $cookie->getName(), $cookie->getValue())];
+        $parts = [sprintf('%s=%s', $cookie->getName(), $cookie->getValue())];
 
         foreach ($attributes as $name => $setCookieName) {
             $setCookieValue = $cookie->offsetGet($name);
@@ -144,7 +144,7 @@ class CookieJar
             // "Expires" attribute
             if ($name === 'expires') {
                 if ($setCookieValue !== -1) {
-                    $header[] = sprintf('%s=%s', $setCookieName, $this->formatExpiresValue($setCookieValue));
+                    $parts[] = sprintf('%s=%s', $setCookieName, $this->formatExpiresValue($setCookieValue));
                 }
                 continue;
             }
@@ -152,15 +152,15 @@ class CookieJar
             // Flag attributes
             if (is_bool($setCookieValue)) {
                 if ($setCookieValue === true) {
-                    $header[] = $setCookieName;
+                    $parts[] = $setCookieName;
                 }
                 continue;
             }
 
-            $header[] = sprintf('%s=%s', $setCookieName, $setCookieValue);
+            $parts[] = sprintf('%s=%s', $setCookieName, $setCookieValue);
         }
 
-        return implode('; ', $header);
+        return implode('; ', $parts);
     }
 
     private function formatExpiresValue(mixed $value): string

--- a/src/Loader/Http/Cookies/CookieJar.php
+++ b/src/Loader/Http/Cookies/CookieJar.php
@@ -150,8 +150,10 @@ class CookieJar
             }
 
             // Flag attributes
-            if ($setCookieValue === true) {
-                $header[] = $setCookieName;
+            if (is_bool($setCookieValue)) {
+                if ($setCookieValue === true) {
+                    $header[] = $setCookieName;
+                }
                 continue;
             }
 


### PR DESCRIPTION
Now you can clearly see what is going on in `buildSetCookieHeaderFromBrowserCookie`.

Review: https://github.com/crwlrsoft/crawler/blob/f0da585ee8798e49a837b02f741c398a9356259e/src/Loader/Http/Cookies/CookieJar.php#L124