### PR TITLE
Fix empty base selectors with `Html` extract step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+* When providing an empty base selector to an `Html` step (`Html::each('')`, `Html::first('')`, `Html::last('')`), it won't fail with an error, but instead log a warning, that it most likely doesn't make sense.
 
 ## [3.4.2] - 2025-03-08
 ### Fixed

--- a/src/Logger/PreStepInvocationLogger.php
+++ b/src/Logger/PreStepInvocationLogger.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Crwlr\Crawler\Logger;
+
+use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
+use Stringable;
+use UnexpectedValueException;
+
+class PreStepInvocationLogger implements LoggerInterface
+{
+    /**
+     * @var array<int, array<string, string>>
+     */
+    public array $messages = [];
+
+    public function emergency(string|Stringable $message, array $context = []): void
+    {
+        $this->log('emergency', $message, $context);
+    }
+
+    public function alert(string|Stringable $message, array $context = []): void
+    {
+        $this->log('alert', $message, $context);
+    }
+
+    public function critical(string|Stringable $message, array $context = []): void
+    {
+        $this->log('critical', $message, $context);
+    }
+
+    public function error(string|Stringable $message, array $context = []): void
+    {
+        $this->log('error', $message, $context);
+    }
+
+    public function warning(string|Stringable $message, array $context = []): void
+    {
+        $this->log('warning', $message, $context);
+    }
+
+    public function notice(string|Stringable $message, array $context = []): void
+    {
+        $this->log('notice', $message, $context);
+    }
+
+    public function info(string|Stringable $message, array $context = []): void
+    {
+        $this->log('info', $message, $context);
+    }
+
+    public function debug(string|Stringable $message, array $context = []): void
+    {
+        $this->log('debug', $message, $context);
+    }
+
+    /**
+     * @param string $level
+     * @param mixed[] $context
+     */
+    public function log($level, string|Stringable $message, array $context = []): void
+    {
+        if (!is_string($level)) {
+            throw new InvalidArgumentException('Level must be string.');
+        }
+
+        if (!in_array($level, ['emergency', 'alert', 'critical', 'error', 'warning', 'notice', 'info', 'debug'], true)) {
+            throw new UnexpectedValueException('Unknown log level.');
+        }
+
+        $this->messages[] = ['level' => $level, 'message' => $message];
+    }
+
+    public function passToOtherLogger(LoggerInterface $logger): void
+    {
+        foreach ($this->messages as $message) {
+            $logger->{$message['level']}($message['message']);
+        }
+    }
+}

--- a/src/Steps/BaseStep.php
+++ b/src/Steps/BaseStep.php
@@ -7,6 +7,7 @@ use Closure;
 use Crwlr\Crawler\Crawler;
 use Crwlr\Crawler\Input;
 use Crwlr\Crawler\Io;
+use Crwlr\Crawler\Logger\PreStepInvocationLogger;
 use Crwlr\Crawler\Output;
 use Crwlr\Crawler\Result;
 use Crwlr\Crawler\Steps\Exceptions\PreRunValidationException;
@@ -89,6 +90,10 @@ abstract class BaseStep implements StepInterface
 
     public function addLogger(LoggerInterface $logger): static
     {
+        if ($this->logger instanceof PreStepInvocationLogger) {
+            $this->logger->passToOtherLogger($logger);
+        }
+
         $this->logger = $logger;
 
         return $this;

--- a/tests/Logger/PreStepInvocationLoggerTest.php
+++ b/tests/Logger/PreStepInvocationLoggerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace tests\Logger;
+
+use Crwlr\Crawler\Logger\PreStepInvocationLogger;
+use tests\_Stubs\DummyLogger;
+
+it('logs messages', function () {
+    $logger = new PreStepInvocationLogger();
+
+    $logger->info('test');
+
+    $logger->warning('foo');
+
+    $logger->error('some error');
+
+    expect($logger->messages)->toHaveCount(3)
+        ->and($logger->messages[0]['level'])->toBe('info')
+        ->and($logger->messages[0]['message'])->toBe('test')
+        ->and($logger->messages[1]['level'])->toBe('warning')
+        ->and($logger->messages[1]['message'])->toBe('foo')
+        ->and($logger->messages[2]['level'])->toBe('error')
+        ->and($logger->messages[2]['message'])->toBe('some error');
+});
+
+it('passes log messages to another logger', function () {
+    $logger = new PreStepInvocationLogger();
+
+    $logger->info('test');
+
+    $logger->warning('foo');
+
+    $logger->error('some error');
+
+    $anotherLogger = new DummyLogger();
+
+    $logger->passToOtherLogger($anotherLogger);
+
+    expect($anotherLogger->messages)->toHaveCount(3)
+        ->and($anotherLogger->messages[0]['level'])->toBe('info')
+        ->and($anotherLogger->messages[0]['message'])->toBe('test')
+        ->and($anotherLogger->messages[1]['level'])->toBe('warning')
+        ->and($anotherLogger->messages[1]['message'])->toBe('foo')
+        ->and($anotherLogger->messages[2]['level'])->toBe('error')
+        ->and($anotherLogger->messages[2]['message'])->toBe('some error');
+});

--- a/tests/Steps/BaseStepTest.php
+++ b/tests/Steps/BaseStepTest.php
@@ -22,8 +22,8 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-
 use tests\_Stubs\DummyLogger;
+
 use function tests\helper_getInputReturningStep;
 use function tests\helper_getStdClassWithData;
 use function tests\helper_getStepFilesContent;
@@ -222,7 +222,7 @@ it(
             ->and($crawlerLogger->messages[0]['message'])->toBe('test')
             ->and($crawlerLogger->messages[1]['level'])->toBe('warning')
             ->and($crawlerLogger->messages[1]['message'])->toBe('foo');
-    }
+    },
 );
 
 /* ----------------------------- validateBeforeRun() ----------------------------- */

