### PR TITLE
Improve post navigate hook browser actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.0] - 2025-03-02
+### Added
+* New `BrowserAction`s to use with the `postBrowserNavigateHook()` method: 
+  * `BrowserAction::clickInsideShadowDom()`
+  * `BrowserAction::moveMouseToElement()`
+  * `BrowserAction::moveMouseToPosition()`
+  * `BrowserAction::scrollDown()`
+  * `BrowserAction::scrollUp()`
+  * `BrowserAction::typeText()`
+  * `BrowserAction::waitForReload()`
+* A new method in `HeadlessBrowserLoaderHelper` to include the HTML content of shadow DOM elements in the returned HTML. Use it like this: `$crawler->getLoader()->browser()->includeShadowElementsInHtml()`.
+
+### Changed
+* The `BrowserAction::clickElement()` action, now automatically waits for an element matching the selector to be rendered, before performing the click. This means you don't need to put a `BrowserAction::waitUntilDocumentContainsElement()` before it. It works the same in the new `BrowserAction::clickInsideShadowDom()` and `BrowserAction::moveMouseToElement()` actions.
+
+### Deprecated
+* `BrowserAction::clickElementAndWaitForReload()` and `BrowserAction::evaluateAndWaitForReload()`. As a replacement, please use `BrowserAction::clickElement()` or `BrowserAction::evaluate()` and `BrowserAction::waitForReload()` separately.
+
 ## [3.2.5] - 2025-02-26
 ### Fixed
 * When a child step is nested in the `extract()` method of an `Html` or `Xml` step, and does not use `each()` as the base, the extracted value is an array with the keys defined in the `extract()` call, rather than an array of such arrays as it would be with `each()` as base.

--- a/src/Steps/Loading/Http/Browser/BrowserAction.php
+++ b/src/Steps/Loading/Http/Browser/BrowserAction.php
@@ -18,16 +18,87 @@ class BrowserAction
     public static function clickElement(string $cssSelector): Closure
     {
         return function (Page $page) use ($cssSelector) {
+            $page->waitUntilContainsElement($cssSelector);
+
             $page->mouse()->find($cssSelector)->click();
         };
     }
 
-    public static function clickElementAndWaitForReload(string $cssSelector): Closure
+    /**
+     * Click an element that lives inside a shadow DOM within the document.
+     *
+     * For this purpose the action needs two selectors: the first one to select the shadow host element and the
+     * second one to select the element that shall be clicked inside that shadow DOM.
+     */
+    public static function clickInsideShadowDom(string $shadowHostSelector, string $clickElementSelector): Closure
+    {
+        return function (Page $page) use ($shadowHostSelector, $clickElementSelector) {
+            $page->evaluate(<<<JS
+            (async function() {
+                let shadowHostElement = document.querySelector('{$shadowHostSelector}');
+
+                while (!shadowHostElement) {
+                    await new Promise(resolve => setTimeout(resolve, 25)); // Kleine Pause
+                    shadowHostElement = document.querySelector('{$shadowHostSelector}');
+                }
+
+                if (shadowHostElement.shadowRoot) {
+                    let clickElement = shadowHostElement.shadowRoot.querySelector('{$clickElementSelector}');
+
+                    while (!clickElement) {
+                        await new Promise(resolve => setTimeout(resolve, 25)); // Kleine Pause
+                        clickElement = shadowHostElement.shadowRoot.querySelector('{$clickElementSelector}');
+                    }
+
+                    clickElement.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+                }
+            })()
+            JS)->waitForResponse(10_000);
+        };
+    }
+
+    public static function moveMouseToElement(string $cssSelector): Closure
     {
         return function (Page $page) use ($cssSelector) {
-            $page->mouse()->find($cssSelector)->click();
+            $page->waitUntilContainsElement($cssSelector);
 
-            $page->waitForReload();
+            $page->mouse()->find($cssSelector);
+        };
+    }
+
+    public static function moveMouseToPosition(int $x, int $y, ?int $steps = null): Closure
+    {
+        return function (Page $page) use ($x, $y, $steps) {
+            if ($steps !== null) {
+                $page->mouse()->move($x, $y, ['steps' => $steps]);
+            } else {
+                $page->mouse()->move($x, $y);
+            }
+        };
+    }
+
+    public static function scrollDown(int $distance): Closure
+    {
+        return function (Page $page) use ($distance) {
+            $page->mouse()->scrollDown($distance);
+        };
+    }
+
+    public static function scrollUp(int $distance): Closure
+    {
+        return function (Page $page) use ($distance) {
+            $page->mouse()->scrollUp($distance);
+        };
+    }
+
+    public static function typeText(string $text, ?int $delay = null): Closure
+    {
+        return function (Page $page) use ($text, $delay) {
+            if ($delay !== null) {
+                $page->keyboard()->setKeyInterval($delay)->typeText($text);
+            } else {
+                $page->keyboard()->typeText($text);
+            }
         };
     }
 
