### PR TITLE
Fix getting value of non existing attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.3] - 2025-01-28
+### Fixed
+* Fix deprecation warning triggered in the `DomQuery` class, when trying to get the value of an HTML/XML attribute that does not exist on the element.
+
 ## [3.2.2] - 2025-01-17
 ### Fixed
 * Warnings about loader hooks being called multiple times, when using a `BotUserAgent` and therefore loading and respecting the robots.txt file, or when using the `Http::stopOnErrorResponse()` method.

--- a/src/Steps/Html/DomQuery.php
+++ b/src/Steps/Html/DomQuery.php
@@ -294,7 +294,7 @@ abstract class DomQuery
         } else {
             $target = trim(
                 $this->attributeName ?
-                    $node->getAttribute($this->attributeName) :
+                    ($node->getAttribute($this->attributeName) ?? '') :
                     $node->{strtolower($this->target->name)}(),
             );
         }

--- a/tests/Steps/Html/CssSelectorTest.php
+++ b/tests/Steps/Html/CssSelectorTest.php
@@ -92,6 +92,12 @@ it('gets the contents of an attribute using the attribute method', function () {
     expect((new CssSelector('.item'))->attribute('data-attr')->apply(new HtmlDocument($html)))->toBe('content');
 });
 
+test('getting an attribute value returns an empty string when the attribute does not exist', function () {
+    $html = '<div class="item">test</div>';
+
+    expect((new CssSelector('.item'))->attribute('foo')->apply(new HtmlDocument($html)))->toBe('');
+});
+
 it('turns the value into an absolute url when toAbsoluteUrl() is called', function () {
     $html = '<a href="/packages/crawler/v0.4/getting-started">getting started</a>';
 

--- a/tests/Steps/Html/XPathQueryTest.php
+++ b/tests/Steps/Html/XPathQueryTest.php
@@ -59,6 +59,12 @@ it('gets the contents of an attribute using the attribute method', function () {
     expect((new XPathQuery('//item'))->attribute('attr')->apply(new XmlDocument($xml)))->toBe('content');
 });
 
+test('getting an attribute value returns an empty string when the attribute does not exist', function () {
+    $xml = '<item>test</item>';
+
+    expect((new XPathQuery('//item'))->attribute('attr')->apply(new XmlDocument($xml)))->toBe('');
+});
+
 it('turns the value into an absolute url when toAbsoluteUrl() is called', function () {
     $xml = '<item>/foo/bar</item>';
 


### PR DESCRIPTION
Fix deprecation warning triggered in the `DomQuery` class, when trying to get the value of an HTML/XML attribute that does not exist on the element.