### PR TITLE
PHP CS Fixer min version 3.57

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -14,7 +14,6 @@ return (new Config())
     ->setRules([
         '@PER-CS' => true,
         'strict_param' => true,
-        'single_class_element_per_statement' => false,
         'array_syntax' => ['syntax' => 'short'],
         'no_unused_imports' => true,
     ])

--- a/composer.json
+++ b/composer.json
@@ -50,13 +50,19 @@
         "phpstan/phpstan-mockery": "^1.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-phpunit": "^1.0",
-        "friendsofphp/php-cs-fixer": "^3.6",
+        "friendsofphp/php-cs-fixer": "^3.57",
         "spatie/invade": "^2.0",
         "symfony/process": "^6.0|^7.0"
     },
     "suggest": {
         "ext-zlib": "Needed to uncompress compressed responses"
     },
+    "funding": [
+        {
+            "type": "github",
+            "url": "https://github.com/sponsors/otsch"
+        }
+    ],
     "autoload": {
         "psr-4": {
             "Crwlr\\Crawler\\": "src/"


### PR DESCRIPTION
Because parallel execution was introduced with that version. Also seems that single_class_element_per_statement isn't necessary. It does not change anything when ran without it. And also add funding block to composer.json.