### PR TITLE
Reuse previously opened browser page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### [3.2.1] - 2025-01-13
+### Fixed
+* Reuse previously opened page when using the (headless) Chrome browser, instead of opening a new page for each request.
+
 ### [3.2.0] - 2025-01-12
 ### Added
 * `RespondedRequest::isServedFromCache()` to determine whether a response was served from cache or actually loaded.

--- a/tests/Loader/Http/HttpLoaderPolitenessTest.php
+++ b/tests/Loader/Http/HttpLoaderPolitenessTest.php
@@ -68,6 +68,8 @@ it('also throttles requests using the headless browser', function ($loadingMetho
 
     $sessionMock->shouldReceive('once');
 
+    $pageMock->shouldReceive('assertNotClosed')->once();
+
     $pageMock->shouldReceive('getSession')->andReturn($sessionMock);
 
     $pageNavigationMock = Mockery::mock(PageNavigation::class);


### PR DESCRIPTION
Reuse previously opened page when using the (headless) Chrome browser, instead of opening a new page for each request.