### PR TITLE
Handle invalid URL input in Http steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.4.5] - 2025-04-09
+### Fixed
+* When feeding an `Http` step with a string that is not a valid URL (e.g. `https://`), the exception when trying to parse it as a URL is caught, and an error logged.
+
 ## [3.4.4] - 2025-04-04
 ### Fixed
 * As sometimes, XML parsing errors occur because of characters that aren't valid within XML documents, the library now catches XML parsing errors, tries to find and replace invalid characters (with transliterates or HTML entities) and retries parsing the document. Works best when you additionally install the `voku/portable-ascii` composer package.

--- a/src/Steps/Step.php
+++ b/src/Steps/Step.php
@@ -10,6 +10,7 @@ use Crwlr\Crawler\Output;
 use Crwlr\Crawler\Steps\Dom\HtmlDocument;
 use Crwlr\Crawler\Steps\Dom\XmlDocument;
 use Crwlr\Crawler\Steps\Loading\Http;
+use Crwlr\Url\Exceptions\InvalidUrlException;
 use Crwlr\Url\Url;
 use Exception;
 use Generator;
@@ -173,7 +174,11 @@ abstract class Step extends BaseStep
             $inputValue instanceof Url ||
             (is_object($inputValue) && method_exists($inputValue, '__toString'))
         ) {
-            return Url::parsePsr7((string) $inputValue);
+            try {
+                return Url::parsePsr7((string) $inputValue);
+            } catch (InvalidUrlException $exception) {
+                throw new InvalidArgumentException($exception->getMessage());
+            }
         }
 
         throw new InvalidArgumentException($exceptionMessage);

--- a/tests/Steps/Dom/XmlDocumentTest.php
+++ b/tests/Steps/Dom/XmlDocumentTest.php
@@ -69,36 +69,36 @@ test('the queryXPath() method returns a NodeList of XmlElement objects', functio
     expect($anyNodesChecked)->toBeTrue();
 });
 
-//it('is able to parse documents containing characters that aren\'t valid within XML documents', function (string $char) {
-//    $xml = <<<XML
-//        <?xml version="1.0" encoding="UTF-8"?>
-//        <rss>
-//        <channel>
-//        <items>
-//        <item>
-//        <title><![CDATA[foo - {$char} - bar]]></title>
-//        </item>
-//        </items>
-//        </channel>
-//        </rss>
-//        XML;
-//
-//    $document = new XmlDocument($xml);
-//
-//    $titles = $document->querySelectorAll('channel item title');
-//
-//    expect($titles)->toBeInstanceOf(NodeList::class)
-//        ->and($titles->count())->toBe(1)
-//        ->and($titles->first()?->text())->toStartWith('foo - ')
-//        ->and($titles->first()?->text())->toEndWith(' - bar');
-//})->with([
-//    [mb_chr(0)],
-//    [mb_chr(6)],
-//    [mb_chr(12)],
-//    [mb_chr(20)],
-//    [mb_chr(31)],
-//    [mb_chr(128)],
-//    [mb_chr(157)],
-//    [mb_chr(195)],
-//    [mb_chr(253)],
-//])->only();
+it('is able to parse documents containing characters that aren\'t valid within XML documents', function (string $char) {
+    $xml = <<<XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <rss>
+        <channel>
+        <items>
+        <item>
+        <title><![CDATA[foo - {$char} - bar]]></title>
+        </item>
+        </items>
+        </channel>
+        </rss>
+        XML;
+
+    $document = new XmlDocument($xml);
+
+    $titles = $document->querySelectorAll('channel item title');
+
+    expect($titles)->toBeInstanceOf(NodeList::class)
+        ->and($titles->count())->toBe(1)
+        ->and($titles->first()?->text())->toStartWith('foo - ')
+        ->and($titles->first()?->text())->toEndWith(' - bar');
+})->with([
+    [mb_chr(0)],
+    [mb_chr(6)],
+    [mb_chr(12)],
+    [mb_chr(20)],
+    [mb_chr(31)],
+    [mb_chr(128)],
+    [mb_chr(157)],
+    [mb_chr(195)],
+    [mb_chr(253)],
+]);

--- a/tests/Steps/Loading/HttpTest.php
+++ b/tests/Steps/Loading/HttpTest.php
@@ -77,6 +77,25 @@ it('logs an error message when invoked with a relative reference URI', function 
         );
 });
 
+it('catches the exception and logs an error when feeded with an invalid URL', function () {
+    $loader = Mockery::mock(HttpLoader::class);
+
+    $logger = new DummyLogger();
+
+    $step = (new Http('GET'))->setLoader($loader);
+
+    $step->addLogger($logger);
+
+    helper_traverseIterable($step->invokeStep(new Input('https://')));
+
+    expect($logger->messages)->toHaveCount(1)
+        ->and($logger->messages[0]['level'])->toBe('error')
+        ->and($logger->messages[0]['message'])->toBe(
+            'The Crwlr\\Crawler\\Steps\\Loading\\Http step was called with input that it can not work with: https:// ' .
+            'is not a valid URL.',
+        );
+});
+
 it('throws an exception when invoked with a relative reference URI and stopOnErrorResponse() was called', function () {
     $logger = new DummyLogger();
 


### PR DESCRIPTION
When feeding an `Http` step with a string that is not a valid URL (e.g. `https://`), the exception when trying to parse it as a URL is caught, and an error logged.