### PR TITLE
Fix data structure of nested HTML/XML steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.5] - 2025-02-26
+### Fixed
+* When a child step is nested in the `extract()` method of an `Html` or `Xml` step, and does not use `each()` as the base, the extracted value is an array with the keys defined in the `extract()` call, rather than an array of such arrays as it would be with `each()` as base.
+
 ## [3.2.4] - 2025-02-25
 ### Fixed
 * Trying to load a relative reference URI (no scheme and host/authority, only path) via the `HttpLoader` now immediately logs (or throws when `loadOrFail()` is used) an error instead of trying to actually load it.

--- a/src/Steps/Dom.php
+++ b/src/Steps/Dom.php
@@ -209,7 +209,7 @@ abstract class Dom extends Step
             if ($domQuery instanceof Dom) {
                 $domQuery->baseUrl = $this->baseUrl;
 
-                $mappedProperties[$key] = iterator_to_array($domQuery->invoke($node));
+                $mappedProperties[$key] = $this->getDataFromChildDomStep($domQuery, $node);
             } else {
                 if (is_string($domQuery)) {
                     $domQuery = $this->makeDefaultDomQueryInstance($domQuery);
@@ -248,5 +248,22 @@ abstract class Dom extends Step
         }
 
         throw new Exception('Invalid state: no base selector');
+    }
+
+    /**
+     * @return mixed[]
+     * @throws Exception
+     */
+    protected function getDataFromChildDomStep(Dom $step, Node $node): array
+    {
+        $childValue = iterator_to_array($step->invoke($node));
+
+        // When the child step was not used with each() as base and the result is an array with one
+        // element (index/key "0") being an array, use that child array.
+        if (!$step->each && count($childValue) === 1 && isset($childValue[0]) && is_array($childValue[0])) {
+            return $childValue[0];
+        }
+
+        return $childValue;
     }
 }


### PR DESCRIPTION
When a child step is nested in the `extract()` method of an `Html` or `Xml` step, and does not use `each()` as the base, the extracted value is an array with the keys defined in the `extract()` call, rather than an array of such arrays as it would be with `each()` as base.