### PR TITLE
Prevent loading relative reference URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.4] - 2025-02-25
+### Fixed
+* Trying to load a relative reference URI (no scheme and host/authority, only path) via the `HttpLoader` now immediately logs (or throws when `loadOrFail()` is used) an error instead of trying to actually load it.
+
 ## [3.2.3] - 2025-01-28
 ### Fixed
 * Fix deprecation warning triggered in the `DomQuery` class, when trying to get the value of an HTML/XML attribute that does not exist on the element.

--- a/tests/Loader/Http/Politeness/RobotsTxtHandlerTest.php
+++ b/tests/Loader/Http/Politeness/RobotsTxtHandlerTest.php
@@ -124,7 +124,7 @@ it('fails silently when parsing fails', function () {
 
     $robotsTxt = new RobotsTxtHandler($loader, new CliLogger());
 
-    expect($robotsTxt->isAllowed('/anything'))->toBeTrue();
+    expect($robotsTxt->isAllowed('https://www.example.com/anything'))->toBeTrue();
 
     $logOutput = $this->getActualOutputForAssertion();
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -291,6 +291,11 @@ function helper_getFastCrawler(): HttpCrawler
     };
 }
 
+function helper_nonBotUserAgent(): UserAgent
+{
+    return new UserAgent('Mozilla/5.0 (compatible; FooBot)');
+}
+
 function helper_getMinThrottler(): Throttler
 {
     return new Throttler(new MultipleOf(0.0001), new MultipleOf(0.0002), Microseconds::fromSeconds(0.0001));


### PR DESCRIPTION
Trying to load a relative reference URI (no scheme and host/authority, only path) via the `HttpLoader` now immediately logs (or throws when `loadOrFail()` is used) an error instead of trying to actually load it.