### PR TITLE
Two fixes/improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.1] - 2025-04-23
+### Fixed
+* An issue that occurred, when a step uses the `PreStepInvocationLogger`. As refiners also use the logger, a newer logger (replacing the `PreStepInvocationLogger`) is now also passed to all registered refiners of a step.
+* Enable applying refiners to output properties with array value. E.g. if a step outputs an array of URLs (`['https://...', 'https://...']`), a `UrlRefiner` will be applied to all those URLs.
+
 ## [3.5.0] - 2025-04-10
 ### Added
 * Dynamically building request URLs from extracted data: `Http` steps now have a new `staticUrl()` method, and you can also use variables within that static URL - as well as in request headers and the body - like `https://www.example.com/foo/[crwl:some_extracted_property]`. These variables will be replaced with the corresponding properties from input data (also works with kept data).

--- a/src/Steps/BaseStep.php
+++ b/src/Steps/BaseStep.php
@@ -98,6 +98,16 @@ abstract class BaseStep implements StepInterface
 
         $this->logger = $logger;
 
+        if (!empty($this->refiners)) {
+            foreach ($this->refiners as $refiner) {
+                if ($refiner instanceof RefinerInterface) {
+                    $refiner->addLogger($logger);
+                } elseif (is_array($refiner) && $refiner['refiner'] instanceof RefinerInterface) {
+                    $refiner['refiner']->addLogger($logger);
+                }
+            }
+        }
+
         return $this;
     }
 

--- a/src/Steps/Refiners/DateTime/DateTimeFormat.php
+++ b/src/Steps/Refiners/DateTime/DateTimeFormat.php
@@ -2,32 +2,34 @@
 
 namespace Crwlr\Crawler\Steps\Refiners\DateTime;
 
-use Crwlr\Crawler\Steps\Refiners\AbstractRefiner;
+use Crwlr\Crawler\Steps\Refiners\String\AbstractStringRefiner;
 use DateTime;
 
