### PR TITLE
Undeprecate XPath Functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1] - 2024-12-10
+### Undeprecated
+* Removed deprecations for all XPath functionality (`Dom::xPath()`, `XPathQuery` class and `Node::queryXPath()`), because it's still available with the net DOM API in PHP 8.4.
+
 ## [3.0.0] - 2024-12-08
 The primary change in version 3.0.0 is that the library now leverages PHP 8.4’s new DOM API when used in an environment with PHP >= 8.4. To maintain compatibility with PHP < 8.4, an abstraction layer has been implemented. This layer dynamically uses either the Symfony DomCrawler component or the new DOM API, depending on the PHP version.
 
 Since no direct interaction with an instance of the Symfony DomCrawler library was required at the step level provided by the library, it is highly likely that you won’t need to make any changes to your code to upgrade to v3. To ensure a smooth transition, please review the points under “Changed.”
-
-If you're using XPath queries for data extraction, please try to switch to using CSS selectors instead, because XPath is no longer supported by the new DOM API. Therefor XPath related functionality was deprecated in this version of the library and will probably be removed in the next major version.
 
 ### Changed
 * __BREAKING__: The `DomQuery::innerText()` method (a.k.a. `Dom::cssSelector('...')->innerText()`) has been removed. `innerText` exists only in the Symfony DomCrawler component, and its usefulness is questionable. If you still require this variant of the DOM element text, please let us know or create a pull request yourself. Thank you!

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -21,3 +21,4 @@ parameters:
         - "#^Call to an undefined (static )?method Dom\\\\.+::.+\\(\\)\\.#"
         - "#^Access to an undefined property Dom\\\\.+::\\$.+\\.#"
         - "#^Function .+ has invalid return type Dom\\\\.+\\.#"
+        - "#^(?:Used )?(?:C|c)onstant DOM\\\\.+ not found\\.#"

