### PR TITLE
Fix loader hooks warning with BotUserAgent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### [3.2.1] - 2025-01-13
+## [3.2.2] - 2025-01-17
+### Fixed
+* Warnings about loader hooks being called multiple times, when using a `BotUserAgent` and therefore loading and respecting the robots.txt file, or when using the `Http::stopOnErrorResponse()` method.
+
+## [3.2.1] - 2025-01-13
 ### Fixed
 * Reuse previously opened page when using the (headless) Chrome browser, instead of opening a new page for each request.
 
-### [3.2.0] - 2025-01-12
+## [3.2.0] - 2025-01-12
 ### Added
 * `RespondedRequest::isServedFromCache()` to determine whether a response was served from cache or actually loaded.
 
@@ -315,7 +319,7 @@ Since no direct interaction with an instance of the Symfony DomCrawler library w
 * The `HttpCrawl` step (`Http::crawl()`) by default now removes the fragment part of URLs to not load the same page multiple times, because in almost any case, servers won't respond with different content based on the fragment. That's why this change is considered non-breaking. For the rare cases when servers respond with different content based on the fragment, you can call the new `keepUrlFragment()` method of the step.
 * Although the `HttpCrawl` step (`Http::crawl()`) already respected the limit of outputs defined via the `maxOutputs()` method, it actually didn't stop loading pages. The limit had no effect on loading, only on passing on outputs (responses) to the next step. This is fixed in this version.
 * A so-called byte order mark at the beginning of a file (/string) can cause issues. So just remove it, when a step's input string starts with a UTF-8 BOM.
-* There seems to be an issue in guzzle when it gets a PSR-7 request object with a header with multiple string values (as array, like: `['accept-encoding' => ['gzip', 'deflate', 'br']]`). When testing it happened that it only sent the last part (in this case `br`). Therefor the `HttpLoader` now prepares headers before sending (in this case to: `['accept-encoding' => ['gzip, deflate, br']]`).
+* There seems to be an issue in guzzle when it gets a PSR-7 request object with a header with multiple string values (as array, like: `['accept-encoding' => ['gzip', 'deflate', 'br']]`). When testing it happened that it only sent the last part (in this case `br`). Therefore, the `HttpLoader` now prepares headers before sending (in this case to: `['accept-encoding' => ['gzip, deflate, br']]`).
 * You can now also use the output key aliases when filtering step outputs. You can even use keys that are only present in the serialized version of an output object.
 
 ## [1.0.2] - 2023-03-20
@@ -351,7 +355,7 @@ Since no direct interaction with an instance of the Symfony DomCrawler library w
 ### Added
 * New functionality to paginate: There is the new `Paginate` child class of the `Http` step class (easy access via `Http::get()->paginate()`). It takes an instance of the `PaginatorInterface` and uses it to iterate through pagination links. There is one implementation of that interface, the `SimpleWebsitePaginator`. The `Http::get()->paginate()` method uses it by default, when called just with a CSS selector to get pagination links. Paginators receive all loaded pages and implement the logic to find pagination links. The paginator class is also called before sending a request, with the request object that is about to be sent as an argument (`prepareRequest()`). This way, it should even be doable to implement more complex pagination functionality. For example when pagination is built using POST request with query strings in the request body.
 * New methods `stopOnErrorResponse()` and `yieldErrorResponses()` that can be used with `Http` steps. By calling `stopOnErrorResponse()` the step will throw a `LoadingException` when a response has a 4xx or 5xx status code. By calling the `yieldErrorResponse()` even error responses will be yielded and passed on to the next steps (this was default behaviour until this version. See the breaking change below).
-* The body of HTTP responses with a `Content-Type` header containing `application/x-gzip` are automatically decoded when `Http::getBodyString()` is used. Therefor added `ext-zlib` to suggested in `composer.json`.
+* The body of HTTP responses with a `Content-Type` header containing `application/x-gzip` are automatically decoded when `Http::getBodyString()` is used. Therefore, added `ext-zlib` to suggested in `composer.json`.
 * New methods `addToResult()` and `addLaterToResult()`. `addToResult()` is a single replacement for `setResultKey()` and `addKeysToResult()` (they are removed, see `Changed` below) that can be used for array and non array output. `addLaterToResult()` is a new method that does not create a Result object immediately, but instead adds the output of the current step to all the Results that will later be created originating from the current output.
 * New methods `outputKey()` and `keepInputData()` that can be used with any step. Using the `outputKey()` method, the step will convert non array output to an array and use the key provided as an argument to this method as array key for the output value. The `keepInputData()` method allows you to forward data from the step's input to the output. If the input is non array you can define a key using the method's argument. This is useful e.g. if you're having data in the initial inputs that you also want to add to the final crawling results.
 * New method `createsResult()` that can be used with any step, so you can differentiate if a step creates a Result object, or just keeps data to add to results later (new `addLaterToResult()` method). But primarily relevant for library internal use.