-class DateTimeFormat extends AbstractRefiner
+class DateTimeFormat extends AbstractStringRefiner
 {
     public function __construct(protected string $targetFormat, protected string|null $originFormat = null) {}
 
     public function refine(mixed $value): mixed
     {
-        if ($this->originFormat) {
-            $parsed = DateTime::createFromFormat($this->originFormat, $value);
-        } else {
-            $parsed = $this->parseFromUnknownFormat($value);
-        }
+        return $this->apply($value, function ($value) {
+            if ($this->originFormat) {
+                $parsed = DateTime::createFromFormat($this->originFormat, $value);
+            } else {
+                $parsed = $this->parseFromUnknownFormat($value);
+            }
 
-        if ($parsed === null) {
-            return $value;
-        } elseif ($parsed === false) {
-            $this->logger?->warning(
-                'Failed parsing date/time "' . $value . '", so can\'t reformat it to requested format.',
-            );
+            if ($parsed === null) {
+                return $value;
+            } elseif ($parsed === false) {
+                $this->logger?->warning(
+                    'Failed parsing date/time "' . $value . '", so can\'t reformat it to requested format.',
+                );
 
-            return $value;
-        }
+                return $value;
+            }
 
-        return $parsed->format($this->targetFormat);
+            return $parsed->format($this->targetFormat);
+        }, 'DateTimeRefiner::reformat()');
     }
 
     private function parseFromUnknownFormat(string $value): ?DateTime

--- a/src/Steps/Refiners/String/AbstractStringRefiner.php
+++ b/src/Steps/Refiners/String/AbstractStringRefiner.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Crwlr\Crawler\Steps\Refiners\String;
+
+use Closure;
+use Crwlr\Crawler\Steps\Refiners\AbstractRefiner;
+
+abstract class AbstractStringRefiner extends AbstractRefiner
+{
+    /**
+     * @param Closure $refiner
+     * @return mixed
+     */
+    protected function apply(mixed $value, Closure $refiner, string $staticRefinerMethod): mixed
+    {
+        if (!is_string($value) && !is_array($value)) {
+            $this->logTypeWarning($staticRefinerMethod, $value);
+
+            return $value;
+        }
+
+        if (is_array($value)) {
+            foreach ($value as $key => $element) {
+                if (is_string($element)) {
+                    $value[$key] = $refiner($element);
+                }
+            }
+        } else {
+            $value = $refiner($value);
+        }
+
+        return $value;
+    }
+}

--- a/src/Steps/Refiners/String/StrAfterFirst.php
+++ b/src/Steps/Refiners/String/StrAfterFirst.php
@@ -2,28 +2,22 @@
 
 namespace Crwlr\Crawler\Steps\Refiners\String;
 
-use Crwlr\Crawler\Steps\Refiners\AbstractRefiner;
-
-class StrAfterFirst extends AbstractRefiner
+class StrAfterFirst extends AbstractStringRefiner
 {
     public function __construct(protected readonly string $first) {}
 
     public function refine(mixed $value): mixed
     {
-        if (!is_string($value)) {
-            $this->logTypeWarning('StringRefiner::afterFirst()', $value);
+        return $this->apply($value, function ($value) {
+            if ($this->first === '') {
+                return $value;
+            }
 
-            return $value;
-        }
+            $split = explode($this->first, $value, 2);
 
-        if ($this->first === '') {
-            return $value;
-        }
+            $lastPart = end($split);
 
-        $split = explode($this->first, $value, 2);
-
-        $lastPart = end($split);
-
-        return trim($lastPart);
+            return trim($lastPart);
+        }, 'StringRefiner::afterFirst()');
     }
 }

--- a/src/Steps/Refiners/String/StrAfterLast.php
+++ b/src/Steps/Refiners/String/StrAfterLast.php
@@ -2,28 +2,22 @@
 
 namespace Crwlr\Crawler\Steps\Refiners\String;
 
-use Crwlr\Crawler\Steps\Refiners\AbstractRefiner;
-
-class StrAfterLast extends AbstractRefiner
+class StrAfterLast extends AbstractStringRefiner
 {
     public function __construct(protected readonly string $last) {}
 
     public function refine(mixed $value): mixed
     {
-        if (!is_string($value)) {
-            $this->logTypeWarning('StringRefiner::afterLast()', $value);
+        return $this->apply($value, function ($value) {
+            if ($this->last === '') {
+                return '';
+            }
 
-            return $value;
-        }
+            $split = explode($this->last, $value);
 
-        if ($this->last === '') {
-            return '';
-        }
+            $lastPart = end($split);
 
-        $split = explode($this->last, $value);
-
-        $lastPart = end($split);
-
-        return trim($lastPart);
+            return trim($lastPart);
+        }, 'StringRefiner::afterLast()');
     }
 }

--- a/src/Steps/Refiners/String/StrBeforeFirst.php
+++ b/src/Steps/Refiners/String/StrBeforeFirst.php
@@ -2,24 +2,18 @@
 
 namespace Crwlr\Crawler\Steps\Refiners\String;
 
-use Crwlr\Crawler\Steps\Refiners\AbstractRefiner;
-
-class StrBeforeFirst extends AbstractRefiner
+class StrBeforeFirst extends AbstractStringRefiner
 {
     public function __construct(protected readonly string $first) {}
 
     public function refine(mixed $value): mixed
     {
-        if (!is_string($value)) {
-            $this->logTypeWarning('StringRefiner::beforeFirst()', $value);
+        return $this->apply($value, function ($value) {
+            if ($this->first === '') {
+                return '';
+            }
 
-            return $value;
-        }
-
-        if ($this->first === '') {
-            return '';
-        }
-
-        return trim(explode($this->first, $value)[0]);
+            return trim(explode($this->first, $value)[0]);
+        }, 'StringRefiner::beforeFirst()');
     }
 }

--- a/src/Steps/Refiners/String/StrBeforeLast.php
+++ b/src/Steps/Refiners/String/StrBeforeLast.php
@@ -2,32 +2,26 @@
 
 namespace Crwlr\Crawler\Steps\Refiners\String;
 
-use Crwlr\Crawler\Steps\Refiners\AbstractRefiner;
-
-class StrBeforeLast extends AbstractRefiner
+class StrBeforeLast extends AbstractStringRefiner
 {
     public function __construct(protected readonly string $last) {}
 
     public function refine(mixed $value): mixed
     {
-        if (!is_string($value)) {
-            $this->logTypeWarning('StringRefiner::beforeLast()', $value);
+        return $this->apply($value, function ($value) {
+            if ($this->last === '') {
+                return $value;
+            }
 
-            return $value;
-        }
+            $split = explode($this->last, $value);
 
-        if ($this->last === '') {
-            return $value;
-        }
+            if (count($split) === 1) {
+                return $value;
+            }
 
-        $split = explode($this->last, $value);
+            array_pop($split);
 
-        if (count($split) === 1) {
-            return $value;
-        }
-
-        array_pop($split);
-
-        return trim(implode($this->last, $split));
+            return trim(implode($this->last, $split));
+        }, 'StringRefiner::beforeLast()');
     }
 }

--- a/src/Steps/Refiners/String/StrBetweenFirst.php
+++ b/src/Steps/Refiners/String/StrBetweenFirst.php
@@ -2,34 +2,28 @@
 
 namespace Crwlr\Crawler\Steps\Refiners\String;
 
-use Crwlr\Crawler\Steps\Refiners\AbstractRefiner;
-
-class StrBetweenFirst extends AbstractRefiner
+class StrBetweenFirst extends AbstractStringRefiner
 {
     public function __construct(protected readonly string $start, protected readonly string $end) {}
 
     public function refine(mixed $value): mixed
     {
-        if (!is_string($value)) {
-            $this->logTypeWarning('StringRefiner::betweenFirst()', $value);
-
-            return $value;
-        }
-
-        if ($this->start === '') {
-            $splitAtStart = ['', $value];
-        } else {
-            $splitAtStart = explode($this->start, $value, 2);
-        }
-
-        if (count($splitAtStart) === 2) {
-            if ($this->end === '') {
-                return trim($splitAtStart[1]);
+        return $this->apply($value, function ($value) {
+            if ($this->start === '') {
+                $splitAtStart = ['', $value];
+            } else {
+                $splitAtStart = explode($this->start, $value, 2);
             }
 
-            return trim(explode($this->end, $splitAtStart[1])[0]);
-        }
+            if (count($splitAtStart) === 2) {
+                if ($this->end === '') {
+                    return trim($splitAtStart[1]);
+                }
 
-        return '';
+                return trim(explode($this->end, $splitAtStart[1])[0]);
+            }
+
+            return '';
+        }, 'StringRefiner::betweenFirst()');
     }
 }

--- a/src/Steps/Refiners/String/StrBetweenLast.php
+++ b/src/Steps/Refiners/String/StrBetweenLast.php
@@ -2,32 +2,26 @@
 
 namespace Crwlr\Crawler\Steps\Refiners\String;
 
-use Crwlr\Crawler\Steps\Refiners\AbstractRefiner;
-
-class StrBetweenLast extends AbstractRefiner
+class StrBetweenLast extends AbstractStringRefiner
 {
     public function __construct(protected readonly string $start, protected readonly string $end) {}
 
     public function refine(mixed $value): mixed
     {
-        if (!is_string($value)) {
-            $this->logTypeWarning('StringRefiner::betweenLast()', $value);
+        return $this->apply($value, function ($value) {
+            if ($this->start === '') {
+                $splitAtStart = ['', $value];
+            } else {
+                $splitAtStart = explode($this->start, $value);
+            }
 
-            return $value;
-        }
+            $lastPart = end($splitAtStart);
 
-        if ($this->start === '') {
-            $splitAtStart = ['', $value];
-        } else {
-            $splitAtStart = explode($this->start, $value);
-        }
+            if ($this->end === '') {
+                return trim($lastPart);
+            }
 
-        $lastPart = end($splitAtStart);
-
-        if ($this->end === '') {
-            return trim($lastPart);
-        }
-
-        return trim(explode($this->end, $lastPart)[0]);
+            return trim(explode($this->end, $lastPart)[0]);
+        }, 'StringRefiner::betweenLast()');
     }
 }

--- a/src/Steps/Refiners/String/StrReplace.php
+++ b/src/Steps/Refiners/String/StrReplace.php
@@ -2,9 +2,7 @@
 
 namespace Crwlr\Crawler\Steps\Refiners\String;
 
-use Crwlr\Crawler\Steps\Refiners\AbstractRefiner;
-
-class StrReplace extends AbstractRefiner
+class StrReplace extends AbstractStringRefiner
 {
     /**
      * @param string|string[] $search
@@ -17,14 +15,20 @@ class StrReplace extends AbstractRefiner
 
     public function refine(mixed $value): mixed
     {
-        if (!is_string($value)) {
-            $this->logTypeWarning('StringRefiner::replace()', $value);
+        return $this->apply($value, function ($value) {
+            $replaced = str_replace($this->search, $this->replace, $value);
 
-            return $value;
-        }
+            return trim($replaced);
+        }, 'StringRefiner::replace()');
 
-        $replaced = str_replace($this->search, $this->replace, $value);
-
-        return trim($replaced);
+        //        if (!is_string($value)) {
+        //            $this->logTypeWarning('StringRefiner::replace()', $value);
+        //
+        //            return $value;
+        //        }
+        //
+        //        $replaced = str_replace($this->search, $this->replace, $value);
+        //
+        //        return trim($replaced);
     }
 }

--- a/src/Steps/Refiners/Url/AbstractUrlRefiner.php
+++ b/src/Steps/Refiners/Url/AbstractUrlRefiner.php
@@ -15,6 +15,14 @@ abstract class AbstractUrlRefiner extends AbstractRefiner
      */
     public function refine(mixed $value): mixed
     {
+        if (is_array($value)) {
+            foreach ($value as $key => $url) {
+                $value[$key] = $this->refine($url);
+            }
+
+            return $value;
+        }
+
         if (!is_string($value) && !$value instanceof Url && !$value instanceof UriInterface) {
             $this->logTypeWarning($this->staticRefinerMethod(), $value);
 

--- a/tests/Steps/Refiners/DateTime/DateTimeFormatTest.php
+++ b/tests/Steps/Refiners/DateTime/DateTimeFormatTest.php
@@ -65,3 +65,17 @@ it(
             ->and($refinedValue)->toBe('21. September 2024 um 13:55:41');
     },
 );
+
+it('reformats an array of date time strings', function () {
+    $refinedValue = DateTimeRefiner::reformat('Y-m-d H:i:s')->refine([
+        '2024-09-21T13:55:41Z',
+        '2024-09-21T13:55:41.000Z',
+        '2024-09-21',
+    ]);
+
+    expect($refinedValue)->toBe([
+        '2024-09-21 13:55:41',
+        '2024-09-21 13:55:41',
+        '2024-09-21 00:00:00',
+    ]);
+});

--- a/tests/Steps/Refiners/Html/RemoveFromHtmlTest.php
+++ b/tests/Steps/Refiners/Html/RemoveFromHtmlTest.php
@@ -79,3 +79,31 @@ it('removes multiple nodes from HTML by xpath query', function () {
         ->and($refinedValue)->toContain('<li>baz</li>')
         ->and($refinedValue)->not()->toContain('<html>');
 });
+
+it('removes node from an array of HTML snippets', function () {
+    $html = [
+        <<<HTML
+        <ul id="list">
+            <li>foo</li>
+            <li class="remove">bar</li>
+            <li>baz</li>
+            <li class="remove">quz</li>
+        </ul>
+        HTML,
+        <<<HTML
+        <ul id="list">
+            <li>lorem</li>
+            <li class="remove">ipsum</li>
+            <li>dolor</li>
+            <li class="remove">sit</li>
+        </ul>
+        HTML,
+    ];
+
+    $refinedValue = HtmlRefiner::remove('.remove')->refine($html);
+
+    expect($refinedValue[0])->not()->toContain('bar')
+        ->and($refinedValue[0])->not()->toContain('quz')
+        ->and($refinedValue[1])->not()->toContain('ipsum')
+        ->and($refinedValue[1])->not()->toContain('sit');
+});

--- a/tests/Steps/Refiners/String/AfterFirstTest.php
+++ b/tests/Steps/Refiners/String/AfterFirstTest.php
@@ -15,14 +15,22 @@ it('logs a warning and returns the unchanged value when $value is not of type st
 
     $logOutput = $this->getActualOutputForAssertion();
 
-    expect($logOutput)->toContain('Refiner StringRefiner::afterFirst() can\'t be applied to value of type ' . gettype($value));
-
-    expect($refinedValue)->toBe($value);
+    expect($logOutput)
+        ->toContain('Refiner StringRefiner::afterFirst() can\'t be applied to value of type ' . gettype($value))
+        ->and($refinedValue)->toBe($value);
 })->with([
     [123],
     [12.3],
     [true],
 ]);
+
+it('works with an array of strings as value', function () {
+    $refinedValue = StringRefiner::afterFirst('a')
+        ->addLogger(new CliLogger())
+        ->refine(['foo a bar a baz', 'lorem a ipsum a dolor']);
+
+    expect($refinedValue)->toBe(['bar a baz', 'ipsum a dolor']);
+});
 
 it('returns the string after first occurrence of another string', function () {
     expect(StringRefiner::afterFirst('foo')->refine('yo lo foo boo choo foo gnu'))->toBe('boo choo foo gnu');

--- a/tests/Steps/Refiners/String/AfterLastTest.php
+++ b/tests/Steps/Refiners/String/AfterLastTest.php
@@ -15,14 +15,22 @@ it('logs a warning and returns the unchanged value when $value is not of type st
 
     $logOutput = $this->getActualOutputForAssertion();
 
-    expect($logOutput)->toContain('Refiner StringRefiner::afterLast() can\'t be applied to value of type ' . gettype($value));
-
-    expect($refinedValue)->toBe($value);
+    expect($logOutput)
+        ->toContain('Refiner StringRefiner::afterLast() can\'t be applied to value of type ' . gettype($value))
+        ->and($refinedValue)->toBe($value);
 })->with([
     [123],
     [12.3],
     [true],
 ]);
+
+it('works with an array of strings as value', function () {
+    $refinedValue = StringRefiner::afterLast('a')
+        ->addLogger(new CliLogger())
+        ->refine(['foo a bar a baz', 'lorem a ipsum a dolor']);
+
+    expect($refinedValue)->toBe(['z', 'dolor']);
+});
 
 it('returns the string after last occurrence of another string', function () {
     expect(StringRefiner::afterLast('foo')->refine('yo lo foo boo choo foo gnu'))->toBe('gnu');

--- a/tests/Steps/Refiners/String/BeforeFirstTest.php
+++ b/tests/Steps/Refiners/String/BeforeFirstTest.php
@@ -15,14 +15,22 @@ it('logs a warning and returns the unchanged value when $value is not of type st
 
     $logOutput = $this->getActualOutputForAssertion();
 
-    expect($logOutput)->toContain('Refiner StringRefiner::beforeFirst() can\'t be applied to value of type ' . gettype($value));
-
-    expect($refinedValue)->toBe($value);
+    expect($logOutput)
+        ->toContain('Refiner StringRefiner::beforeFirst() can\'t be applied to value of type ' . gettype($value))
+        ->and($refinedValue)->toBe($value);
 })->with([
     [123],
     [12.3],
     [true],
 ]);
+
+it('works with an array of strings as value', function () {
+    $refinedValue = StringRefiner::beforeFirst('a')
+        ->addLogger(new CliLogger())
+        ->refine(['foo a bar a baz', 'lorem a ipsum a dolor']);
+
+    expect($refinedValue)->toBe(['foo', 'lorem']);
+});
 
 it('returns the string before the first occurrence of another string', function () {
     expect(StringRefiner::beforeFirst('foo')->refine('yo lo foo boo choo foo gnu'))->toBe('yo lo');

--- a/tests/Steps/Refiners/String/BeforeLastTest.php
+++ b/tests/Steps/Refiners/String/BeforeLastTest.php
@@ -15,14 +15,22 @@ it('logs a warning and returns the unchanged value when $value is not of type st
 
     $logOutput = $this->getActualOutputForAssertion();
 
-    expect($logOutput)->toContain('Refiner StringRefiner::beforeLast() can\'t be applied to value of type ' . gettype($value));
-
-    expect($refinedValue)->toBe($value);
+    expect($logOutput)
+        ->toContain('Refiner StringRefiner::beforeLast() can\'t be applied to value of type ' . gettype($value))
+        ->and($refinedValue)->toBe($value);
 })->with([
     [123],
     [12.3],
     [true],
 ]);
+
+it('works with an array of strings as value', function () {
+    $refinedValue = StringRefiner::beforeLast('a')
+        ->addLogger(new CliLogger())
+        ->refine(['foo a bar a baz', 'lorem a ipsum a dolor']);
+
+    expect($refinedValue)->toBe(['foo a bar a b', 'lorem a ipsum']);
+});
 
 it('returns the string before the last occurrence of another string', function () {
     expect(StringRefiner::beforeLast('foo')->refine('yo lo foo boo choo foo gnu'))->toBe('yo lo foo boo choo');

--- a/tests/Steps/Refiners/String/BetweenFirstTest.php
+++ b/tests/Steps/Refiners/String/BetweenFirstTest.php
@@ -15,14 +15,22 @@ it('logs a warning and returns the unchanged value when $value is not of type st
 
     $logOutput = $this->getActualOutputForAssertion();
 
-    expect($logOutput)->toContain('Refiner StringRefiner::betweenFirst() can\'t be applied to value of type ' . gettype($value));
-
-    expect($refinedValue)->toBe($value);
+    expect($logOutput)
+        ->toContain('Refiner StringRefiner::betweenFirst() can\'t be applied to value of type ' . gettype($value))
+        ->and($refinedValue)->toBe($value);
 })->with([
     [123],
     [12.3],
     [true],
 ]);
+
+it('works with an array of strings as value', function () {
+    $refinedValue = StringRefiner::betweenFirst('foo', 'bar')
+        ->addLogger(new CliLogger())
+        ->refine(['one foo two bar three foo four bar five', 'six foo seven bar eight foo nine bar ten']);
+
+    expect($refinedValue)->toBe(['two', 'seven']);
+});
 
 it('gets the (trimmed) string between the first occurrence of start and the next occurrence of end', function () {
     $refiner = StringRefiner::betweenFirst('foo', 'bar');

--- a/tests/Steps/Refiners/String/BetweenLastTest.php
+++ b/tests/Steps/Refiners/String/BetweenLastTest.php
@@ -15,14 +15,22 @@ it('logs a warning and returns the unchanged value when $value is not of type st
 
     $logOutput = $this->getActualOutputForAssertion();
 
-    expect($logOutput)->toContain('Refiner StringRefiner::betweenLast() can\'t be applied to value of type ' . gettype($value));
-
-    expect($refinedValue)->toBe($value);
+    expect($logOutput)
+        ->toContain('Refiner StringRefiner::betweenLast() can\'t be applied to value of type ' . gettype($value))
+        ->and($refinedValue)->toBe($value);
 })->with([
     [123],
     [12.3],
     [true],
 ]);
+
+it('works with an array of strings as value', function () {
+    $refinedValue = StringRefiner::betweenLast('foo', 'bar')
+        ->addLogger(new CliLogger())
+        ->refine(['one foo two bar three foo four bar five', 'six foo seven bar eight foo nine bar ten']);
+
+    expect($refinedValue)->toBe(['four', 'nine']);
+});
 
 it('gets the (trimmed) string between the last occurrence of start and the next occurrence of end', function () {
     $refiner = StringRefiner::betweenLast('foo', 'bar');

--- a/tests/Steps/Refiners/String/ReplaceTest.php
+++ b/tests/Steps/Refiners/String/ReplaceTest.php
@@ -15,14 +15,22 @@ it('logs a warning and returns the unchanged value when $value is not of type st
 
     $logOutput = $this->getActualOutputForAssertion();
 
-    expect($logOutput)->toContain('Refiner StringRefiner::replace() can\'t be applied to value of type ' . gettype($value));
-
-    expect($refinedValue)->toBe($value);
+    expect($logOutput)
+        ->toContain('Refiner StringRefiner::replace() can\'t be applied to value of type ' . gettype($value))
+        ->and($refinedValue)->toBe($value);
 })->with([
     [123],
     [12.3],
     [true],
 ]);
+
+it('works when the value is an array of strings', function () {
+    $refinedValue = StringRefiner::replace('foo', 'bar')
+        ->addLogger(new CliLogger())
+        ->refine(['foo boo', 'who foo', 'yo lo']);
+
+    expect($refinedValue)->toBe(['bar boo', 'who bar', 'yo lo']);
+});
 
 it('replaces occurrences of a string with another string', function () {
     expect(StringRefiner::replace('foo', 'bar')->refine('foo, test lorem foo yolo'))->toBe('bar, test lorem bar yolo');

--- a/tests/Steps/Refiners/Url/WithFragmentTest.php
+++ b/tests/Steps/Refiners/Url/WithFragmentTest.php
@@ -44,3 +44,13 @@ it('resets any query', function (mixed $value, string $expected) {
     ['https://www.example.com/foo#bar', 'https://www.example.com/foo'],
     ['https://www.crwlr.software/#', 'https://www.crwlr.software/'],
 ]);
+
+it('refines an array of URLs', function () {
+    expect(
+        UrlRefiner::withFragment('#lorem')
+            ->refine([
+                'https://www.example.com/path#foo',
+                'https://www.example.com/path#bar',
+            ])
+    )->toBe(['https://www.example.com/path#lorem', 'https://www.example.com/path#lorem']);
+});

--- a/tests/Steps/Refiners/Url/WithFragmentTest.php
+++ b/tests/Steps/Refiners/Url/WithFragmentTest.php
@@ -51,6 +51,6 @@ it('refines an array of URLs', function () {
             ->refine([
                 'https://www.example.com/path#foo',
                 'https://www.example.com/path#bar',
-            ])
+            ]),
     )->toBe(['https://www.example.com/path#lorem', 'https://www.example.com/path#lorem']);
 });

--- a/tests/Steps/Refiners/Url/WithHostTest.php
+++ b/tests/Steps/Refiners/Url/WithHostTest.php
@@ -44,6 +44,6 @@ it('refines an array of URLs', function () {
             ->refine([
                 'https://www.example.com/foo',
                 'https://www.example.com/bar',
-            ])
+            ]),
     )->toBe(['https://crwl.io/foo', 'https://crwl.io/bar']);
 });

--- a/tests/Steps/Refiners/Url/WithHostTest.php
+++ b/tests/Steps/Refiners/Url/WithHostTest.php
@@ -37,3 +37,13 @@ it('replaces the host in a URL', function (mixed $value, string $expected) {
     [Url::parse('https://www.crwlr.software/baz'), 'https://www.crwlr.software/baz'],
     [Url::parsePsr7('https://crwl.io/quz'), 'https://www.crwlr.software/quz'],
 ]);
+
+it('refines an array of URLs', function () {
+    expect(
+        UrlRefiner::withHost('crwl.io')
+            ->refine([
+                'https://www.example.com/foo',
+                'https://www.example.com/bar',
+            ])
+    )->toBe(['https://crwl.io/foo', 'https://crwl.io/bar']);
+});

--- a/tests/Steps/Refiners/Url/WithPathTest.php
+++ b/tests/Steps/Refiners/Url/WithPathTest.php
@@ -37,3 +37,13 @@ it('replaces the path in a URL', function (mixed $value, string $expected) {
     [Url::parse('https://www.crwlr.software/packages'), 'https://www.crwlr.software/some/path/123'],
     [Url::parsePsr7('https://www.crwl.io/'), 'https://www.crwl.io/some/path/123'],
 ]);
+
+it('refines an array of URLs', function () {
+    expect(
+        UrlRefiner::withPath('/hawedere')
+            ->refine([
+                'https://www.example.com/foo',
+                'https://www.example.com/bar',
+            ])
+    )->toBe(['https://www.example.com/hawedere', 'https://www.example.com/hawedere']);
+});

--- a/tests/Steps/Refiners/Url/WithPathTest.php
+++ b/tests/Steps/Refiners/Url/WithPathTest.php
@@ -44,6 +44,6 @@ it('refines an array of URLs', function () {
             ->refine([
                 'https://www.example.com/foo',
                 'https://www.example.com/bar',
-            ])
+            ]),
     )->toBe(['https://www.example.com/hawedere', 'https://www.example.com/hawedere']);
 });

--- a/tests/Steps/Refiners/Url/WithPortTest.php
+++ b/tests/Steps/Refiners/Url/WithPortTest.php
@@ -37,3 +37,13 @@ it('replaces the port in a URL', function (mixed $value, string $expected) {
     [Url::parse('https://www.crwlr.software:5678/bar'), 'https://www.crwlr.software:1234/bar'],
     [Url::parsePsr7('https://crwl.io/quz'), 'https://crwl.io:1234/quz'],
 ]);
+
+it('refines an array of URLs', function () {
+    expect(
+        UrlRefiner::withPort(1234)
+            ->refine([
+                'https://www.example.com/foo',
+                'https://www.example.com/bar',
+            ])
+    )->toBe(['https://www.example.com:1234/foo', 'https://www.example.com:1234/bar']);
+});

--- a/tests/Steps/Refiners/Url/WithPortTest.php
+++ b/tests/Steps/Refiners/Url/WithPortTest.php
@@ -44,6 +44,6 @@ it('refines an array of URLs', function () {
             ->refine([
                 'https://www.example.com/foo',
                 'https://www.example.com/bar',
-            ])
+            ]),
     )->toBe(['https://www.example.com:1234/foo', 'https://www.example.com:1234/bar']);
 });