--- a/src/Steps/Dom.php
+++ b/src/Steps/Dom.php
@@ -91,8 +91,6 @@ abstract class Dom extends Step
 
     /**
      * @throws InvalidDomQueryException
-     * @deprecated As the usage of XPath queries is no longer an option with the new DOM API introduced in
-     *             PHP 8.4, please switch to using CSS selectors instead!
      */
     public static function xPath(string $query): XPathQuery
     {

--- a/src/Steps/Dom/HtmlDocument.php
+++ b/src/Steps/Dom/HtmlDocument.php
@@ -5,6 +5,7 @@ namespace Crwlr\Crawler\Steps\Dom;
 use Crwlr\Utils\PhpVersion;
 use DOMNode;
 use Symfony\Component\DomCrawler\Crawler;
+use const DOM\HTML_NO_DEFAULT_NS;
 
 /**
  * @method HtmlElement|null querySelector(string $selector)
@@ -47,7 +48,7 @@ class HtmlDocument extends DomDocument
     protected function makeDocumentInstance(string $source): object
     {
         if (PhpVersion::isAtLeast(8, 4)) {
-            return \Dom\HTMLDocument::createFromString($source, LIBXML_NOERROR);
+            return \Dom\HTMLDocument::createFromString($source, HTML_NO_DEFAULT_NS | LIBXML_NOERROR);
         }
 
         return new Crawler($source);

--- a/src/Steps/Dom/HtmlDocument.php
+++ b/src/Steps/Dom/HtmlDocument.php
@@ -5,6 +5,7 @@ namespace Crwlr\Crawler\Steps\Dom;
 use Crwlr\Utils\PhpVersion;
 use DOMNode;
 use Symfony\Component\DomCrawler\Crawler;
+
 use const DOM\HTML_NO_DEFAULT_NS;
 
 /**

--- a/src/Steps/Dom/Node.php
+++ b/src/Steps/Dom/Node.php
@@ -47,10 +47,6 @@ abstract class Node
         return $this->makeNodeListInstance($this->node->querySelectorAll($selector));
     }
 
-    /**
-     * @deprecated As the usage of XPath queries is no longer an option with the new DOM API introduced in
-     *             PHP 8.4, please switch to using CSS selectors instead!
-     */
     public function queryXPath(string $query): NodeList
     {
         $node = $this->node;
@@ -107,12 +103,24 @@ abstract class Node
             return $this->node->outerHtml();
         }
 
+        if ($this->node instanceof Document) {
+            $node = $this->node->documentElement;
+
+            if ($this->node instanceof \Dom\HTMLDocument) {
+                return $this->node->saveHTML($node);
+            } elseif ($this->node instanceof \Dom\XMLDocument) {
+                return $this->node->saveXML($node);
+            }
+        }
+
         $parentDocument = $this->getParentDocumentOfNode($this->node);
 
-        if ($parentDocument instanceof \Dom\HTMLDocument) {
-            return $parentDocument->saveHTML($this->node);
-        } elseif ($parentDocument instanceof \Dom\XMLDocument) {
-            return $parentDocument->saveXML($this->node);
+        if ($parentDocument) {
+            if ($parentDocument instanceof \Dom\HTMLDocument) {
+                return $parentDocument->saveHTML($this->node);
+            } elseif ($parentDocument instanceof \Dom\XMLDocument) {
+                return $parentDocument->saveXML($this->node);
+            }
         }
 
         return $this->node->innerHTML;

--- a/src/Steps/Dom/XmlDocument.php
+++ b/src/Steps/Dom/XmlDocument.php
@@ -33,7 +33,7 @@ class XmlDocument extends DomDocument
     protected function makeDocumentInstance(string $source): object
     {
         if (PhpVersion::isAtLeast(8, 4)) {
-            return \Dom\XMLDocument::createFromString($source, LIBXML_NOERROR);
+            return \Dom\XMLDocument::createFromString($source, LIBXML_NOERROR | LIBXML_NONET);
         }
 
         return new Crawler($source);

--- a/src/Steps/Html/CssSelector.php
+++ b/src/Steps/Html/CssSelector.php
@@ -27,7 +27,7 @@ final class CssSelector extends DomQuery
             }
         } else {
             try {
-                (new HtmlDocument('<p></p>'))->querySelector($query);
+                (new HtmlDocument('<!doctype html><html></html>'))->querySelector($query);
             } catch (DOMException $exception) {
                 throw InvalidDomQueryException::fromDomException($query, $exception);
             }

--- a/src/Steps/Html/XPathQuery.php
+++ b/src/Steps/Html/XPathQuery.php
@@ -8,11 +8,6 @@ use Crwlr\Crawler\Steps\Html\Exceptions\InvalidDomQueryException;
 use DOMDocument;
 use DOMXPath;
 
-/**
- * @deprecated As the usage of XPath queries is no longer an option with the new DOM API introduced in
- *              PHP 8.4, please switch to using CSS selectors instead!
- */
-
 class XPathQuery extends DomQuery
 {
     /**

--- a/tests/Steps/BaseStepTest.php
+++ b/tests/Steps/BaseStepTest.php
@@ -830,7 +830,7 @@ it('runs a sub crawler for a certain output property', function () {
 
     $results = helper_invokeStepWithInput($step, [
         'foo' => 'hey',
-        'bar' => '<html><head></head><body><h1>Hello World!</h1></body>',
+        'bar' => '<!doctype html><html><head></head><body><h1>Hello World!</h1></body>',
     ]);
 
     expect($results)->toHaveCount(1)
@@ -847,14 +847,15 @@ test('when a sub crawler returns multiple results, they are an array in the pare
     });
 
     $html = <<<HTML
-<html>
-<head></head>
-<body>
-<div class="item"><h3>one</h3></div>
-<div class="item"><h3>two</h3></div>
-<div class="item"><h3>three</h3></div>
-</body>
-HTML;
+        <!doctype html>
+        <html>
+        <head></head>
+        <body>
+        <div class="item"><h3>one</h3></div>
+        <div class="item"><h3>two</h3></div>
+        <div class="item"><h3>three</h3></div>
+        </body>
+        HTML;
 
     $results = helper_invokeStepWithInput($step, ['foo' => 'hey', 'bar' => $html, 'baz' => 'yo']);
 
@@ -883,9 +884,9 @@ it('runs a sub crawler with multiple inputs, when defined property is array', fu
     $results = helper_invokeStepWithInput($step, [
         'foo' => 'hey',
         'bar' => [
-            '<html><head></head><body><h1>No. 1</h1></body>',
-            '<html><head></head><body><h1>No. 2</h1></body>',
-            '<html><head></head><body><h1>No. 3</h1></body>',
+            '<!doctype html><html><head></head><body><h1>No. 1</h1></body>',
+            '<!doctype html><html><head></head><body><h1>No. 2</h1></body>',
+            '<!doctype html><html><head></head><body><h1>No. 3</h1></body>',
         ],
         'baz' => 'yo',
     ]);

--- a/tests/Steps/Dom/HtmlDocumentTest.php
+++ b/tests/Steps/Dom/HtmlDocumentTest.php
@@ -7,7 +7,7 @@ use Crwlr\Crawler\Steps\Dom\HtmlElement;
 use Crwlr\Crawler\Steps\Dom\NodeList;
 
 it('gets the href of a base tag in the document', function () {
-    $html = '<html><head><title>foo</title><base href="/foo/bar" /></head><body>hello</body></html>';
+    $html = '<!doctype html><html><head><title>foo</title><base href="/foo/bar" /></head><body>hello</body></html>';
 
     $document = new HtmlDocument($html);
 
@@ -16,6 +16,7 @@ it('gets the href of a base tag in the document', function () {
 
 it('gets the href of the first base tag in the document', function () {
     $html = <<<HTML
+        <!doctype html>
         <html>
         <head>
             <title>foo</title>
@@ -32,7 +33,7 @@ it('gets the href of the first base tag in the document', function () {
 });
 
 test('getBaseHref() returns null if the document does not contain a base tag', function () {
-    $html = '<html><head><title>foo</title></head><body>hey</body></html>';
+    $html = '<!doctype html><html><head><title>foo</title></head><body>hey</body></html>';
 
     $document = new HtmlDocument($html);
 
@@ -40,7 +41,7 @@ test('getBaseHref() returns null if the document does not contain a base tag', f
 });
 
 test('the querySelector() method returns an HtmlElement object', function () {
-    $html = '<html><head><title>foo</title></head><body><div class="element">hello</div></body></html>';
+    $html = '<!doctype html><html><head><title>foo</title></head><body><div class="element">hello</div></body></html>';
 
     $document = new HtmlDocument($html);
 
@@ -48,7 +49,7 @@ test('the querySelector() method returns an HtmlElement object', function () {
 });
 
 test('the querySelectorAll() method returns a NodeList of HtmlElement objects', function () {
-    $html = '<html><head><title>foo</title></head><body><ul><li>foo</li><li>bar</li></ul></body></html>';
+    $html = '<!doctype html><html><head><title>foo</title></head><body><ul><li>foo</li><li>bar</li></ul></body></html>';
 
     $document = new HtmlDocument($html);
 
@@ -68,7 +69,7 @@ test('the querySelectorAll() method returns a NodeList of HtmlElement objects', 
 });
 
 test('the queryXPath() method returns a NodeList of HtmlElement objects', function () {
-    $html = '<html><head><title>foo</title></head><body><ul><li>foo</li><li>bar</li></ul></body></html>';
+    $html = '<!doctype html><html><head><title>foo</title></head><body><ul><li>foo</li><li>bar</li></ul></body></html>';
 
     $document = new HtmlDocument($html);
 

--- a/tests/Steps/Dom/HtmlElementTest.php
+++ b/tests/Steps/Dom/HtmlElementTest.php
@@ -8,6 +8,7 @@ use Crwlr\Crawler\Steps\Dom\NodeList;
 
 test('child nodes selected via querySelector() are HtmlElement instances', function () {
     $html = <<<HTML
+        <!doctype html>
         <html>
         <head></head>
         <body>
@@ -26,6 +27,7 @@ test('child nodes selected via querySelector() are HtmlElement instances', funct
 
 test('child nodes selected via querySelectorAll() are HtmlElement instances', function () {
     $html = <<<HTML
+        <!doctype html>
         <html>
         <head></head>
         <body>
@@ -53,6 +55,7 @@ test('child nodes selected via querySelectorAll() are HtmlElement instances', fu
 
 test('child nodes selected via queryXPath() are HtmlElement instances', function () {
     $html = <<<HTML
+        <!doctype html>
         <html>
         <head></head>
         <body>
@@ -82,6 +85,7 @@ test('child nodes selected via queryXPath() are HtmlElement instances', function
 
 it('gets the node name', function () {
     $html = <<<HTML
+        <!doctype html>
         <html>
         <head></head>
         <body>
@@ -100,6 +104,7 @@ it('gets the node name', function () {
 
 it('gets the text of a node', function () {
     $html = <<<HTML
+        <!doctype html>
         <html>
         <head></head>
         <body>
@@ -119,6 +124,7 @@ it('gets the text of a node', function () {
 
 it('gets the outer HTML of a node', function () {
     $html = <<<HTML
+        <!doctype html>
         <html>
         <head></head>
         <body>
@@ -142,6 +148,7 @@ it('gets the outer HTML of a node', function () {
 
 it('gets the inner HTML of a node', function () {
     $html = <<<HTML
+        <!doctype html>
         <html>
         <head></head>
         <body>
@@ -164,6 +171,7 @@ it('gets the inner HTML of a node', function () {
 
 it('gets an attribute from a node', function () {
     $html = <<<HTML
+        <!doctype html>
         <html>
         <head></head>
         <body>

--- a/tests/Steps/Dom/NodeListTest.php
+++ b/tests/Steps/Dom/NodeListTest.php
@@ -11,6 +11,7 @@ use Symfony\Component\DomCrawler\Crawler;
 
 it('can be constructed from a symfony Crawler instance', function () {
     $html = <<<HTML
+        <!doctype html>
         <html>
         <head></head>
         <body>
@@ -40,6 +41,7 @@ it('can be constructed from a symfony Crawler instance', function () {
 
 it('can be constructed from a \Dom\NodeList instance', function () {
     $html = <<<HTML
+        <!doctype html>
         <html>
         <head></head>
         <body>
@@ -67,6 +69,7 @@ it('can be constructed from a \Dom\NodeList instance', function () {
 
 it('can be instantiated from an array of Nodes (object instances from this library)', function () {
     $html = <<<HTML
+        <!doctype html>
         <html>
         <head></head>
         <body>
@@ -95,6 +98,7 @@ it('can be instantiated from an array of Nodes (object instances from this libra
 
 it('gets the count of the node list', function () {
     $html = <<<HTML
+        <!doctype html>
         <html>
         <head>
             <title>Foo</title>
@@ -112,6 +116,7 @@ it('gets the count of the node list', function () {
 
 it('can be iterated and the elements are instances of Crwlr\Crawler\Steps\Dom\Node', function () {
     $html = <<<HTML
+        <!doctype html>
         <html>
         <head>
             <title>Foo</title>
@@ -139,6 +144,7 @@ it(
     'can be iterated with the each() method and return values are returned as an array from the each() call',
     function () {
         $html = <<<HTML
+            <!doctype html>
             <html>
             <head></head>
             <body>
@@ -169,6 +175,7 @@ it(
 
 test('an empty NodeList can be iterated', function () {
     $html = <<<HTML
+        <!doctype html>
         <html>
         <head>
             <title>Foo</title>
@@ -192,6 +199,7 @@ test('an empty NodeList can be iterated', function () {
 
 it('returns the first, last and nth element of the NodeList', function () {
     $html = <<<HTML
+        <!doctype html>
         <html>
         <head></head>
         <body>

--- a/tests/Steps/Dom/NodeTest.php
+++ b/tests/Steps/Dom/NodeTest.php
@@ -13,6 +13,7 @@ use Exception;
 use Symfony\Component\DomCrawler\Crawler;
 use tests\Steps\Dom\_Stubs\HtmlNodeStub;
 use tests\Steps\Dom\_Stubs\XmlNodeStub;
+
 use const DOM\HTML_NO_DEFAULT_NS;
 
 function helper_getSymfonyCrawlerInstanceFromSource(string $source, string $selectNode = 'body'): Crawler

--- a/tests/Steps/Dom/NodeTest.php
+++ b/tests/Steps/Dom/NodeTest.php
@@ -13,6 +13,7 @@ use Exception;
 use Symfony\Component\DomCrawler\Crawler;
 use tests\Steps\Dom\_Stubs\HtmlNodeStub;
 use tests\Steps\Dom\_Stubs\XmlNodeStub;
+use const DOM\HTML_NO_DEFAULT_NS;
 
 function helper_getSymfonyCrawlerInstanceFromSource(string $source, string $selectNode = 'body'): Crawler
 {
@@ -35,7 +36,7 @@ function helper_getLegacyDomNodeInstanceFromSource(string $source, string $selec
 
 function helper_getPhp84HtmlDomNodeInstanceFromSource(string $source, string $selectNode = 'body'): \Dom\Node
 {
-    return HTMLDocument::createFromString($source, LIBXML_NOERROR)->querySelector($selectNode);
+    return HTMLDocument::createFromString($source, HTML_NO_DEFAULT_NS | LIBXML_NOERROR)->querySelector($selectNode);
 }
 
 function helper_getPhp84XmlDomNodeInstanceFromSource(string $source, string $selectNode = 'body'): \Dom\Node
@@ -125,17 +126,18 @@ it('can be instantiated from a DOMNode instance', function () {
 });
 
 $html = <<<HTML
-        <html>
-        <head>
-            <title>Foo</title>
-        </head>
-        <body>
-            <div class="foo">
-                <h1>Title</h1>
-            </div>
-        </body>
-        </html>
-        HTML;
+    <!doctype html>
+    <html>
+    <head>
+        <title>Foo</title>
+    </head>
+    <body>
+        <div class="foo">
+            <h1>Title</h1>
+        </div>
+    </body>
+    </html>
+    HTML;
 
 it('selects an element within a node via querySelector()', function (object $originalNode) {
     /** @var Crawler|DOMNode $originalNode */
@@ -162,6 +164,7 @@ it('selects an element within a node via querySelector() in PHP >= 8.4', functio
 })->group('php84');
 
 $html = <<<HTML
+    <!doctype html>
     <html>
     <head><title>Bar</title></head>
     <body>
@@ -206,6 +209,7 @@ it(
 )->group('php84');
 
 $html = <<<HTML
+    <!doctype html>
     <html>
     <head><title>Foo</title></head>
     <body>
@@ -318,6 +322,7 @@ it(
 )->group('php84');
 
 $html = <<<HTML
+    <!doctype html>
     <html>
     <head><title>Lorem Ipsum</title></head>
     <body>
@@ -390,6 +395,7 @@ it(
 )->group('php84');
 
 $html = <<<HTML
+    <!doctype html>
     <html>
     <head><title>Foo</title></head>
     <body>
@@ -417,6 +423,7 @@ it('gets the value of an attribute in PHP >= 8.4', function () use ($html) {
 })->group('php84');
 
 $html = <<<HTML
+    <!doctype html>
     <html>
     <head><title>Foo</title></head>
     <body><div class="element"></div></body>
@@ -460,6 +467,7 @@ it('gets the name of a node in PHP >= 8.4', function () use ($html) {
 })->group('php84');
 
 $html = <<<HTML
+    <!doctype html>
     <html>
     <head><title>Bar</title></head>
     <body>
@@ -582,6 +590,7 @@ it('gets the outer source of an XML node in PHP >= 8.4', function () use ($xml) 
 })->group('php84');
 
 $html = <<<HTML
+    <!doctype html>
     <html>
     <head><title>Bar</title></head>
     <body>

--- a/tests/Steps/Loading/Http/DocumentTest.php
+++ b/tests/Steps/Loading/Http/DocumentTest.php
@@ -9,7 +9,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 
 it('creates a HtmlDocument instance from a RespondedRequest', function () {
-    $body = '<html><head><title>foo</title></head><body>hello</body></html>';
+    $body = '<!DOCTYPE html><html><head><title>foo</title></head><body>hello</body></html>';
 
     $respondedRequest = new RespondedRequest(
         new Request('GET', 'https://www.example.com/foo'),
@@ -19,11 +19,13 @@ it('creates a HtmlDocument instance from a RespondedRequest', function () {
     $document = new Document($respondedRequest);
 
     expect($document->dom())->toBeInstanceOf(HtmlDocument::class)
-        ->and($document->dom()->outerHtml())->toBe('<html><head><title>foo</title></head><body>hello</body></html>');
+        ->and($document->dom()->outerHtml())->toBe(
+            '<html><head><title>foo</title></head><body>hello</body></html>',
+        );
 });
 
 it('returns the effectiveUri as url()', function () {
-    $body = '<html><head><title>foo</title><base href="/baz" /></head><body>hello</body></html>';
+    $body = '<!doctype html><html><head><title>foo</title><base href="/baz" /></head><body>hello</body></html>';
 
     $respondedRequest = new RespondedRequest(
         new Request('GET', 'https://www.example.com/foo'),
@@ -51,7 +53,7 @@ it('returns the effectiveUri as baseUrl() if no base tag in HTML', function () {
 });
 
 it('returns the URL referenced in base tag as baseUrl()', function () {
-    $body = '<html><head><title>foo</title><base href="/baz" /></head><body>hello</body></html>';
+    $body = '<!doctype html><html><head><title>foo</title><base href="/baz" /></head><body>hello</body></html>';
 
     $respondedRequest = new RespondedRequest(
         new Request('GET', 'https://www.example.com/foo'),
@@ -79,7 +81,7 @@ it('returns the effectiveUri as canonicalUrl() if no canonical link in HTML', fu
 });
 
 it('returns the URL referenced in canonical link as canonicalUrl()', function () {
-    $body = '<html><head><title>foo</title><link rel="canonical" href="/quz" /></head><body>hello</body></html>';
+    $body = '<!doctype html><html><head><title>foo</title><link rel="canonical" href="/quz" /></head><body>hello</body></html>';
 
     $respondedRequest = new RespondedRequest(
         new Request('GET', 'https://www.example.com/foo'),

--- a/tests/Steps/Loading/Http/Paginators/StopRules/IsEmptyInJsonTest.php
+++ b/tests/Steps/Loading/Http/Paginators/StopRules/IsEmptyInJsonTest.php
@@ -19,7 +19,7 @@ it('throws an exception when response is not valid JSON', function () {
 
     $respondedRequest = new RespondedRequest(
         new Request('GET', 'https://www.crwl.io/'),
-        new Response(body: '<html></html>'),
+        new Response(body: '<!doctype html><html></html>'),
     );
 
     expect($rule->shouldStop($respondedRequest->request, $respondedRequest))->toBeTrue();


### PR DESCRIPTION
I found that I was wrong about XPath not being available for usage with the new DOM API in PHP 8.4. As it is still available, remove the deprecations introduced in 3.0.0.