### PR TITLE
Improve Paginate step behavior and deprecate class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.5] - 2025-08-05
+### Fixed
+* Removed the overriding `validateAndSanitizeInput()` method from the `Paginate` HTTP step to ensure features like `staticUrl()` and `useInputKeyAsUrl()` work correctly.
+* The `Paginate` HTTP step now also supports receiving an array of URLs, initiating pagination separately for each one.
+
+### Deprecated
+* The `Crwlr\Crawler\Steps\Loading\Http\Paginate` class. It shall be removed and its behavior implemented in the `Http` class directly, in the next major version.
+
 ## [3.5.4] - 2025-07-28
 ### Fixed
 * An issue in the `SimpleWebsitePaginator` when used with stop rules.

--- a/src/Steps/Loading/Http.php
+++ b/src/Steps/Loading/Http.php
@@ -112,7 +112,9 @@ class Http extends HttpBase
             $paginator = Paginator::simpleWebsite($paginator, $defaultPaginatorMaxPages);
         }
 
-        return new Paginate($paginator, $this->method, $this->headers, $this->body, $this->httpVersion);
+        return $this->transferSettingsToPaginateStep(
+            new Paginate($paginator, $this->method, $this->headers, $this->body, $this->httpVersion),
+        );
     }
 
     public function outputType(): StepOutputType
@@ -138,5 +140,35 @@ class Http extends HttpBase
         }
 
         $this->resetInputRequestParams();
+    }
+
+    /**
+     * Temporary fix to transfer settings that may have already been defined on the current instance,
+     * to a new Paginate step instance. This shall be fixed in the next major version (v4) by removing
+     * the Paginate class and implementing it in the Http class directly.
+     */
+    private function transferSettingsToPaginateStep(Paginate $step): Paginate
+    {
+        $step->stopOnErrorResponse = $this->stopOnErrorResponse;
+
+        $step->yieldErrorResponses = $this->yieldErrorResponses;
+
+        $step->useAsUrl = $this->useAsUrl;
+
+        $step->useAsBody = $this->useAsBody;
+
+        $step->useAsHeaders = $this->useAsHeaders;
+
+        $step->useAsHeader = $this->useAsHeader;
+
+        $step->staticUrl = $this->staticUrl;
+
+        $step->postBrowserNavigateHooks = $this->postBrowserNavigateHooks;
+
+        $step->skipCache = $this->skipCache;
+
+        $step->forceBrowserUsage = $this->forceBrowserUsage;
+
+        return $step;
     }
 }

--- a/tests/_Integration/Http/PaginationTest.php
+++ b/tests/_Integration/Http/PaginationTest.php
@@ -47,9 +47,8 @@ it('only iterates pagination until max pages limit is reached', function () {
 
     $results = helper_generatorToArray($crawler->run());
 
-    expect($results)->toHaveCount(2);
-
-    expect($this->getActualOutputForAssertion())->toContain('Max pages limit reached');
+    expect($results)->toHaveCount(2)
+        ->and($this->getActualOutputForAssertion())->toContain('Max pages limit reached');
 });
 
 it('resets the finished paginating state after each processed (/paginated) input', function () {

--- a/tests/_Integration/Http/QueryParamPaginationTest.php
+++ b/tests/_Integration/Http/QueryParamPaginationTest.php
@@ -51,6 +51,26 @@ it('paginates using query params sent in the request body', function () {
     expect($results)->toHaveCount(4);
 });
 
+it('also paginates using query params sent in the request body, when used in combination with static URL', function () {
+    $crawler = new QueryParamPaginationCrawler();
+
+    $crawler
+        ->input('foo')
+        ->addStep(
+            Http::post(body: 'page=1')
+                ->staticUrl('http://localhost:8000/query-param-pagination')
+                ->paginate(
+                    Paginator::queryParams(3)
+                        ->inBody()
+                        ->increase('page'),
+                )->keep(['body']),
+        );
+
+    $results = helper_generatorToArray($crawler->run());
+
+    expect($results)->toHaveCount(3);
+});
+
 it('paginates using URL query params', function () {
     $crawler = new QueryParamPaginationCrawler();
 


### PR DESCRIPTION
- Removed custom `validateAndSanitizeInput()` in `Paginate` step class, because it breaks functionality implemented in the version of the same method in the `HttpBase` class.
- Paginate step now accepts arrays of URLs and paginates each one separately.
- Deprecated the `Paginate` class (see comment above the `Http::transferSettingsToPaginateStep()` method).