### PR TITLE
Use extracted data to dynamically build request URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.0] - 2025-04-10
 ### Added
+* Dynamically building request URLs from extracted data: `Http` steps now have a new `staticUrl()` method, and you can also use variables within that static URL - as well as in request headers and the body - like `https://www.example.com/foo/[crwl:some_extracted_property]`. These variables will be replaced with the corresponding properties from input data (also works with kept data).
 * New Refiners:
     * `DateTimeRefiner::reformat('Y-m-d H:i:s')` to reformat a date time string to a different format. Tries to automatically recognize the input format. If this does not work, you can provide an input format to use as the second argument.
     * `HtmlRefiner::remove('#foo')` to remove nodes matching the given selector from selected HTML.

--- a/src/Steps/BaseStep.php
+++ b/src/Steps/BaseStep.php
@@ -82,6 +82,8 @@ abstract class BaseStep implements StepInterface
 
     protected int $currentOutputCount = 0;
 
+    private ?Input $fullOriginalInput = null;
+
     /**
      * @param Input $input
      * @return Generator<Output>
@@ -306,6 +308,24 @@ abstract class BaseStep implements StepInterface
         $this->subCrawlers[$for] = $crawlerBuilder;
 
         return $this;
+    }
+
+    /**
+     * In case useInputKey() was used, use this method to store the original input so you can still
+     * access it later.
+     */
+    protected function storeOriginalInput(Input $input): void
+    {
+        $this->fullOriginalInput = $input;
+    }
+
+    /**
+     * In case useInputKey() was used, this method shall still provide access to the full input object,
+     * that the step was last called with.
+     */
+    protected function getFullOriginalInput(): ?Input
+    {
+        return $this->fullOriginalInput;
     }
 
     protected function runSubCrawlersFor(Output $output): Output

--- a/src/Steps/Group.php
+++ b/src/Steps/Group.php
@@ -34,6 +34,8 @@ final class Group extends BaseStep
             return;
         }
 
+        $this->storeOriginalInput($input);
+
         // When input is array and useInputKey() was used, invoke the steps only with that input array element,
         // but keep the original input, because we want to use it e.g. for the keepInputData() functionality.
         $inputForStepInvocation = $this->getInputKeyToUse($input);

--- a/src/Steps/Step.php
+++ b/src/Steps/Step.php
@@ -43,6 +43,8 @@ abstract class Step extends BaseStep
             return;
         }
 
+        $this->storeOriginalInput($input);
+
         $inputForStepInvocation = $this->getInputKeyToUse($input);
 
         if ($inputForStepInvocation) {

--- a/src/Utils/TemplateString.php
+++ b/src/Utils/TemplateString.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Crwlr\Crawler\Utils;
+
+use Adbar\Dot;
+
+class TemplateString
+{
+    /**
+     * @param mixed[] $data
+     */
+    public static function resolve(string $string, array $data = []): string
+    {
+//        if (str_contains($string, '{{ crwl_var(') || str_contains($string, '{{crwl_var(')) {
+        if (str_contains($string, '[crwl:')) {
+            return preg_replace_callback('/\[crwl:(.+?)]/m', function ($matches) use ($data) {
+                $varName = self::trimAndUnescapeQuotes($matches[1]);
+
+                if (array_key_exists($varName, $data)) {
+                    return $data[$varName];
+                } elseif (str_contains($varName, '.')) {
+                    $dot = new Dot($data);
+
+                    return $dot->get($varName);
+                }
+
+                return '';
+            }, $string) ?? $string;
+        }
+
+        return $string;
+    }
+
+    private static function trimAndUnescapeQuotes(string $string): string
+    {
+        if (
+            str_starts_with($string, '\'') && str_ends_with($string, '\'') ||
+            str_starts_with($string, '"') && str_ends_with($string, '"')
+        ) {
+            $string = substr($string, 1, -1);
+        }
+
+        $string = str_replace(["\'", '\"'], ["'", '"'], $string);
+
+        return $string;
+    }
+}

--- a/src/Utils/TemplateString.php
+++ b/src/Utils/TemplateString.php
@@ -11,7 +11,6 @@ class TemplateString
      */
     public static function resolve(string $string, array $data = []): string
     {
-//        if (str_contains($string, '{{ crwl_var(') || str_contains($string, '{{crwl_var(')) {
         if (str_contains($string, '[crwl:')) {
             return preg_replace_callback('/\[crwl:(.+?)]/m', function ($matches) use ($data) {
                 $varName = self::trimAndUnescapeQuotes($matches[1]);

--- a/tests/Utils/TemplateStringTest.php
+++ b/tests/Utils/TemplateStringTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace tests\Utils;
+
+use Crwlr\Crawler\Utils\TemplateString;
+
+it('resolves the variable syntax in a string with data from an array', function () {
+    $string = <<<STRING
+        https://www.example.com/[crwl:foo]/bar
+
+        Lorem ipsum [crwl:'asdf'] dolor. Don't replace [crwl.io](/a/markdown/link) this.
+
+        But [crwl:'asdf\'asdf'] this.
+
+        Also with [crwl:"qu\"z"] quotes in it.
+        STRING;
+
+    $replaced = TemplateString::resolve($string, [
+        'foo' => 'foo',
+        'asdf' => 'asdf',
+        'var' => 'yolo',
+        'asdf\'asdf' => 'replace',
+        'qu"z' => 'double',
+    ]);
+
+    expect($replaced)->toBe(
+        <<<STRING
+        https://www.example.com/foo/bar
+
+        Lorem ipsum asdf dolor. Don't replace [crwl.io](/a/markdown/link) this.
+
+        But replace this.
+
+        Also with double quotes in it.
+        STRING,
+    );
+});
+
+it('resolves two variables in one line (regex is non greedy)', function () {
+    expect(
+        TemplateString::resolve(
+            'hi [crwl:"one"]/[crwl:two] bye',
+            ['one' => 'bonjour', 'two' => 'ciao'],
+        ),
+    )->toBe('hi bonjour/ciao bye');
+});


### PR DESCRIPTION
`Http` steps now have a new `staticUrl()` method, and you can also use variables within that static URL - as well as in request headers and in the body - like
`https://www.example.com/foo/[crwl:some_extracted_property]`. These variables will be replaced with the corresponding properties from input data (also works with kept data).