### PR TITLE
Empty DOM Queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ vendor
 .phpunit.result.cache
 .phpunit.cache
 /cachedir
+/storedir
 /tests/_Temp/_cachedir/*
 !/tests/_Temp/_cachedir/.gitkeep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### [3.0.4] - 2024-12-18
+### Fixed
+* Minor improvement for the `DomQuery` (base for `Dom::cssSelector()` and `Dom::xPath()`): enable providing an empty string as selector, to simply get the node that the selector is applied to.
+
 ### [3.0.3] - 2024-12-11
 ### Fixed
 * Improved fix for non UTF-8 characters in HTML documents declared as UTF-8.

--- a/src/Steps/Html/CssSelector.php
+++ b/src/Steps/Html/CssSelector.php
@@ -19,17 +19,21 @@ final class CssSelector extends DomQuery
      */
     public function __construct(string $query)
     {
-        if (PhpVersion::isBelow(8, 4)) {
-            try {
-                (new CssSelectorConverter())->toXPath($query);
-            } catch (ExpressionErrorException|SyntaxErrorException $exception) {
-                throw InvalidDomQueryException::fromSymfonyException($query, $exception);
-            }
-        } else {
-            try {
-                (new HtmlDocument('<!doctype html><html></html>'))->querySelector($query);
-            } catch (DOMException $exception) {
-                throw InvalidDomQueryException::fromDomException($query, $exception);
+        $query = trim($query);
+
+        if ($query !== '') {
+            if (PhpVersion::isBelow(8, 4)) {
+                try {
+                    (new CssSelectorConverter())->toXPath($query);
+                } catch (ExpressionErrorException|SyntaxErrorException $exception) {
+                    throw InvalidDomQueryException::fromSymfonyException($query, $exception);
+                }
+            } else {
+                try {
+                    (new HtmlDocument('<!doctype html><html></html>'))->querySelector($query);
+                } catch (DOMException $exception) {
+                    throw InvalidDomQueryException::fromDomException($query, $exception);
+                }
             }
         }
 
@@ -38,6 +42,10 @@ final class CssSelector extends DomQuery
 
     protected function filter(Node $node): NodeList
     {
+        if ($this->query === '') {
+            return new NodeList([$node]);
+        }
+
         return $node->querySelectorAll($this->query);
     }
 }

--- a/src/Steps/Html/XPathQuery.php
+++ b/src/Steps/Html/XPathQuery.php
@@ -15,13 +15,21 @@ class XPathQuery extends DomQuery
      */
     public function __construct(string $query)
     {
-        $this->validateQuery($query);
+        $query = trim($query);
 
-        parent::__construct($query);
+        if ($query !== '') {
+            $this->validateQuery($query);
+        }
+
+        parent::__construct(trim($query));
     }
 
     protected function filter(Node $node): NodeList
     {
+        if ($this->query === '') {
+            return new NodeList([$node]);
+        }
+
         return $node->queryXPath($this->query);
     }
 

--- a/tests/Steps/HtmlTest.php
+++ b/tests/Steps/HtmlTest.php
@@ -156,6 +156,52 @@ test(
     },
 );
 
+test(
+    'when selecting elements with each(), you can reference the element already selected within the each() selector ' .
+    'itself, in sub selectors',
+    function () {
+        $html = <<<HTML
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+                <title>Bookstore Example in HTML :)</title>
+            </head>
+            <body>
+                <div id="list">
+                    <div class="element" data-attr="yo">
+                        <a href="/bar">direct element child</a>
+                        <div class="sub-element">
+                            <a href="/baz">sub child</a>
+                        </div>
+                    </div>
+                </div>
+            </body>
+            </html>
+            HTML;
+
+        $response = new RespondedRequest(
+            new Request('GET', 'https://www.example.com/foo'),
+            new Response(body: $html),
+        );
+
+        $output = helper_invokeStepWithInput(
+            Html::each('#list .element')->extract([
+                // This is what this test is about. The element already selected in each (.element) can be
+                // referenced in these child selectors.
+                'link' => Dom::cssSelector('.element > a')->link(),
+                'attribute' => Dom::cssSelector('')->attribute('data-attr'),
+            ]),
+            $response,
+        );
+
+        expect($output)->toHaveCount(1)
+            ->and($output[0]->get())->toBe([
+                'link' => 'https://www.example.com/bar',
+                'attribute' => 'yo',
+            ]);
+    },
+);
+
 test('the static getLink method works without argument', function () {
     expect(Html::getLink())->toBeInstanceOf(GetLink::class);
 });

--- a/tests/Steps/XmlTest.php
+++ b/tests/Steps/XmlTest.php
@@ -176,6 +176,46 @@ it('works when the response string starts with an UTF-8 byte order mark characte
     ]);
 });
 
+test(
+    'when selecting elements with each(), you can reference the element already selected within the each() selector ' .
+    'itself, in sub selectors',
+    function () {
+        $xml = <<<XML
+            <?xml version="1.0" encoding="utf-8"?>
+            <data>
+                <items>
+                    <item attr="abc">
+                        <id>123</id>
+                        <subitems>
+                            <subitem>
+                                <id>456</id>
+                            </subitem>
+                        </subitems>
+                    </item>
+                </items>
+            </data>
+            XML;
+
+        $response = new RespondedRequest(
+            new Request('GET', 'https://www.example.com/foo'),
+            new Response(body: $xml),
+        );
+
+        $output = helper_invokeStepWithInput(
+            Xml::each('data items item')->extract([
+                // This is what this test is about. The element already selected in each (item) can be
+                // referenced in these child selectors.
+                'id' => Dom::cssSelector('item > id'),
+                'attribute' => Dom::cssSelector('')->attribute('attr'),
+            ]),
+            $response,
+        );
+
+        expect($output)->toHaveCount(1)
+            ->and($output[0]->get())->toBe(['id' => '123', 'attribute' => 'abc']);
+    },
+);
+
 it('works with tags with camelCase names', function () {
     $xml = <<<XML
         <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
Minor improvement for the `DomQuery` (base for `Dom::cssSelector()` and `Dom::xPath()`): enable providing an empty string as selector, to simply get the node that the selector is applied to.