--- a/tests/Steps/Refiners/Url/WithQueryTest.php
+++ b/tests/Steps/Refiners/Url/WithQueryTest.php
@@ -51,6 +51,6 @@ it('refines an array of URLs', function () {
             ->refine([
                 'https://www.example.com/foo?one=two',
                 'https://www.example.com/bar?three=four',
-            ])
+            ]),
     )->toBe(['https://www.example.com/foo', 'https://www.example.com/bar']);
 });

--- a/tests/Steps/Refiners/Url/WithQueryTest.php
+++ b/tests/Steps/Refiners/Url/WithQueryTest.php
@@ -44,3 +44,13 @@ it('resets any query', function (mixed $value, string $expected) {
     ['https://www.example.com/foo?one=two', 'https://www.example.com/foo'],
     ['https://www.crwlr.software/?', 'https://www.crwlr.software/'],
 ]);
+
+it('refines an array of URLs', function () {
+    expect(
+        UrlRefiner::withoutQuery()
+            ->refine([
+                'https://www.example.com/foo?one=two',
+                'https://www.example.com/bar?three=four',
+            ])
+    )->toBe(['https://www.example.com/foo', 'https://www.example.com/bar']);
+});

--- a/tests/Steps/Refiners/Url/WithSchemeTest.php
+++ b/tests/Steps/Refiners/Url/WithSchemeTest.php
@@ -44,6 +44,6 @@ it('refines an array of URLs', function () {
             ->refine([
                 'http://www.example.com/foo',
                 'https://www.example.com/bar',
-            ])
+            ]),
     )->toBe(['https://www.example.com/foo', 'https://www.example.com/bar']);
 });