@@ -38,10 +109,10 @@ class BrowserAction
         };
     }
 
-    public static function evaluateAndWaitForReload(string $jsCode): Closure
+    public static function waitForReload(): Closure
     {
-        return function (Page $page) use ($jsCode) {
-            $page->evaluate($jsCode)->waitForPageReload();
+        return function (Page $page) {
+            $page->waitForReload();
         };
     }
 
@@ -49,6 +120,30 @@ class BrowserAction
     {
         return function (Page $page) use ($seconds) {
             usleep(Microseconds::fromSeconds($seconds)->value);
+        };
+    }
+
+    /**
+     * @deprecated Use the two methods evaluate() and waitForReload() separately.
+     */
+    public static function evaluateAndWaitForReload(string $jsCode): Closure
+    {
+        return function (Page $page) use ($jsCode) {
+            $page->evaluate($jsCode)->waitForPageReload();
+        };
+    }
+
+    /**
+     * @deprecated Use the two methods clickElement() and waitForReload() separately.
+     */
+    public static function clickElementAndWaitForReload(string $cssSelector): Closure
+    {
+        return function (Page $page) use ($cssSelector) {
+            $page->waitUntilContainsElement($cssSelector);
+
+            $page->mouse()->find($cssSelector)->click();
+
+            $page->waitForReload();
         };
     }
 }

--- a/tests/_Integration/_Server/BrowserActions/ClickAndWaitForReload.php
+++ b/tests/_Integration/_Server/BrowserActions/ClickAndWaitForReload.php
@@ -6,7 +6,15 @@
 </head>
 <body>
 <div>
