### PR TITLE
Force one output per input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * New Refiners:
     * `DateTimeRefiner::reformat('Y-m-d H:i:s')` to reformat a date time string to a different format. Tries to automatically recognize the input format. If this does not work, you can provide an input format to use as the second argument.
     * `HtmlRefiner::remove('#foo')` to remove nodes matching the given selector from selected HTML.
+* Steps that produce multiple outputs per input can now group them per input by calling the new `Step::oneOutputPerInput()` method.
 
 ## [3.4.5] - 2025-04-09
 ### Fixed

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -155,6 +155,18 @@ function helper_getStepYieldingMultipleObjectsWithNumber(): Step
     };
 }
 
+function helper_getStepYieldingInputArrayAsSeparateOutputs(): Step
+{
+    return new class extends Step {
+        protected function invoke(mixed $input): Generator
+        {
+            foreach ($input as $output) {
+                yield $output;
+            }
+        }
+    };
+}
+
 function helper_getLoadingStep(): Step
 {
     return new class extends Step {


### PR DESCRIPTION
Steps that produce multiple outputs per input can now group them per input by calling the new `Step::oneOutputPerInput()` method.