### PR TITLE
Fix keeping data from group child steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.4.3] - 2025-04-03
 ### Fixed
 * When providing an empty base selector to an `Html` step (`Html::each('')`, `Html::first('')`, `Html::last('')`), it won't fail with an error, but instead log a warning, that it most likely doesn't make sense.
 * The `Step::keep()` methods now also work when applied to child steps within a group step.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 * When providing an empty base selector to an `Html` step (`Html::each('')`, `Html::first('')`, `Html::last('')`), it won't fail with an error, but instead log a warning, that it most likely doesn't make sense.
+* The `Step::keep()` methods now also work when applied to child steps within a group step.
 
 ## [3.4.2] - 2025-03-08
 ### Fixed

--- a/tests/Steps/GroupTest.php
+++ b/tests/Steps/GroupTest.php
@@ -529,6 +529,46 @@ it('keeps all defined keys from a combined array output when keep() was called w
         ]);
 });
 
+it('keeps data, when keep() is called on child steps', function () {
+    $step1 = helper_getValueReturningStep(['foo' => 'fooValue', 'bar' => 'barValue']);
+
+    $step2 = helper_getValueReturningStep(['baz' => 'bazValue', 'quz' => 'quzValue']);
+
+    $group = (new Group())
+        ->addStep($step1->keep('foo'))
+        ->addStep($step2->keep(['baz', 'quz']));
+
+    $output = helper_invokeStepWithInput($group);
+
+    expect($output)->toHaveCount(1)
+        ->and($output[0]->keep)->toBe([
+            'foo' => 'fooValue',
+            'baz' => 'bazValue',
+            'quz' => 'quzValue',
+        ]);
+});
+
+it('keeps data, when keepAs() is called on child steps', function () {
+    $step1 = helper_getValueReturningStep('fooValue');
+
+    $step2 = helper_getValueReturningStep(['bar' => 'barValue', 'baz' => 'bazValue']);
+
+    $group = (new Group())
+        ->addStep($step1->keepAs('foo'))
+        ->addStep($step2->keepAs('quz'));
+
+    $output = helper_invokeStepWithInput($group);
+
+    expect($output)->toHaveCount(1)
+        ->and($output[0]->keep)->toBe([
+            'foo' => 'fooValue',
+            'quz' => [
+                'bar' => 'barValue',
+                'baz' => 'bazValue',
+            ],
+        ]);
+});
+
 test(
     'when steps yield multiple outputs it combines the first output from first step with first output from second ' .
         'step and so on.',


### PR DESCRIPTION
The `Step::keep()` methods now also work when applied to child steps within a group step.