-    <a id="click" href="?reloaded=1">Click here</a>
+    <div id="click">Click here</div>
+
+    <script>
+        document.getElementById('click').addEventListener('click', function (ev) {
+            setTimeout(function () {
+                window.location.href = '/browser-actions/click-and-wait-for-reload?reloaded=1';
+            }, 200);
+        })
+    </script>
 
     <?php if (isset($_GET['reloaded'])) { ?>
         <div id="reloaded">yes</div>

--- a/tests/_Integration/_Server/BrowserActions/Main.php
+++ b/tests/_Integration/_Server/BrowserActions/Main.php
@@ -3,20 +3,77 @@
 <head>
     <meta charset=utf-8>
     <title>Hello World</title>
+    <style>
+        #mouseover_check_1 { position: absolute; top: 200px; right: 100px; }
+        #mouseover_check_2 { position: absolute; top: 400px; left:300px; }
+        #scroll_down_check { position: absolute; top: 4000px; }
+        #scroll_up_check { position: absolute; top: 2000px; }
+    </style>
 </head>
 <body>
 <div>
-    <div id="delayed_el_container"></div>
-
-    <div id="click_worked"></div>
-    <div id="click_element" onclick="document.getElementById('click_worked').innerHTML = 'yes'">Click me</div>
-
+    <div id="click_el_wrapper"></div>
+    <div id="shadow_host"></div>
     <div id="evaluation_container"></div>
+    <div id="input_wrapper">
+        <div id="input_value"></div>
+        <input type="text" id="input" />
+    </div>
+    <div id="mouseover_check_1">mouse wasn't here yet</div>
+    <div id="mouseover_check_2">mouse wasn't here yet</div>
+    <div id="scroll_up_check">not scrolled up yet</div>
+    <div id="scroll_down_check">not scrolled down yet</div>
 
     <script>
         setTimeout(function () {
-            document.getElementById('delayed_el_container').innerHTML = '<div id="delayed_el">a</div>';
-        }, 300);
+            document.getElementById('click_el_wrapper').innerHTML = '<div id="click_worked"></div>' + "\n" +
+                '<div id="click_element" onclick="document.getElementById(\'click_worked\').innerHTML = \'yes\'">' +
+                'Click me</div>';
+        }, 200);
+        const shadowHost = document.getElementById('shadow_host');
+        const shadowDom = shadowHost.attachShadow({ mode: 'open' });
+        const shadowClickDiv = document.createElement('div');
+        shadowClickDiv.id = 'shadow_click_div';
+        shadowClickDiv.innerHTML = 'Not clicked yet';
+        shadowClickDiv.addEventListener('click', function () {
+            this.innerHTML = 'clicked';
+        }, false);
+        shadowDom.appendChild(shadowClickDiv);
+        document.getElementById('mouseover_check_1').addEventListener('mouseover', function () {
+            this.innerHTML = 'mouse was here';
+        });
+        document.getElementById('mouseover_check_2').addEventListener('mouseover', function () {
+            this.innerHTML = 'mouse was here';
+        });
+        document.addEventListener('scroll', function () {
+            const elementIsVisibleInViewport = (el, partiallyVisible = false) => {
+                const { top, left, bottom, right } = el.getBoundingClientRect();
+                const { innerHeight, innerWidth } = window;
+                return partiallyVisible
+                    ? ((top > 0 && top < innerHeight) ||
+                        (bottom > 0 && bottom < innerHeight)) &&
+                    ((left > 0 && left < innerWidth) || (right > 0 && right < innerWidth))
+                    : top >= 0 && left >= 0 && bottom <= innerHeight && right <= innerWidth;
+            };
+
+            const scrollDownCheckEl = document.getElementById('scroll_down_check');
+            const scrollUpCheckEl = document.getElementById('scroll_up_check');
+
+            if (elementIsVisibleInViewport(scrollDownCheckEl, true) && scrollDownCheckEl.innerHTML !== 'scrolled down') {
+                scrollDownCheckEl.innerHTML = 'scrolled down';
+            }
+
+            if (
+                elementIsVisibleInViewport(scrollUpCheckEl, true) &&
+                scrollDownCheckEl.innerHTML === 'scrolled down' &&
+                scrollUpCheckEl.innerHTML !== 'scrolled up'
+            ) {
+                scrollUpCheckEl.innerHTML = 'scrolled up';
+            }
+        }, false);
+        document.getElementById('input').addEventListener('input', function (ev) {
+            document.getElementById('input_value').innerHTML = document.getElementById('input').value;
+        }, false);
     </script>
 </div>
 </body>

--- a/tests/_Integration/_Server/BrowserActions/Wait.php
+++ b/tests/_Integration/_Server/BrowserActions/Wait.php
@@ -6,11 +6,11 @@
 </head>
 <body>
 <div>
-    <div id="delayed_container"></div>
+    <div id="insert_here"></div>
 
     <script>
         setTimeout(function () {
-            document.getElementById('delayed_container').innerHTML = 'hooray';
+            document.getElementById('insert_here').innerHTML = '<div id="delayed_container">hooray</div>';
         }, 200);
     </script>
 </div>


### PR DESCRIPTION
- Added new `BrowserAction`s for `postBrowserNavigateHook()`:
  - `clickInsideShadowDom()`
  - `moveMouseToElement()`
  - `moveMouseToPosition()`
  - `scrollDown()`
  - `scrollUp()`
  - `typeText()`
  - `waitForReload()`
- Added `includeShadowElementsInHtml()` to `HeadlessBrowserLoaderHelper` to include shadow DOM content in returned HTML.
- Updated `clickElement()` to automatically wait for elements before clicking, removing the need for `waitUntilDocumentContainsElement()`.
- Deprecated `clickElementAndWaitForReload()` and `evaluateAndWaitForReload()`, recommending `clickElement()` or `evaluate()` with `waitForReload()` instead.