--- a/tests/Steps/DomTest.php
+++ b/tests/Steps/DomTest.php
@@ -159,6 +159,26 @@ it('extracts each matching result when the each method is used', function () {
         ->and($output[1]->get())->toBe(['match' => 'match 3']);
 });
 
+it('logs a warning, when the each() method is used with an empty selector', function (string|DomQuery $selector) {
+    $logger = new DummyLogger();
+
+    $step = helper_getDomStepInstance()::each($selector)->extract(['match' => '.match']);
+
+    $step->addLogger($logger);
+
+    $outputs = helper_invokeStepWithInput($step, helper_getStepFilesContent('Html/basic.html'));
+
+    expect($outputs)->toHaveCount(1)
+        ->and($outputs[0]->get())->toBe(['match' => ['match 1', 'match 2', 'match 3']])
+        ->and($logger->messages[0]['level'])->toBe('warning')
+        ->and($logger->messages[0]['message'])
+        ->toStartWith('The selector you provided for the ‘each’ option is empty.');
+})->with([
+    [''],
+    [Dom::cssSelector('')],
+    [Dom::xPath('')],
+]);
+
 it('extracts the first matching result when the first method is used', function () {
     $output = helper_invokeStepWithInput(
         helper_getDomStepInstance()::first('.list .item')->extract(['match' => '.match']),
@@ -169,6 +189,26 @@ it('extracts the first matching result when the first method is used', function 
         ->and($output[0]->get())->toBe(['match' => 'match 2']);
 });
 
+it('logs a warning, when the first() method is used with an empty selector', function (string|DomQuery $selector) {
+    $logger = new DummyLogger();
+
+    $step = helper_getDomStepInstance()::first($selector)->extract(['match' => '.match']);
+
+    $step->addLogger($logger);
+
+    $outputs = helper_invokeStepWithInput($step, helper_getStepFilesContent('Html/basic.html'));
+
+    expect($outputs)->toHaveCount(1)
+        ->and($outputs[0]->get())->toBe(['match' => ['match 1', 'match 2', 'match 3']])
+        ->and($logger->messages[0]['level'])->toBe('warning')
+        ->and($logger->messages[0]['message'])
+        ->toStartWith('The selector you provided for the ‘first’ option is empty.');
+})->with([
+    [''],
+    [Dom::cssSelector('')],
+    [Dom::xPath('')],
+]);
+
 it('extracts the last matching result when the last method is used', function () {
     $output = helper_invokeStepWithInput(
         helper_getDomStepInstance()::last('.list .item')->extract(['match' => '.match']),
@@ -178,6 +218,26 @@ it('extracts the last matching result when the last method is used', function ()
     expect($output)->toHaveCount(1)
         ->and($output[0]->get())->toBe(['match' => 'match 3']);
 });
+
+it('logs a warning, when the last() method is used with an empty selector', function (string|DomQuery $selector) {
+    $logger = new DummyLogger();
+
+    $step = helper_getDomStepInstance()::last($selector)->extract(['match' => '.match']);
+
+    $step->addLogger($logger);
+
+    $outputs = helper_invokeStepWithInput($step, helper_getStepFilesContent('Html/basic.html'));
+
+    expect($outputs)->toHaveCount(1)
+        ->and($outputs[0]->get())->toBe(['match' => ['match 1', 'match 2', 'match 3']])
+        ->and($logger->messages[0]['level'])->toBe('warning')
+        ->and($logger->messages[0]['message'])
+        ->toStartWith('The selector you provided for the ‘last’ option is empty.');
+})->with([
+    [''],
+    [Dom::cssSelector('')],
+    [Dom::xPath('')],
+]);
 
 it('doesn\'t yield any output when the each selector doesn\'t match anything', function () {
     $output = helper_invokeStepWithInput(


### PR DESCRIPTION
When providing an empty base selector to an `Html` step (`Html::each('')`, `Html::first('')`, `Html::last('')`), it won't fail with an error, but instead log a warning, that it most likely doesn't make sense.