--- a/src/Loader/Http/HttpLoader.php
+++ b/src/Loader/Http/HttpLoader.php
@@ -158,6 +158,8 @@ class HttpLoader extends Loader
             return null;
         } finally {
             $this->callHook('afterLoad', $request);
+
+            $this->_resetCalledHooks();
         }
     }
 
@@ -166,6 +168,8 @@ class HttpLoader extends Loader
      */
     public function loadOrFail(mixed $subject): RespondedRequest
     {
+        $this->_resetCalledHooks();
+
         $request = $this->validateSubjectType($subject);
 
         try {
@@ -189,6 +193,8 @@ class HttpLoader extends Loader
 
             return $respondedRequest;
         } catch (Throwable $exception) {
+            $this->_resetCalledHooks();
+
             throw LoadingException::from($exception);
         }
     }

--- a/tests/Steps/Filters/ComparisonFilterTest.php
+++ b/tests/Steps/Filters/ComparisonFilterTest.php
@@ -10,9 +10,8 @@ use function tests\helper_getStdClassWithData;
 it('compares a single value', function () {
     $comparison = new ComparisonFilter(ComparisonFilterRule::GreaterThan, 3);
 
-    expect($comparison->evaluate(4))->toBeTrue();
-
-    expect($comparison->evaluate(2))->toBeFalse();
+    expect($comparison->evaluate(4))->toBeTrue()
+        ->and($comparison->evaluate(2))->toBeFalse();
 });
 
 it('compares a value from an array by key', function () {
@@ -20,9 +19,8 @@ it('compares a value from an array by key', function () {
 
     $comparison->useKey('bar');
 
-    expect($comparison->evaluate(['foo' => 'fooValue', 'bar' => 'barValue']))->toBeFalse();
-
-    expect($comparison->evaluate(['foo' => 'fooValue', 'bar' => 'barzValue']))->toBeTrue();
+    expect($comparison->evaluate(['foo' => 'fooValue', 'bar' => 'barValue']))->toBeFalse()
+        ->and($comparison->evaluate(['foo' => 'fooValue', 'bar' => 'barzValue']))->toBeTrue();
 });
 
 it('compares a value from an object by key', function () {
@@ -30,7 +28,6 @@ it('compares a value from an object by key', function () {
 
     $comparison->useKey('bar');
 
-    expect($comparison->evaluate(helper_getStdClassWithData(['foo' => 'fooValue', 'bar' => 'barValue'])))->toBeFalse();
-
-    expect($comparison->evaluate(helper_getStdClassWithData(['foo' => 'fooValue', 'bar' => 'barzValue'])))->toBeTrue();
+    expect($comparison->evaluate(helper_getStdClassWithData(['foo' => 'fooValue', 'bar' => 'barValue'])))->toBeFalse()
+        ->and($comparison->evaluate(helper_getStdClassWithData(['foo' => 'fooValue', 'bar' => 'barzValue'])))->toBeTrue();
 });

--- a/tests/Steps/Filters/Enums/ComparisonFilterRuleTest.php
+++ b/tests/Steps/Filters/Enums/ComparisonFilterRuleTest.php
@@ -43,6 +43,18 @@ it('correctly applies greater than operator', function (bool $expectedResult, mi
     [false, 11, 11],
     [false, 0, 1],
     [false, 3.59, 3.591],
+    [true, '123', '122'],
+    [true, '123', 122],
+    [true, 123, '122'],
+    [false, '123', '124'],
+    [false, '123', 124],
+    [false, 123, '124'],
+    [true, '123.45', '123.44'],
+    [true, '123.45', 123.44],
+    [true, 123.45, '123.44'],
+    [false, '123.45', '123.46'],
+    [false, '123.45', 123.46],
+    [false, 123.45, '123.46'],
 ]);
 
 it('correctly applies greater than or equal operator', function (bool $expectedResult, mixed $value1, mixed $value2) {
@@ -56,6 +68,18 @@ it('correctly applies greater than or equal operator', function (bool $expectedR
     [true, 11, 11],
     [false, 0, 1],
     [false, 3.59, 3.591],
+    [true, '123', '122'],
+    [true, '123', 122],
+    [true, 123, '123'],
+    [false, '123', '124'],
+    [false, '123', 124],
+    [false, 123, '124'],
+    [true, '123.45', '123.44'],
+    [true, '123.44', 123.44],
+    [true, 123.45, '123.44'],
+    [false, '123.45', '123.46'],
+    [false, '123.45', 123.46],
+    [false, 123.45, '123.46'],
 ]);
 
 it('correctly applies less than operator', function (bool $expectedResult, mixed $value1, mixed $value2) {
@@ -69,6 +93,18 @@ it('correctly applies less than operator', function (bool $expectedResult, mixed
     [false, 11, 11],
     [false, 1, 0],
     [false, 9.2901, 9.29],
+    [true, '123', '124'],
+    [true, '123', 124],
+    [true, 123, '124'],
+    [false, '123', '122'],
+    [false, '123', 122],
+    [false, 123, '122'],
+    [true, '123.45', '123.46'],
+    [true, '123.45', 123.46],
+    [true, 123.45, '123.46'],
+    [false, '123.45', '123.44'],
+    [false, '123.45', 123.44],
+    [false, 123.45, '123.44'],
 ]);
 
 it('correctly applies less than or equal operator', function (bool $expectedResult, mixed $value1, mixed $value2) {
@@ -82,4 +118,16 @@ it('correctly applies less than or equal operator', function (bool $expectedResu
     [true, 11, 11],
     [false, 1, 0],
     [false, 9.2901, 9.29],
+    [true, '123', '124'],
+    [true, '123', 124],
+    [true, 123, '123'],
+    [false, '123', '122'],
+    [false, '123', 122],
+    [false, 123, '122'],
+    [true, '123.45', '123.46'],
+    [true, '123.45', 123.45],
+    [true, 123.45, '123.46'],
+    [false, '123.45', '123.44'],
+    [false, '123.45', 123.44],
+    [false, 123.45, '123.44'],
 ]);

--- a/tests/_Integration/Http/RobotsTxtTest.php
+++ b/tests/_Integration/Http/RobotsTxtTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace tests\_Integration\Http;
+
+use Crwlr\Crawler\HttpCrawler;
+use Crwlr\Crawler\Loader\LoaderInterface;
+use Crwlr\Crawler\Steps\Html;
+use Crwlr\Crawler\Steps\Loading\Http;
+use Crwlr\Crawler\UserAgents\BotUserAgent;
+use Crwlr\Crawler\UserAgents\UserAgentInterface;
+use Psr\Log\LoggerInterface;
+use tests\_Stubs\DummyLogger;
+
+use function tests\helper_generatorToArray;
+use function tests\helper_getFastLoader;
+
+/**
+ * @method DummyLogger getLogger()
+ */
+class RobotsTxtCrawler extends HttpCrawler
+{
+    protected function logger(): LoggerInterface
+    {
+        return new DummyLogger();
+    }
+
+    protected function userAgent(): UserAgentInterface
+    {
+        return new BotUserAgent('MyBot');
+    }
+
+    public function loader(UserAgentInterface $userAgent, LoggerInterface $logger): LoaderInterface
+    {
+        return helper_getFastLoader($userAgent, $logger);
+    }
+}
+
+it('does not warn about loader hooks being called multiple times', function () {
+    // This occurred because the RobotsTxtHandler, used by the HttpLoader, loads the robots.txt via HttpLoader::load().
+    // The call to the RobotsTxtHandler is triggered from within HttpLoader::load(), after the loader hooks
+    // had already been reset at the start of the load() method. Resetting the loader hooks not only at the beginning
+    // but also at the end of HttpLoader::load() resolves the issue.
+    $crawler = new RobotsTxtCrawler();
+
+    $crawler
+        ->input('http://localhost:8000/hello-world')
+        ->addStep(Http::get())
+        ->addStep(Html::root()->extract('body')->keepAs('body'));
+
+    $results = helper_generatorToArray($crawler->run());
+
+    expect($results[0]->get('body'))->toBe('Hello World!');
+
+    $logger = $crawler->getLogger();
+
+    foreach ($logger->messages as $message) {
+        expect($message['message'])->not->toContain(' was already called in this load call.');
+    }
+});
+
+it('also does not warn about loader hooks being called multiple times when loadOrFail() is used', function () {
+    // See comment in the test above.
+    $crawler = new RobotsTxtCrawler();
+
+    $crawler
+        ->input('http://localhost:8000/hello-world')
+        ->addStep(Http::get()->stopOnErrorResponse())
+        ->addStep(Html::root()->extract('body')->keepAs('body'));
+
+    $results = helper_generatorToArray($crawler->run());
+
+    expect($results[0]->get('body'))->toBe('Hello World!');
+
+    $logger = $crawler->getLogger();
+
+    foreach ($logger->messages as $message) {
+        expect($message['message'])->not->toContain(' was already called in this load call.');
+    }
+});

--- a/tests/_Integration/Server.php
+++ b/tests/_Integration/Server.php
@@ -224,3 +224,14 @@ if ($route === '/broken-mime-type-rss') {
 
     return include(__DIR__ . '/_Server/BrokenMimeTypeRss.php');
 }
+
+if ($route === '/robots.txt') {
+    return <<<ROBOTSTXT
+        User-Agent: *
+        Disallow:
+        ROBOTSTXT;
+}
+
+if ($route === '/hello-world') {
+    return include(__DIR__ . '/_Server/HelloWorld.php');
+}

--- a/tests/_Integration/_Server/HelloWorld.php
+++ b/tests/_Integration/_Server/HelloWorld.php
@@ -1,0 +1,9 @@
+<!Doctype html>
+<html>
+<head>
+    <title>Hello World!</title>
+</head>
+<body>
+Hello World!
+</body>
+</html>


### PR DESCRIPTION
Warnings about loader hooks being called multiple times, when using a `BotUserAgent` and therefore loading and respecting the robots.txt file, or when using the `Http::stopOnErrorResponse()` method.

Also add some more tests for the greater than and less than comparison filters, when comparing values with different types.