### PR TITLE
Fix getting non HTML documents via browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### [3.1.2] - 2025-01-08
+### Fixed
+* When loading a non-HTML document (e.g., XML) via the Chrome browser, the library now retrieves the original source. Previously, it returned the outerHTML of the rendered document, which wrapped the content in an HTML structure.
+
 ### [3.1.1] - 2025-01-07
 ### Fixed
 * When the `validateAndSanitize()` method of a step throws an `InvalidArgumentException`, the exception is now caught, logged and the step is not invoked with the invalid input. This improves fault tolerance. Feeding a step with one invalid input shouldn't cause the whole crawler run to fail. Exceptions other than `InvalidArgumentException` remain uncaught.

--- a/tests/_Integration/Http/HeadlessBrowserTest.php
+++ b/tests/_Integration/Http/HeadlessBrowserTest.php
@@ -305,3 +305,15 @@ it('executes the javascript code provided via HeadlessBrowserLoaderHelper::setPa
 
     expect($results[0]->get('content'))->toBe('secret content');
 });
+
+it('gets the source of an XML response without being wrapped in an HTML document', function () {
+    $crawler = new HeadlessBrowserCrawler();
+
+    $crawler
+        ->input('http://localhost:8000/rss-feed')
+        ->addStep(Http::get()->keep(['body']));
+
+    $results = helper_generatorToArray($crawler->run());
+
+    expect($results[0]->get('body'))->toStartWith('<?xml version="1.0" encoding="utf-8"?>' . PHP_EOL . '<rss');
+});

--- a/tests/_Integration/Server.php
+++ b/tests/_Integration/Server.php
@@ -212,3 +212,9 @@ if (str_starts_with($route, '/non-utf-8-charset')) {
 if (str_starts_with($route, '/page-init-script')) {
     return include(__DIR__ . '/_Server/PageInitScript.php');
 }
+
+if ($route === '/rss-feed') {
+    header('Content-Type: text/xml; charset=utf-8');
+
+    return include(__DIR__ . '/_Server/RssFeed.php');
+}

--- a/tests/_Integration/_Server/RssFeed.php
+++ b/tests/_Integration/_Server/RssFeed.php
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xml:base="https://www.example.com" xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/"
+     xmlns:content="http://purl.org/rss/1.0/modules/content/">
+    <channel>
+        <title>Example</title>
+        <link>https://www.example.com</link>
+        <description>Public RSS feed</description>
+        <language>en</language>
+        <atom:link href="https://www.example.com/feeds/rss.xml" rel="self" type="application/rss+xml" />
+        <item>
+            <title><![CDATA[Foo, bar, baz]]></title>
+            <link><![CDATA[https://www.example.com/foo/bar-baz]]></link>
+            <description><![CDATA[Lorem ipsum]]></description>
+            <pubDate>Wed, 08 Jan 2025 12:14:47 GMT</pubDate>
+            <dc:creator>Christian Olear</dc:creator>
+            <guid isPermaLink="false"><![CDATA[https://www.example.com/foo/bar-baz]]></guid>
+            <media:thumbnail url="https://images.example.com/foo-bar-baz.jpg" />
+        </item>
+    </channel>
+</rss>


### PR DESCRIPTION
When loading a non-HTML document (e.g., XML) via the Chrome browser, the library now retrieves the original source. Previously, it returned the outerHTML of the rendered document, which wrapped the content in an HTML structure.