--- a/tests/Steps/Refiners/Url/WithSchemeTest.php
+++ b/tests/Steps/Refiners/Url/WithSchemeTest.php
@@ -37,3 +37,13 @@ it('replaces the scheme in a URL', function (mixed $value, string $expected) {
     [Url::parse('ftp://www.example.com/bar'), 'https://www.example.com/bar'],
     [Url::parsePsr7('http://www.example.com/baz'), 'https://www.example.com/baz'],
 ]);
+
+it('refines an array of URLs', function () {
+    expect(
+        UrlRefiner::withScheme('https')
+            ->refine([
+                'http://www.example.com/foo',
+                'https://www.example.com/bar',
+            ])
+    )->toBe(['https://www.example.com/foo', 'https://www.example.com/bar']);
+});

--- a/tests/Steps/Refiners/Url/WithoutPortTest.php
+++ b/tests/Steps/Refiners/Url/WithoutPortTest.php
@@ -37,3 +37,13 @@ it('resets the port to null in a URL', function (mixed $value, string $expected)
     [Url::parse('https://www.crwlr.software:5678/bar'), 'https://www.crwlr.software/bar'],
     [Url::parsePsr7('https://crwl.io/quz'), 'https://crwl.io/quz'],
 ]);
+
+it('refines an array of URLs', function () {
+    expect(
+        UrlRefiner::withoutPort()
+            ->refine([
+                'https://www.example.com:8000/foo',
+                'https://www.example.com:8080/bar',
+            ])
+    )->toBe(['https://www.example.com/foo', 'https://www.example.com/bar']);
+});

--- a/tests/Steps/Refiners/Url/WithoutPortTest.php
+++ b/tests/Steps/Refiners/Url/WithoutPortTest.php
@@ -44,6 +44,6 @@ it('refines an array of URLs', function () {
             ->refine([
                 'https://www.example.com:8000/foo',
                 'https://www.example.com:8080/bar',
-            ])
+            ]),
     )->toBe(['https://www.example.com/foo', 'https://www.example.com/bar']);
 });


### PR DESCRIPTION
* An issue that occurred, when a step uses the `PreStepInvocationLogger`. As refiners also use the logger, a newer logger (replacing the `PreStepInvocationLogger`) is now also passed to all registered refiners of a step.
* Enable applying refiners to output properties with array value. E.g. if a step outputs an array of URLs (`['https://...', 'https://...']`), a `UrlRefiner` will be applied to all those URLs.