### PR TITLE
Fix using SimpleWebsitePaginator with stop rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.4] - 2025-07-28
+### Fixed
+* An issue in the `SimpleWebsitePaginator` when used with stop rules.
+
 ## [3.5.3] - 2025-06-10
 ### Fixed
 * Issues with passing cookies from the cookie jar to the headless browser when using the `useBrowser()` method on `Http` steps, in cases where the loader wasn’t globally configured to use the browser for all requests.

--- a/src/Steps/Loading/Http/Paginators/SimpleWebsitePaginator.php
+++ b/src/Steps/Loading/Http/Paginators/SimpleWebsitePaginator.php
@@ -80,7 +80,7 @@ class SimpleWebsitePaginator extends Http\AbstractPaginator
         RequestInterface $request,
         ?RespondedRequest $respondedRequest,
     ): void {
-        $this->registerLoadedRequest($request);
+        $this->registerLoadedRequest($respondedRequest ?? $request);
 
         if ($this->latestRequest) {
             $this->latestRequestKey = RequestKey::from($this->latestRequest);

--- a/tests/Steps/Loading/Http/Paginators/SimpleWebsitePaginatorTest.php
+++ b/tests/Steps/Loading/Http/Paginators/SimpleWebsitePaginatorTest.php
@@ -5,6 +5,7 @@ namespace tests\Steps\Loading\Http\Paginators;
 use Crwlr\Crawler\Loader\Http\Messages\RespondedRequest;
 use Crwlr\Crawler\Logger\CliLogger;
 use Crwlr\Crawler\Steps\Loading\Http\Paginators\SimpleWebsitePaginator;
+use Crwlr\Crawler\Steps\Loading\Http\Paginators\StopRules\PaginatorStopRules;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
@@ -335,4 +336,18 @@ it('cleans up the stored parent requests always when getting the next request to
     $paginator->processLoaded($respondedRequest->request, $respondedRequest);
 
     expect(count($paginator->parentRequests()))->toBe(0);
+});
+
+it('does not stop, when a response does not meet the stop rule criterion', function () {
+    $paginator = new SimpleWebsitePaginator('.pagination', 3);
+
+    $paginator->stopWhen(PaginatorStopRules::contains('hello world'));
+
+    $responseBody = helper_createResponseBodyWithPaginationLinks(['/listing?page=2' => 'Next page']);
+
+    $respondedRequest = helper_getRespondedRequestWithResponseBody('/listing', $responseBody);
+
+    $paginator->processLoaded($respondedRequest->request, $respondedRequest);
+
+    expect($paginator->hasFinished())->toBeFalse();
 });


### PR DESCRIPTION
Calling the `registerLoadedRequest()` method in the `SimpleWebsitePaginator` only with the request and not with the RespondedRequest when available, caused that most pre-built stop rules says paginating should be stopped, because they doe not receive a response to check.