### PR TITLE
Fix HttpLoader::dontUseCookies() with browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.4] - 2025-01-10
+### Fixed
+* `HttpLoader::dontUseCookies()` now also works when using the Chrome browser. Cookies are cleared before every request.
+
 ## [3.1.3] - 2025-01-10
 ### Fixed
 * Further improve getting the raw response body from non-HTML documents via Chrome browser.

--- a/src/Loader/Http/HeadlessBrowserLoaderHelper.php
+++ b/src/Loader/Http/HeadlessBrowserLoaderHelper.php
@@ -93,6 +93,10 @@ class HeadlessBrowserLoaderHelper
     ): RespondedRequest {
         $this->page = $this->getBrowser($request, $proxy)->createPage();
 
+        if ($cookieJar === null) {
+            $this->page->getSession()->sendMessageSync(new Message('Network.clearBrowserCookies'));
+        }
+
         $statusCode = 200;
 
         $responseHeaders = [];

--- a/src/Loader/Http/HttpLoader.php
+++ b/src/Loader/Http/HttpLoader.php
@@ -393,7 +393,7 @@ class HttpLoader extends Loader
                 $request,
                 $this->throttler,
                 $proxy,
-                $this->cookieJar,
+                $this->useCookies ? $this->cookieJar : null,
             );
         }
 

--- a/tests/_Integration/Http/HeadlessBrowserTest.php
+++ b/tests/_Integration/Http/HeadlessBrowserTest.php
@@ -132,6 +132,29 @@ it('uses cookies', function () {
         ->and($results[0]->get('printed-cookie'))->toBe('foo123');
 });
 
+it('does not use cookies when HttpLoader::dontUseCookies() was called', function () {
+    $crawler = new HeadlessBrowserCrawler();
+
+    $crawler->getLoader()->dontUseCookies();
+
+    $crawler
+        ->input('http://localhost:8000/set-cookie')
+        ->addStep(Http::get())
+        ->addStep(new class extends Step {
+            protected function invoke(mixed $input): Generator
+            {
+                yield 'http://localhost:8000/print-cookie';
+            }
+        })
+        ->addStep(Http::get())
+        ->addStep((new GetStringFromResponseHtmlBody())->keepAs('printed-cookie'));
+
+    $results = helper_generatorToArray($crawler->run());
+
+    expect($results)->toHaveCount(1)
+        ->and($results[0]->get('printed-cookie'))->toBeEmpty();
+});
+
 it('renders javascript', function () {
     $crawler = new HeadlessBrowserCrawler();
 


### PR DESCRIPTION
`HttpLoader::dontUseCookies()` now also works when using the Chrome browser. Cookies are cleared before every request.