### PR TITLE
Fix order of calls in HttpBase step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.2] - 2025-03-08
+### Fixed
+* Issue when using `Http::get()->useBrowser()->postBrowserNavigateHook()`. Previously in this case, when the loader is configured to use the HTTP client, the post browser navigate hook was actually not set because of an issue with the order, things happened internally.
+
 ## [3.4.1] - 2025-03-08
 ### Fixed
 * Since, when using the Chrome browser for loading, we can only execute GET requests:

--- a/src/Steps/Loading/HttpBase.php
+++ b/src/Steps/Loading/HttpBase.php
@@ -243,6 +243,7 @@ abstract class HttpBase extends Step
 
     /**
      * @throws LoadingException
+     * @throws Exception
      */
     protected function getResponseFromRequest(RequestInterface $request): ?RespondedRequest
     {
@@ -273,10 +274,6 @@ abstract class HttpBase extends Step
 
         $resetConfig = ['resetToHttpClient' => false, 'resetToBrowser' => false];
 
-        if (!empty($this->postBrowserNavigateHooks) && $loader->usesHeadlessBrowser()) {
-            $loader->browser()->setTempPostNavigateHooks($this->postBrowserNavigateHooks);
-        }
-
         if ($this->skipCache) {
             $loader->skipCacheForNextRequest();
         }
@@ -296,6 +293,10 @@ abstract class HttpBase extends Step
             $resetConfig['resetToHttpClient'] = true;
 
             $loader->useHeadlessBrowser();
+        }
+
+        if (!empty($this->postBrowserNavigateHooks) && $loader->usesHeadlessBrowser()) {
+            $loader->browser()->setTempPostNavigateHooks($this->postBrowserNavigateHooks);
         }
 
         return $resetConfig;


### PR DESCRIPTION
Fixes an issue when using
`Http::get()->useBrowser()->postBrowserNavigateHook()`. Previously in this case, when the loader is configured to use the HTTP client, the post browser navigate hook was actually not set because of an issue with the order, things happened internally.