### PR TITLE
Two new HeadlessBrowserLoaderHelper features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### [3.1.0] - 2025-01-03
+### Added
+* New method `HeadlessBrowserLoaderHelper::setPageInitScript()` (`$crawler->getLoader()->browser()->setPageInitScript()`) to provide javascript code that is executed on every new browser page before navigating anywhere.
+* New method `HeadlessBrowserLoaderHelper::useNativeUserAgent()` (`$crawler->getLoader()->browser()->useNativeUserAgent()`) to allow using the native `User-Agent` that your Chrome browser sends by default.
+
 ### [3.0.4] - 2024-12-18
 ### Fixed
 * Minor improvement for the `DomQuery` (base for `Dom::cssSelector()` and `Dom::xPath()`): enable providing an empty string as selector, to simply get the node that the selector is applied to.

--- a/tests/_Integration/Server.php
+++ b/tests/_Integration/Server.php
@@ -208,3 +208,7 @@ if (str_starts_with($route, '/redirect')) {
 if (str_starts_with($route, '/non-utf-8-charset')) {
     return include(__DIR__ . '/_Server/NonUtf8.php');
 }
+
+if (str_starts_with($route, '/page-init-script')) {
+    return include(__DIR__ . '/_Server/PageInitScript.php');
+}

--- a/tests/_Integration/_Server/PageInitScript.php
+++ b/tests/_Integration/_Server/PageInitScript.php
@@ -1,0 +1,11 @@
+<!Doctype html>
+<html>
+<head>
+</head>
+<body>
+<div id="content"></div>
+<script>
+    document.getElementById('content').innerHTML = window._secret_content;
+</script>
+</body>
+</html>


### PR DESCRIPTION
* New method `HeadlessBrowserLoaderHelper::setPageInitScript()` (`$crawler->getLoader()->browser()->setPageInitScript()`) to provide javascript code that is executed on every new browser page before navigating anywhere.
* New method `HeadlessBrowserLoaderHelper::useNativeUserAgent()` (`$crawler->getLoader()->browser()->useNativeUserAgent()`) to allow using the native `User-Agent` that your Chrome browser sends by default.