### PR TITLE
Add new refiners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+* New Refiners:
+    * `DateTimeRefiner::reformat('Y-m-d H:i:s')` to reformat a date time string to a different format. Tries to automatically recognize the input format. If this does not work, you can provide an input format to use as the second argument.
+    * `HtmlRefiner::remove('#foo')` to remove nodes matching the given selector from selected HTML.
+
 ## [3.4.5] - 2025-04-09
 ### Fixed
 * When feeding an `Http` step with a string that is not a valid URL (e.g. `https://`), the exception when trying to parse it as a URL is caught, and an error logged.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -22,3 +22,4 @@ parameters:
         - "#^Access to an undefined property Dom\\\\.+::\\$.+\\.#"
         - "#^Function .+ has invalid return type Dom\\\\.+\\.#"
         - "#^(?:Used )?(?:C|c)onstant DOM\\\\.+ not found\\.#"
+        - "#^Instantiated class Dom\\\\.+ not found.#"

--- a/src/Steps/Refiners/DateTime/DateTimeFormat.php
+++ b/src/Steps/Refiners/DateTime/DateTimeFormat.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Refiners\DateTime;
+
+use Crwlr\Crawler\Steps\Refiners\AbstractRefiner;
+use DateTime;
+
+class DateTimeFormat extends AbstractRefiner
+{
+    public function __construct(protected string $targetFormat, protected string|null $originFormat = null) {}
+
+    public function refine(mixed $value): mixed
+    {
+        if ($this->originFormat) {
+            $parsed = DateTime::createFromFormat($this->originFormat, $value);
+        } else {
+            $parsed = $this->parseFromUnknownFormat($value);
+        }
+
+        if ($parsed === null) {
+            return $value;
+        } elseif ($parsed === false) {
+            $this->logger?->warning(
+                'Failed parsing date/time "' . $value . '", so can\'t reformat it to requested format.',
+            );
+
+            return $value;
+        }
+
+        return $parsed->format($this->targetFormat);
+    }
+
+    private function parseFromUnknownFormat(string $value): ?DateTime
+    {
+        $timestamp = strtotime($value);
+
+        if ($timestamp === false || $timestamp === 0) {
+            $this->logger?->warning(
+                'Failed to automatically (without known format) parse date/time "' . $value . '", so can\'t reformat ' .
+                'it to requested format.',
+            );
+
+            return null;
+        }
+
+        return (new DateTime())->setTimestamp($timestamp);
+    }
+}

--- a/src/Steps/Refiners/DateTimeRefiner.php
+++ b/src/Steps/Refiners/DateTimeRefiner.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Refiners;
+
+use Crwlr\Crawler\Steps\Refiners\DateTime\DateTimeFormat;
+
+class DateTimeRefiner
+{
+    public static function reformat(string $targetFormat, ?string $originFormat = null): DateTimeFormat
+    {
+        return new DateTimeFormat($targetFormat, $originFormat);
+    }
+}

--- a/src/Steps/Refiners/Html/RemoveFromHtml.php
+++ b/src/Steps/Refiners/Html/RemoveFromHtml.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Refiners\Html;
+
+use Crwlr\Crawler\Steps\Dom;
+use Crwlr\Crawler\Steps\Dom\HtmlDocument;
+use Crwlr\Crawler\Steps\Html\CssSelector;
+use Crwlr\Crawler\Steps\Html\DomQuery;
+use Crwlr\Crawler\Steps\Html\Exceptions\InvalidDomQueryException;
+use Crwlr\Crawler\Steps\Refiners\AbstractRefiner;
+use Throwable;
+
+class RemoveFromHtml extends AbstractRefiner
+{
+    public function __construct(protected string|DomQuery $selector) {}
+
+    public function refine(mixed $value): mixed
+    {
+        $selectorString = is_string($this->selector) ? $this->selector : $this->selector->query;
+
+        if (trim($selectorString) === '') {
+            $this->logger?->warning('If you want HTML nodes to be removed, please define a selector for those nodes.');
+
+            return $value;
+        }
+
+        if (is_string($this->selector)) {
+            try {
+                $this->selector = Dom::cssSelector($this->selector);
+            } catch (InvalidDomQueryException $exception) {
+                $this->logger?->error('Invalid selector in refiner to remove HTML: ' . $exception->getMessage());
+
+                return $value;
+            }
+        }
+
+        try {
+            $document = new HtmlDocument($value);
+        } catch (Throwable $exception) {
+            $this->logger?->warning(
+                'Failed parsing output as HTML in refiner to remove nodes from HTML: ' . $exception->getMessage(),
+            );
+
+            return $value;
+        }
+
+        if ($this->selector instanceof CssSelector) {
+            $document->removeNodesMatchingSelector($this->selector->query);
+        } else {
+            $document->removeNodesMatchingXPath($this->selector->query);
+        }
+
+        if (str_contains($value, '<html') || str_contains($value, '<HTML')) {
+            return $document->outerHtml();
+        }
+
+        return $document->querySelector('body')?->innerHtml() ?? $document->outerHtml();
+    }
+}

