### PR TITLE
Get XML via chrome improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.5] - 2025-01-10
+### Fixed
+* Another improvement for getting XML source when using the browser, in cases where Chrome doesn't identify the response as an XML document (even though a Content-Type header is sent).
+
 ## [3.1.4] - 2025-01-10
 ### Fixed
 * `HttpLoader::dontUseCookies()` now also works when using the Chrome browser. Cookies are cleared before every request.

--- a/src/Loader/Http/HeadlessBrowserLoaderHelper.php
+++ b/src/Loader/Http/HeadlessBrowserLoaderHelper.php
@@ -385,7 +385,10 @@ class HeadlessBrowserLoaderHelper
 
         try {
             return $page->evaluate(
-                'document.contentType === \'text/html\' || document instanceof HTMLDocument',
+                <<<JS
+                (document.contentType === 'text/html' || document instanceof HTMLDocument) &&
+                !(document.contentType === 'text/plain' && document.body.textContent.trimLeft().startsWith('<?xml '))
+                JS,
             )->getReturnValue(3000);
         } catch (Throwable $e) {
             return true;

--- a/tests/_Integration/Http/HeadlessBrowserTest.php
+++ b/tests/_Integration/Http/HeadlessBrowserTest.php
@@ -340,3 +340,19 @@ it('gets the source of an XML response without being wrapped in an HTML document
 
     expect($results[0]->get('body'))->toStartWith('<?xml version="1.0" encoding="utf-8"?>' . PHP_EOL . '<rss');
 });
+
+it(
+    'gets the source of an XML response without being wrapped in an HTML document even when chrome does not ' .
+    'identify the document as an XML document',
+    function () {
+        $crawler = new HeadlessBrowserCrawler();
+
+        $crawler
+            ->input('http://localhost:8000/broken-mime-type-rss')
+            ->addStep(Http::get()->keep(['body']));
+
+        $results = helper_generatorToArray($crawler->run());
+
+        expect($results[0]->get('body'))->toStartWith('<?xml version="1.0" encoding="UTF-8"?>');
+    },
+);

--- a/tests/_Integration/Server.php
+++ b/tests/_Integration/Server.php
@@ -218,3 +218,9 @@ if ($route === '/rss-feed') {
 
     return include(__DIR__ . '/_Server/RssFeed.php');
 }
+
+if ($route === '/broken-mime-type-rss') {
+    header('Content-Type: application/rss+xml; charset=UTF-8');
+
+    return include(__DIR__ . '/_Server/BrokenMimeTypeRss.php');
+}

--- a/tests/_Integration/_Server/BrokenMimeTypeRss.php
+++ b/tests/_Integration/_Server/BrokenMimeTypeRss.php
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"
+                                           xmlns:content="http://purl.org/rss/1.0/modules/content/"
+                                           xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+                                           xmlns:dc="http://purl.org/dc/elements/1.1/"
+                                           xmlns:atom="http://www.w3.org/2005/Atom"
+                                           xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
+                                           xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
+>
+
+    <channel>
+        <title>Lorem ipsum</title>
+        <atom:link href="https://www.example.com/feed/" rel="self" type="application/rss+xml" />
+        <link>https://www.example.com/</link>
+        <description>Lorem ipsum dolor sit amet</description>
+        <lastBuildDate>Fri, 10 Jan 2025 10:48:01 +0000</lastBuildDate>
+        <language>en</language>
+        <sy:updatePeriod>
+            hourly	</sy:updatePeriod>
+        <sy:updateFrequency>
+            1	</sy:updateFrequency>
+
+        <item>
+            <title>Foo</title>
+            <link>https://www.example.com/some-article</link>
+            <comments>https://www.example.com/some-article#comments</comments>
+
+            <dc:creator><![CDATA[Christian Olear]]></dc:creator>
+            <pubDate>Fri, 10 Jan 2025 10:48:01 +0000</pubDate>
+            <category><![CDATA[Foo]]></category>
+            <category><![CDATA[Bar]]></category>
+            <category><![CDATA[Baz]]></category>
+            <guid isPermaLink="false">https://www.example.com/?a=123</guid>
+
+            <description><![CDATA[<p>Lorem ipsum dolor</p><p>sit amet</p>]]></description>
+
+
+            <enclosure url="https://www.example.com/some-article/image.jpg" type="image/jpeg" />	</item>
+    </channel>
+</rss>


### PR DESCRIPTION
Another improvement for getting XML source when using the browser, in cases where Chrome doesn't identify the response as an XML document (even though a Content-Type header is sent).