--- a/src/Steps/Refiners/HtmlRefiner.php
+++ b/src/Steps/Refiners/HtmlRefiner.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Refiners;
+
+use Crwlr\Crawler\Steps\Html\DomQuery;
+use Crwlr\Crawler\Steps\Refiners\Html\RemoveFromHtml;
+
+class HtmlRefiner
+{
+    public static function remove(string|DomQuery $selector): RemoveFromHtml
+    {
+        return new RemoveFromHtml($selector);
+    }
+}

--- a/tests/Steps/Dom/NodeTest.php
+++ b/tests/Steps/Dom/NodeTest.php
@@ -57,6 +57,8 @@ function helper_getAbstractNodeInstance(object $originalNode, bool $html = true)
     return new XmlNodeStub($originalNode);
 }
 
+/* ----------------------------- Instantiation ----------------------------- */
+
 it('can be created from a \DOM\Node instance', function () {
     $xml = <<<XML
         <?xml version="1.0" encoding="utf-8"?>
@@ -125,6 +127,8 @@ it('can be instantiated from a DOMNode instance', function () {
     expect($node)->toBeInstanceOf(Node::class)
         ->and($node->text())->toBe('1Foo');
 });
+
+/* ----------------------------- querySelector(All)() ----------------------------- */
 
 $html = <<<HTML
     <!doctype html>
@@ -332,6 +336,8 @@ $html = <<<HTML
     </html>
     HTML;
 
+/* ----------------------------- queryXPath() ----------------------------- */
+
 it(
     'selects all elements within a node, matching an XPath query using queryXPath()',
     function (object $originalNode) {
@@ -395,6 +401,216 @@ it(
     },
 )->group('php84');
 
+/* ----------------------------- removeNodesMatchingSelector() ----------------------------- */
+
+$html = <<<HTML
+    <!doctype html>
+    <html>
+    <head></head>
+    <body>
+        <ul id="list">
+            <li class="remove">foo</li>
+            <li>bar</li>
+            <li>baz</li>
+            <li class="remove">quz</li>
+            <li>lorem</li>
+        </ul>
+    </body>
+    </html>
+    HTML;
+
+it('removes all nodes that match a given CSS selector', function (object $originalNode) {
+    /** @var Crawler|DOMNode $originalNode */
+    $node = helper_getAbstractNodeInstance($originalNode);
+
+    $node->removeNodesMatchingSelector('#list .remove');
+
+    $sourceAfterRemoval = $node->outer();
+
+    expect($sourceAfterRemoval)->toContain('<li>bar</li>')
+        ->toContain('<li>baz</li>')
+        ->not()->toContain('<li class="remove">')
+        ->not()->toContain('foo')
+        ->not()->toContain('quz');
+})->with([
+    [helper_getSymfonyCrawlerInstanceFromSource($html)],
+    [helper_getLegacyDomNodeInstanceFromSource($html)],
+]);
+
+it('removes all nodes that match a given CSS selector in PHP >= 8.4', function () use ($html) {
+    $originalNode = helper_getPhp84HtmlDomNodeInstanceFromSource($html);
+
+    $node = helper_getAbstractNodeInstance($originalNode);
+
+    $node->removeNodesMatchingSelector('#list .remove');
+
+    $sourceAfterRemoval = $node->outer();
+
+    expect($sourceAfterRemoval)->toContain('<li>bar</li>')
+        ->toContain('<li>baz</li>')
+        ->not()->toContain('<li class="remove">')
+        ->not()->toContain('foo')
+        ->not()->toContain('quz');
+})->group('php84');
+
+$xml = <<<XML
+    <?xml version="1.0" encoding="utf-8"?>
+    <feed>
+        <items>
+            <item>
+                <id>1</id>
+                <title>foo</title>
+                <description>lorem</description>
+            </item>
+            <item>
+                <id>2</id>
+                <title>bar</title>
+                <description>ipsum</description>
+            </item>
+            <item>
+                <id>3</id>
+                <title>baz</title>
+                <description>dolor</description>
+            </item>
+        </items>
+    </feed>
+    XML;
+
+it('removes all nodes that match a given CSS selector from XML', function (object $originalNode) {
+    /** @var Crawler|DOMNode $originalNode */
+    $node = helper_getAbstractNodeInstance($originalNode, false);
+
+    $node->removeNodesMatchingSelector('feed items item title');
+
+    $sourceAfterRemoval = $node->outer();
+
+    expect($sourceAfterRemoval)->toContain('<id>')
+        ->toContain('<description>')
+        ->not()->toContain('<title>');
+})->with([
+    [helper_getSymfonyCrawlerInstanceFromSource($xml, 'feed')],
+]);
+
+it('removes all nodes that match a given CSS selector from XML in PHP >= 8.4', function () use ($xml) {
+    $originalNode = helper_getPhp84XmlDomNodeInstanceFromSource($xml, 'feed');
+
+    $node = helper_getAbstractNodeInstance($originalNode);
+
+    $node->removeNodesMatchingSelector('feed items item title');
+
+    $sourceAfterRemoval = $node->outer();
+
+    expect($sourceAfterRemoval)->toContain('<id>')
+        ->toContain('<description>')
+        ->not()->toContain('<title>');
+})->group('php84');
+
+/* ----------------------------- removeNodesMatchingXPath() ----------------------------- */
+
+$html = <<<HTML
+    <!doctype html>
+    <html>
+    <head></head>
+    <body>
+        <ul id="list">
+            <li class="remove">foo</li>
+            <li>bar</li>
+            <li>baz</li>
+            <li class="remove">quz</li>
+            <li>lorem</li>
+        </ul>
+    </body>
+    </html>
+    HTML;
+
+it('removes all nodes that match a given XPath query', function (object $originalNode) {
+    /** @var Crawler|DOMNode $originalNode */
+    $node = helper_getAbstractNodeInstance($originalNode);
+
+    $node->removeNodesMatchingXPath('//li[contains(@class, \'remove\')]');
+
+    $sourceAfterRemoval = $node->outer();
+
+    expect($sourceAfterRemoval)->toContain('<li>bar</li>')
+        ->toContain('<li>baz</li>')
+        ->not()->toContain('<li class="remove">')
+        ->not()->toContain('foo')
+        ->not()->toContain('quz');
+})->with([
+    [helper_getSymfonyCrawlerInstanceFromSource($html)],
+    [helper_getLegacyDomNodeInstanceFromSource($html)],
+]);
+
+it('removes all nodes that match a given XPath query in PHP >= 8.4', function () use ($html) {
+    $originalNode = helper_getPhp84HtmlDomNodeInstanceFromSource($html);
+
+    $node = helper_getAbstractNodeInstance($originalNode);
+
+    $node->removeNodesMatchingXPath('//li[contains(@class, \'remove\')]');
+
+    $sourceAfterRemoval = $node->outer();
+
+    expect($sourceAfterRemoval)->toContain('<li>bar</li>')
+        ->toContain('<li>baz</li>')
+        ->not()->toContain('<li class="remove">')
+        ->not()->toContain('foo')
+        ->not()->toContain('quz');
+})->group('php84');
+
+$xml = <<<XML
+    <?xml version="1.0" encoding="utf-8"?>
+    <feed>
+        <items>
+            <item>
+                <id>1</id>
+                <title>foo</title>
+                <description>lorem</description>
+            </item>
+            <item>
+                <id>2</id>
+                <title>bar</title>
+                <description>ipsum</description>
+            </item>
+            <item>
+                <id>3</id>
+                <title>baz</title>
+                <description>dolor</description>
+            </item>
+        </items>
+    </feed>
+    XML;
+
+it('removes all nodes that match a given XPath query from XML', function (object $originalNode) {
+    /** @var Crawler|DOMNode $originalNode */
+    $node = helper_getAbstractNodeInstance($originalNode);
+
+    $node->removeNodesMatchingXPath('//feed/items/item/title');
+
+    $sourceAfterRemoval = $node->outer();
+
+    expect($sourceAfterRemoval)->toContain('<id>')
+        ->toContain('<description>')
+        ->not()->toContain('<title>');
+})->with([
+    [helper_getSymfonyCrawlerInstanceFromSource($xml, 'feed')],
+]);
+
+it('removes all nodes that match a given XPath query from XML in PHP >= 8.4', function () use ($xml) {
+    $originalNode = helper_getPhp84XmlDomNodeInstanceFromSource($xml, 'feed');
+
+    $node = helper_getAbstractNodeInstance($originalNode);
+
+    $node->removeNodesMatchingXPath('//feed/items/item/title');
+
+    $sourceAfterRemoval = $node->outer();
+
+    expect($sourceAfterRemoval)->toContain('<id>')
+        ->toContain('<description>')
+        ->not()->toContain('<title>');
+})->group('php84');
+
+/* ----------------------------- getAttribute() ----------------------------- */
+
 $html = <<<HTML
     <!doctype html>
     <html>
@@ -449,6 +665,8 @@ it('returns null when an attribute does not exist in PHP >= 8.4', function () us
     expect($node->getAttribute('data-test'))->toBeNull();
 })->group('php84');
 
+/* ----------------------------- nodeName() ----------------------------- */
+
 it('gets the name of a node', function (object $originalNode) {
     /** @var Crawler|DOMNode $originalNode */
     $node = helper_getAbstractNodeInstance($originalNode);
@@ -477,6 +695,8 @@ $html = <<<HTML
     </html>
     HTML;
 
+/* ----------------------------- text() ----------------------------- */
+
 it('gets the text content of an HTML node', function (object $originalNode) {
     /** @var Crawler|DOMNode $originalNode */
     $node = helper_getAbstractNodeInstance($originalNode);
@@ -495,6 +715,8 @@ it('gets the text content of an HTML node in PHP >= 8.4', function () use ($html
     expect($node->text())->toBe('Title Lorem ipsum.');
 })->group('php84');
 
+/* ----------------------------- innerSource() ----------------------------- */
+
 it('gets the inner source of an HTML node', function (object $originalNode) {
     /** @var Crawler|DOMNode $originalNode */
     $node = helper_getAbstractNodeInstance($originalNode);
@@ -512,6 +734,8 @@ it('gets the inner source of an HTML node in PHP >= 8.4', function () use ($html
 
     expect($node->inner())->toBe(' <h1>Title</h1> <p>Lorem ipsum.</p> ');
 })->group('php84');
+
+/* ----------------------------- outerSource () ----------------------------- */
 
 it('gets the outer source of an HTML node', function (object $originalNode) {
     /** @var Crawler|DOMNode $originalNode */
@@ -536,6 +760,8 @@ $xml = <<<XML
     <items> <item> <id>1</id> <title>Lorem Ipsum</title> </item> </items>
     XML;
 
+/* ----------------------------- text() ----------------------------- */
+
 it('gets the text content of an XML node', function (object $originalNode) {
     /** @var Crawler|DOMNode $originalNode */
     $node = helper_getAbstractNodeInstance($originalNode);
@@ -554,6 +780,8 @@ it('gets the text content of an XML node in PHP >= 8.4', function () use ($xml) 
     expect($node->text())->toBe('1 Lorem Ipsum');
 })->group('php84');
 
+/* ----------------------------- innerSource() XML ----------------------------- */
+
 it('gets the inner source of an XML node', function (object $originalNode) {
     /** @var Crawler|DOMNode $originalNode */
     $node = helper_getAbstractNodeInstance($originalNode);
@@ -571,6 +799,8 @@ it('gets the inner source of an XML node in PHP >= 8.4', function () use ($xml) 
 
     expect($node->inner())->toBe(' <id>1</id> <title>Lorem Ipsum</title> ');
 })->group('php84');
+
+/* ----------------------------- outerSource() XML ----------------------------- */
 
 it('gets the outer source of an XML node', function (object $originalNode) {
     /** @var Crawler|DOMNode $originalNode */
@@ -601,6 +831,8 @@ $html = <<<HTML
     </body>
     </html>
     HTML;
+
+/* ------------ :has() :not() CSS pseudo class selectors in PHP 8.4 ------------- */
 
 it('selects elements using a CSS selector containing the :has() pseudo class', function () use ($html) {
     $originalNode = helper_getPhp84HtmlDomNodeInstanceFromSource($html);

--- a/tests/Steps/Refiners/DateTime/DateTimeFormatTest.php
+++ b/tests/Steps/Refiners/DateTime/DateTimeFormatTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace tests\Steps\Refiners\DateTime;
+
+use Crwlr\Crawler\Steps\Refiners\DateTimeRefiner;
+use tests\_Stubs\DummyLogger;
+
+it('reformats common date/time strings without knowing the origin format', function (string $from, string $to) {
+    $refinedValue = DateTimeRefiner::reformat('Y-m-d H:i:s')->refine($from);
+
+    expect($refinedValue)->toBe($to);
+})->with([
+    ['2024-09-21T13:55:41Z', '2024-09-21 13:55:41'],
+    ['2024-09-21T13:55:41.000Z', '2024-09-21 13:55:41'],
+    ['2024-09-21', '2024-09-21 00:00:00'],
+    ['2024-09-21, 13:55:41', '2024-09-21 13:55:41'],
+    ['21 September 2024, 13:55:41', '2024-09-21 13:55:41'],
+    ['21. September 2024, 13:55:41', '2024-09-21 13:55:41'],
+    ['21 September 2024', '2024-09-21 00:00:00'],
+    ['21. September 2024', '2024-09-21 00:00:00'],
+    ['21.09.2024', '2024-09-21 00:00:00'],
+    ['21.09.2024 13:55', '2024-09-21 13:55:00'],
+    ['21.09.2024 13:55:41', '2024-09-21 13:55:41'],
+    ['Sat, 21 September 2024 13:55:41 +0000', '2024-09-21 13:55:41'],
+    ['Sat Sep 21 2024 16:55:41 GMT+0100', '2024-09-21 15:55:41'],
+]);
+
+it('reformats a format that PHP\'s strtotime() does not know, when the origin format is provided', function () {
+    $refinedValue = DateTimeRefiner::reformat('Y-m-d H:i:s', 'd. F Y \u\m H:i:s')
+        ->refine('21. September 2024 um 13:55:41');
+
+    expect($refinedValue)->toBe('2024-09-21 13:55:41');
+});
+
+it('logs a warning message (and keeps original input) when it wasn\'t able to auto-convert a date time string', function () {
+    $refiner = DateTimeRefiner::reformat('Y-m-d H:i:s');
+
+    $logger = new DummyLogger();
+
+    $refiner->addLogger($logger);
+
+    $refinedValue = $refiner->refine('21. September 2024 um 13:55:41');
+
+    expect($logger->messages)->toHaveCount(1)
+        ->and($logger->messages[0]['level'])->toBe('warning')
+        ->and($logger->messages[0]['message'])->toStartWith('Failed to automatically (without known format) parse')
+        ->and($refinedValue)->toBe('21. September 2024 um 13:55:41');
+});
+
+it(
+    'logs a warning message (and keeps original input) when it wasn\'t able to convert a date time string with the ' .
+    'given origin format',
+    function () {
+        $refiner = DateTimeRefiner::reformat('Y-m-d H:i:s', 'd. F Y um H:i:s');
+
+        $logger = new DummyLogger();
+
+        $refiner->addLogger($logger);
+
+        $refinedValue = $refiner->refine('21. September 2024 um 13:55:41');
+
+        expect($logger->messages)->toHaveCount(1)
+            ->and($logger->messages[0]['level'])->toBe('warning')
+            ->and($logger->messages[0]['message'])->toStartWith('Failed parsing date/time ')
+            ->and($refinedValue)->toBe('21. September 2024 um 13:55:41');
+    },
+);

--- a/tests/Steps/Refiners/Html/RemoveFromHtmlTest.php
+++ b/tests/Steps/Refiners/Html/RemoveFromHtmlTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace tests\Steps\Refiners\DateTime;
+
+use Crwlr\Crawler\Steps\Dom;
+use Crwlr\Crawler\Steps\Refiners\HtmlRefiner;
+
+it('removes a certain node from an HTML document by selector', function () {
+    $html = <<<HTML
+        <!doctype html>
+        <html>
+        <head></head>
+        <body>
+        <h1>Hi!</h1>
+        <div id="foo">remove this!</div>
+        </body>
+        </html>
+        HTML;
+
+    $refinedValue = HtmlRefiner::remove('#foo')->refine($html);
+
+    expect($refinedValue)->not()->toContain('remove this!')
+        ->and($refinedValue)->toContain('<h1>Hi!</h1>');
+});
+
+it('removes a certain node from an HTML snippet by selector', function () {
+    $html = <<<HTML
+        <article>
+        <h1>Hi!</h1>
+        <p id="foo">remove this!</p>
+        </article>
+        HTML;
+
+    $refinedValue = HtmlRefiner::remove('#foo')->refine($html);
+
+    expect($refinedValue)->not()->toContain('remove this!')
+        ->and($refinedValue)->toContain('<h1>Hi!</h1>')
+        ->and($refinedValue)->not()->toContain('<html>');
+});
+
+it('removes multiple nodes from an HTML snippet by selector', function () {
+    $html = <<<HTML
+        <article>
+        <ul id="list">
+            <li>foo</li>
+            <li class="remove">bar</li>
+            <li>baz</li>
+            <li class="remove">quz</li>
+        </ul>
+        </article>
+        HTML;
+
+    $refinedValue = HtmlRefiner::remove('#list .remove')->refine($html);
+
+    expect($refinedValue)->not()->toContain('bar')
+        ->and($refinedValue)->not()->toContain('quz')
+        ->and($refinedValue)->toContain('<li>foo</li>')
+        ->and($refinedValue)->toContain('<li>baz</li>')
+        ->and($refinedValue)->not()->toContain('<html>');
+});
+
+it('removes multiple nodes from HTML by xpath query', function () {
+    $html = <<<HTML
+        <article>
+        <ul id="list">
+            <li>foo</li>
+            <li class="remove">bar</li>
+            <li>baz</li>
+            <li class="remove">quz</li>
+        </ul>
+        </article>
+        HTML;
+
+    $refinedValue = HtmlRefiner::remove(Dom::xPath('//li[contains(@class, \'remove\')]'))->refine($html);
+
+    expect($refinedValue)->not()->toContain('bar')
+        ->and($refinedValue)->not()->toContain('quz')
+        ->and($refinedValue)->toContain('<li>foo</li>')
+        ->and($refinedValue)->toContain('<li>baz</li>')
+        ->and($refinedValue)->not()->toContain('<html>');
+});


### PR DESCRIPTION
* `DateTimeRefiner::reformat('Y-m-d H:i:s')` to reformat a date time string to a different format. Tries to automatically recognize the input format. If this does not work, you can provide an input format to use as the second argument.
* `HtmlRefiner::remove('#foo')` to remove nodes matching the given selector from selected HTML.